### PR TITLE
Fixed #191

### DIFF
--- a/src/locale/Locale.ts
+++ b/src/locale/Locale.ts
@@ -34,7 +34,7 @@ export const SupportedLocales = Array.from(
         'es-MX',
         'zh-CN',
         ...(import.meta.hot ? EventuallySupportedLocales : []),
-    ])
+    ]),
 );
 
 /** One of the supported locales above */
@@ -84,6 +84,8 @@ export type Locale = {
         moderate: DialogText;
         /** Content moderation rules that creators promise to follow. See en-US.json for ground truth language. */
         flags: FlagDescriptions;
+        /** Progress message */
+        progress: Template;
         /** Buttons on the moderation page */
         button: {
             submit: ButtonText;
@@ -166,14 +168,14 @@ export function getBestSupportedLocales(locales: string[]) {
         .map((preferredLocale) => {
             // Is there an exact match?
             const exact = SupportedLocales.find(
-                (locale) => preferredLocale === locale
+                (locale) => preferredLocale === locale,
             );
             if (exact) return exact;
             // Does a language match, even if locale doesn't match?
             const languageExact = SupportedLocales.find(
                 (locale) =>
                     getLocaleLanguage(preferredLocale) ===
-                    getLocaleLanguage(locale)
+                    getLocaleLanguage(locale),
             );
             if (languageExact) return languageExact;
             // No match
@@ -190,28 +192,28 @@ export function createBind(
     locales: Locales,
     nameAndDoc: (locale: Locale) => NameAndDoc,
     type?: Type,
-    value?: Expression
+    value?: Expression,
 ) {
     return Bind.make(
         getDocLocales(locales, (l) => nameAndDoc(l).doc),
         getNameLocales(locales, (l) => nameAndDoc(l).names),
         type,
-        value
+        value,
     );
 }
 
 export function createInputs(
     locales: Locales,
     fun: (locale: Locale) => NameAndDoc[],
-    types: (Type | [Type, Expression])[]
+    types: (Type | [Type, Expression])[],
 ) {
     return types.map((type, index) =>
         createBind(
             locales,
             (l) => fun(l)[index],
             Array.isArray(type) ? type[0] : type,
-            Array.isArray(type) ? type[1] : undefined
-        )
+            Array.isArray(type) ? type[1] : undefined,
+        ),
     );
 }
 
@@ -221,7 +223,7 @@ export function createFunction(
     typeVars: TypeVariables | undefined,
     inputs: Bind[],
     output: Type,
-    expression: Expression
+    expression: Expression,
 ) {
     return FunctionDefinition.make(
         getDocLocales(locales, (l) => nameAndDoc(l).doc),
@@ -229,6 +231,6 @@ export function createFunction(
         typeVars,
         inputs,
         expression,
-        output
+        output,
     );
 }

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -4383,6 +4383,7 @@
             "disclosure": "Reveal private information about other people such as names, contact information, or physical addresses",
             "misinformation": "Contain false, misleading, deceptive, or manipulative information"
         },
+        "progress": "*$1* moderated, *$2* remaining",
         "button": {
             "submit": {
                 "tip": "Save these moderation settings",

--- a/src/routes/moderate/+page.svelte
+++ b/src/routes/moderate/+page.svelte
@@ -57,7 +57,9 @@
     let project: Project | undefined = undefined;
 
     let newFlags: Moderation;
-
+    
+    let moderatedCount = 0;
+    let unmoderatedCount = 0;
     onMount(async () => {
         try {
             await nextBatch();
@@ -92,6 +94,10 @@
         );
         const documentSnapshots = await getDocs(unmoderated);
 
+        if(!lastBatch) { //add to total projects if there was not a last batch detected
+            unmoderatedCount += documentSnapshots.docs.length;
+        }
+
         // Remember the last document.
         lastBatch = documentSnapshots.docs[documentSnapshots.docs.length - 1];
 
@@ -110,6 +116,7 @@
         // Save the project with the new flags.
         if (project) Projects.edit(project.withFlags(newFlags), false, true);
 
+        moderatedCount += 1; //increment the moderated count when saved with new flags.
         skip();
     }
 
@@ -134,6 +141,9 @@
             {:else if project === undefined}
                 <Spinning label="" />
             {:else}
+                <div class="progress-counter">
+                    <p>Moderated: {moderatedCount} of {unmoderatedCount} projects</p>
+                </div>
                 <MarkupHtmlView
                     markup={$locales.get(
                         (l) => l.moderation.moderate.explanation

--- a/src/routes/moderate/+page.svelte
+++ b/src/routes/moderate/+page.svelte
@@ -38,6 +38,7 @@
     import type { Flag, Moderation } from '../../models/Moderation';
     import Spinning from '../../components/app/Spinning.svelte';
     import { ProjectsCollection } from '../../db/ProjectsDatabase';
+    import Markup from '@nodes/Markup';
 
     const user = getUser();
 
@@ -57,7 +58,7 @@
     let project: Project | undefined = undefined;
 
     let newFlags: Moderation;
-    
+
     let moderatedCount = 0;
     let unmoderatedCount = 0;
     onMount(async () => {
@@ -84,17 +85,18 @@
                 where('public', '==', true),
                 or(
                     ...Array.from(Object.keys(Flags)).map((flag) =>
-                        where(new FieldPath('flags', flag), '==', null)
-                    )
-                )
+                        where(new FieldPath('flags', flag), '==', null),
+                    ),
+                ),
             ),
             orderBy('timestamp'),
             ...(lastBatch ? [startAfter(lastBatch)] : []),
-            limit(1)
+            limit(1),
         );
         const documentSnapshots = await getDocs(unmoderated);
 
-        if(!lastBatch) { //add to total projects if there was not a last batch detected
+        if (!lastBatch) {
+            //add to total projects if there was not a last batch detected
             unmoderatedCount += documentSnapshots.docs.length;
         }
 
@@ -133,8 +135,9 @@
                 <Spinning label="" />
             {:else if moderator === false}
                 <p
-                    >It looks like you're not a moderator. Do you want to become
-                    one?</p
+                    >It looks like you're not a moderator. If you were recently
+                    given moderator privileges, you may need to login again. If
+                    not, see the wiki for how to request moderation privileges.</p
                 >
             {:else if lastBatch === undefined}
                 <p>Nothing else to moderate!</p>
@@ -142,11 +145,18 @@
                 <Spinning label="" />
             {:else}
                 <div class="progress-counter">
-                    <p>Moderated: {moderatedCount} of {unmoderatedCount} projects</p>
+                    <MarkupHtmlView
+                        markup={Markup.words(
+                            $locales.get((l) => l.moderation.progress),
+                        ).concretize($locales, [
+                            moderatedCount,
+                            unmoderatedCount,
+                        ]) ?? '?'}
+                    />
                 </div>
                 <MarkupHtmlView
                     markup={$locales.get(
-                        (l) => l.moderation.moderate.explanation
+                        (l) => l.moderation.moderate.explanation,
                     )}
                 />
                 {#each Object.entries(project.getFlags()) as [flag, state]}
@@ -158,7 +168,7 @@
                                 (newFlags = withFlag(
                                     newFlags,
                                     flag,
-                                    value === true
+                                    value === true,
                                 ))}
                         />
                         <label for={flag}>
@@ -173,11 +183,11 @@
                     <Button
                         background
                         tip={$locales.get(
-                            (l) => l.moderation.button.submit.tip
+                            (l) => l.moderation.button.submit.tip,
                         )}
                         action={save}
                         >{$locales.get(
-                            (l) => l.moderation.button.submit.label
+                            (l) => l.moderation.button.submit.label,
                         )}</Button
                     >
                     <Button
@@ -185,7 +195,7 @@
                         tip={$locales.get((l) => l.moderation.button.skip.tip)}
                         action={skip}
                         >{$locales.get(
-                            (l) => l.moderation.button.skip.label
+                            (l) => l.moderation.button.skip.label,
                         )}</Button
                     >
                 </div>

--- a/static/locales/es-MX/es-MX.json
+++ b/static/locales/es-MX/es-MX.json
@@ -4455,6 +4455,7 @@
             "disclosure": "Revelar información privada sobre otras personas, como nombres, información de contacto o direcciones físicas",
             "misinformation": "Contener información falsa, engañosa, manipuladora o manipulativa"
         },
+        "progress": "$?",
         "button": {
             "submit": {
                 "tip": "Guardar estas configuraciones de moderación",

--- a/static/locales/example/example.json
+++ b/static/locales/example/example.json
@@ -2651,6 +2651,7 @@
             "disclosure": "$?",
             "misinformation": "$?"
         },
+        "progress": "$?",
         "button": {
             "submit": {
                 "tip": "$?",

--- a/static/locales/zh-CN/zh-CN.json
+++ b/static/locales/zh-CN/zh-CN.json
@@ -4265,6 +4265,7 @@
             "disclosure": "披露其他人的私人信息，如姓名、联系方式或实际地址。",
             "misinformation": "包含虚假、误导性、欺骗性或操纵性信息。"
         },
+        "progress": "$?",
         "button": {
             "submit": {
                 "tip": "保存这些审查设置",

--- a/static/schemas/Locale.json
+++ b/static/schemas/Locale.json
@@ -234,7 +234,7 @@
       ],
       "type": "object"
     },
-    "FunctionText<[def-alias-1127088073-3847-4093-1127088073-0-8054,def-alias-1127088073-3847-4093-1127088073-0-8054]>": {
+    "FunctionText<[def-alias-1127088073-3908-4154-1127088073-0-8124,def-alias-1127088073-3908-4154-1127088073-0-8124]>": {
       "additionalProperties": false,
       "properties": {
         "doc": {
@@ -262,7 +262,7 @@
       ],
       "type": "object"
     },
-    "FunctionText<[def-alias-1127088073-3847-4093-1127088073-0-8054]>": {
+    "FunctionText<[def-alias-1127088073-3908-4154-1127088073-0-8124]>": {
       "additionalProperties": false,
       "properties": {
         "doc": {
@@ -377,11 +377,11 @@
                   "description": "Functions in the type",
                   "properties": {
                     "and": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "not": {
@@ -389,11 +389,11 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequal": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "or": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -449,7 +449,7 @@
                   "description": "Functions in the type",
                   "properties": {
                     "add": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "all": {
@@ -491,7 +491,7 @@
                       "type": "object"
                     },
                     "append": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "combine": {
@@ -533,7 +533,7 @@
                       "type": "object"
                     },
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "filter": {
@@ -617,11 +617,11 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "has": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "join": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "last": {
@@ -633,7 +633,7 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "random": {
@@ -641,7 +641,7 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "replace": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%2Cdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%2Cdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "reverse": {
@@ -649,11 +649,11 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "sans": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "sansAll": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "sansFirst": {
@@ -703,7 +703,7 @@
                       "type": "object"
                     },
                     "subsequence": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%2Cdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%2Cdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "translate": {
@@ -875,7 +875,7 @@
                   "description": "Functions in the type",
                   "properties": {
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "filter": {
@@ -917,15 +917,15 @@
                       "type": "object"
                     },
                     "notequals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "remove": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "set": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%2Cdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%2Cdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "size": {
@@ -971,7 +971,7 @@
                       "type": "object"
                     },
                     "unset": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -1042,11 +1042,11 @@
                   "description": "Functions in the type",
                   "properties": {
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -1331,7 +1331,7 @@
                   "description": "Functions in the type",
                   "properties": {
                     "add": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "cos": {
@@ -1339,43 +1339,43 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "divide": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "equal": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "greaterOrEqual": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "greaterThan": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "lessOrEqual": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "lessThan": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "max": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "min": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "multiply": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequal": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "positive": {
@@ -1383,15 +1383,15 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "power": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "remainder": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "root": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "round": {
@@ -1411,7 +1411,7 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "subtract": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -1485,15 +1485,15 @@
                   "description": "Functions in the type",
                   "properties": {
                     "add": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "difference": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "filter": {
@@ -1535,15 +1535,15 @@
                       "type": "object"
                     },
                     "intersection": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "remove": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "size": {
@@ -1589,7 +1589,7 @@
                       "type": "object"
                     },
                     "union": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -1657,11 +1657,11 @@
                   "description": "Functions in the type",
                   "properties": {
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequal": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -1716,11 +1716,11 @@
                   "description": "Functions in the type",
                   "properties": {
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequal": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -1780,19 +1780,19 @@
                   "description": "Functions in the type",
                   "properties": {
                     "combine": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "ends": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "equals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "has": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "length": {
@@ -1800,19 +1800,19 @@
                       "description": "See `en-US.json` for documentation"
                     },
                     "notequals": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "repeat": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "segment": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     },
                     "starts": {
-                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3847-4093-1127088073-0-8054%5D%3E",
+                      "$ref": "#/definitions/FunctionText%3C%5Bdef-alias-1127088073-3908-4154-1127088073-0-8124%5D%3E",
                       "description": "See `en-US.json` for documentation"
                     }
                   },
@@ -2462,6 +2462,10 @@
               "$ref": "#/definitions/DialogText",
               "description": "Moderation view text"
             },
+            "progress": {
+              "$ref": "#/definitions/Template",
+              "description": "Progress message"
+            },
             "unmoderated": {
               "$ref": "#/definitions/DialogText",
               "description": "What to sa when content has not yet been moderated"
@@ -2477,6 +2481,7 @@
             "unmoderated",
             "moderate",
             "flags",
+            "progress",
             "button"
           ],
           "type": "object"


### PR DESCRIPTION
Incorporated a moderated posts count (to showcase moderator progress), and a unmoderated post count (to showcase total projects to moderate). Incremented the moderated post when user saves a project with new flags, and does not increment when project is skipped. Unmoderated total posts are returned by calling a .length call on the paginated query results.