### PR TITLE
#331 Remove non PII strings from project

### DIFF
--- a/src/components/project/Collaborators.svelte
+++ b/src/components/project/Collaborators.svelte
@@ -9,6 +9,7 @@
     import CreatorList from './CreatorList.svelte';
     import Public from './Public.svelte';
     import Feedback from '@components/app/Feedback.svelte';
+    import PII from './PII.svelte';
 
     export let project: Project;
 
@@ -77,5 +78,10 @@
         isPublic={project.isPublic()}
         set={(choice) => Projects.reviseProject(project.asPublic(choice === 1))}
         flags={project.getFlags()}
+    />
+
+    <PII
+        nonPII={project.getNonPII()}
+        unmark={(piiText) => Projects.reviseProject(project.withPII(piiText))}
     />
 {/if}

--- a/src/components/project/PII.svelte
+++ b/src/components/project/PII.svelte
@@ -30,6 +30,7 @@
 <style>
     .piiLabel {
         font-style: italic;
+        margin-right: 0.5em;
     }
 
     .piiText {

--- a/src/components/project/PII.svelte
+++ b/src/components/project/PII.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import Subheader from '@components/app/Subheader.svelte';
+    import MarkupHtmlView from '@components/concepts/MarkupHTMLView.svelte';
+    import Button from '@components/widgets/Button.svelte';
+    import { locales } from '@db/Database';
+
+    export let nonPII: string[];
+    export let unmark: (piiText: string) => void;
+</script>
+
+<Subheader>
+    {$locales.get((l) => l.ui.dialog.share.subheader.pii.header)}
+</Subheader>
+
+<MarkupHtmlView
+    markup={$locales.get((l) => l.ui.dialog.share.subheader.pii.explanation)}
+/>
+
+{#each nonPII as piiText}
+    <div class="piiText">
+        <span class="piiLabel">{piiText}</span>
+        <Button
+            background
+            tip={$locales.get((l) => l.ui.dialog.share.button.sensitive.tip)}
+            action={() => unmark(piiText)}
+            >{$locales.get((l) => l.ui.dialog.share.button.sensitive.label)}</Button>
+    </div>
+{/each}
+
+<style>
+    .piiLabel {
+        font-style: italic;
+    }
+
+    .piiText {
+        margin-block-start: 0.5em;
+    }
+</style>

--- a/src/conflicts/PossiblePII.ts
+++ b/src/conflicts/PossiblePII.ts
@@ -46,6 +46,9 @@ export class PossiblePII extends Conflict {
                             (l) => l.node.Translation.conflict[this.pii.kind],
                         ),
                         this.pii.text,
+                        locales.get(
+                            (l) => l.node.Translation.conflict.reminder,
+                        )
                     ),
             },
             resolutions: [

--- a/src/locale/NodeTexts.ts
+++ b/src/locale/NodeTexts.ts
@@ -639,6 +639,8 @@ type NodeTexts = {
             handle: InternalConflictText;
             /** How to describe the resolution of the sensitive information conflict. */
             resolution: Template;
+            /** Note to remind users where they can manage sensitive information for their project. */
+            reminder: Template;
         }>;
     /**
      * A formatted text literal, e.g., ` `hello *wordplay*` `

--- a/src/locale/UITexts.ts
+++ b/src/locale/UITexts.ts
@@ -533,6 +533,8 @@ type UITexts = {
                 gallery: DialogText;
                 /** The public/private toggle subheader and explanation */
                 public: DialogText;
+                /** The personal information subheader and explanation */
+                pii: DialogText;
             };
             /** Text fields in the share dialog */
             field: {
@@ -543,6 +545,8 @@ type UITexts = {
             button: {
                 /** Description for the email submission button. */
                 submit: string;
+                /** Description and label for the button to mark PII as sensitive again. */
+                sensitive: ButtonText;
             };
             /** Modes in the share dialog */
             mode: {

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1045,12 +1045,13 @@
             "emotion": "serious",
             "doc": "I represent some text, with a @Language tag. See @Text to learn more!",
             "conflict": {
-                "phone": "Is *$1* someone's phone number? Don't share me online if so!",
-                "email": "Is *$1* someone's email? Don't share me here if so!",
-                "tin": "Is *$1* a tax identifier? If yes, definitely don't share me, I'm very sensitive information!",
-                "address": "Is *$1* someone's home address? If so, don't put me here, we don't want anyone getting stalked!",
-                "handle": "Is *$1* your username for somewhere else on the internet? If so, don't share me here unless you really mean to.",
-                "resolution": "This isn't sensitive data"
+                "phone": "Is *$1* someone's phone number? Don't share me online if so!\n\n$2",
+                "email": "Is *$1* someone's email? Don't share me here if so!\n\n$2",
+                "tin": "Is *$1* a tax identifier? If yes, definitely don't share me, I'm very sensitive information!\n\n$2",
+                "address": "Is *$1* someone's home address? If so, don't put me here, we don't want anyone getting stalked!\n\n$2",
+                "handle": "Is *$1* your username for somewhere else on the internet? If so, don't share me here unless you really mean to.\n\n$2",
+                "resolution": "This isn't sensitive data",
+                "reminder": "Note: You can undo this action and see other things you've marked as non-sensitive in the sharing dialog."
             }
         },
         "FormattedLiteral": {
@@ -4111,6 +4112,10 @@
                     "public": {
                         "header": "Public/Private",
                         "explanation": "Public projects and galleries can be seen by anyone in the world. Our goal is for this content to bring affirmation and joy, and publicly sharing is a way to do that. But it also means following some rules. You promise that your project does not:"
+                    },
+                    "pii": {
+                        "header": "Personal Information",
+                        "explanation": "Sharing personally identifiable information (PII) publicly can put creators at risk, so we detect possible PII and warn creators to either remove the sensitive data or mark it as non-sensitive.\n\nBelow is a list of possible PII in this project you have marked as non-sensitive. You can click the button next to it to mark it as sensitive again, but doing so means that your project won't be saved online anymore."
                     }
                 },
                 "field": {
@@ -4130,7 +4135,11 @@
                     "anonymous": "You must be logged in to share."
                 },
                 "button": {
-                    "submit": "Share the project with this email address"
+                    "submit": "Share the project with this email address",
+                    "sensitive": {
+                        "tip": "Mark this text as sensitive again",
+                        "label": "sensitive"
+                    }
                 },
                 "options": {
                     "gallery": "gallery chooser"

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -870,12 +870,27 @@ export default class Project {
         return this.data.timestamp;
     }
 
+    getNonPII() {
+        return this.data.nonPII;
+    }
+
     withNonPII(text: string) {
         return new Project({
             ...this.data,
             // Add to the set of text
             nonPII: Array.from(new Set([...this.data.nonPII, text])),
         });
+    }
+
+    withPII(text: string) {
+        const withPII = this.data.nonPII.filter((piiText) => {
+            return piiText != text;
+        });
+        return new Project({
+            ...this.data,
+            // Remove from the set of text
+            nonPII: withPII,
+        })
     }
 
     isNotPII(text: string) {

--- a/src/models/Project.ts
+++ b/src/models/Project.ts
@@ -883,12 +883,12 @@ export default class Project {
     }
 
     withPII(text: string) {
+        // Remove from the set of text
         const withPII = this.data.nonPII.filter((piiText) => {
             return piiText != text;
         });
         return new Project({
             ...this.data,
-            // Remove from the set of text
             nonPII: withPII,
         })
     }

--- a/static/locales/es-MX/es-MX.json
+++ b/static/locales/es-MX/es-MX.json
@@ -1025,12 +1025,13 @@
             "emotion": "serious",
             "doc": "Represento algún texto, con una etiqueta @Language. ¡Consulta @Text para aprender más!",
             "conflict": {
-                "phone": "¿Es *$1* el número de teléfono de alguien? ¡No me compartas en línea si es así!",
-                "email": "¿Es *$1* el correo electrónico de alguien? ¡No me lo compartas aquí si es así!",
-                "tin": "¿Es *$1* un identificador fiscal? Si es así, ¡definitivamente no me compartas, soy información muy sensible!",
-                "address": "¿Es *$1* la dirección de la casa de alguien? Si es así, no me pongas aquí, ¡no queremos que nadie sea acosado!",
-                "handle": "¿Es *$1* tu nombre de usuario en algún otro lugar de Internet? Si es así, no me lo compartas aquí a menos que realmente lo desees.",
-                "resolution": "Esto no es información sensible"
+                "phone": "¿Es *$1* el número de teléfono de alguien? ¡No me compartas en línea si es así!\n\n$2",
+                "email": "¿Es *$1* el correo electrónico de alguien? ¡No me lo compartas aquí si es así!\n\n$2",
+                "tin": "¿Es *$1* un identificador fiscal? Si es así, ¡definitivamente no me compartas, soy información muy sensible!\n\n$2",
+                "address": "¿Es *$1* la dirección de la casa de alguien? Si es así, no me pongas aquí, ¡no queremos que nadie sea acosado!\n\n$2",
+                "handle": "¿Es *$1* tu nombre de usuario en algún otro lugar de Internet? Si es así, no me lo compartas aquí a menos que realmente lo desees.\n\n$2",
+                "resolution": "Esto no es información sensible",
+                "reminder": "$?"
             }
         },
         "FormattedLiteral": {
@@ -4147,6 +4148,10 @@
                     "public": {
                         "header": "Público/Privado",
                         "explanation": "Proyectos y galerías públicas pueden ser vistos por cualquier persona en el mundo. Nuestra meta es que este contenido traiga afirmación y alegría, y compartir públicamente es una manera de lograrlo. Pero también implica seguir algunas reglas. Prometes que tu proyecto no:"
+                    },
+                    "pii": {
+                        "header": "$?",
+                        "explanation": "$?"
                     }
                 },
                 "field": {
@@ -4166,7 +4171,11 @@
                     "anonymous": "Debes iniciar sesión para compartir."
                 },
                 "button": {
-                    "submit": "Compartir el proyecto con esta dirección de correo electrónico"
+                    "submit": "Compartir el proyecto con esta dirección de correo electrónico",
+                    "sensitive": {
+                        "tip": "$?",
+                        "label": "$?"
+                    }
                 },
                 "options": {
                     "gallery": "celector de la galería"

--- a/static/locales/example/example.json
+++ b/static/locales/example/example.json
@@ -701,7 +701,8 @@
                 "tin": "$?",
                 "address": "$?",
                 "handle": "$?",
-                "resolution": "$?"
+                "resolution": "$?",
+                "reminder": "$?"
             }
         },
         "FormattedLiteral": {
@@ -2421,6 +2422,10 @@
                     "public": {
                         "header": "$?",
                         "explanation": "$?"
+                    },
+                    "pii": {
+                        "header": "$?",
+                        "explanation": "$?"
                     }
                 },
                 "field": {
@@ -2440,7 +2445,11 @@
                     "anonymous": "$?"
                 },
                 "button": {
-                    "submit": "$?"
+                    "submit": "$?",
+                    "sensitive": {
+                        "tip": "$?",
+                        "label": "$?"
+                    }
                 },
                 "options": {
                     "gallery": "$?"

--- a/static/locales/zh-CN/zh-CN.json
+++ b/static/locales/zh-CN/zh-CN.json
@@ -1051,7 +1051,8 @@
                 "tin": "$?",
                 "address": "$?",
                 "handle": "$?",
-                "resolution": "$?"
+                "resolution": "$?",
+                "reminder": "$?"
             }
         },
         "FormattedLiteral": {
@@ -3968,6 +3969,10 @@
                     "public": {
                         "header": "公开/私有",
                         "explanation": "公开项目和画廊可以被世界上任何人看到。通过将项目或画廊设为公开，您承诺："
+                    },
+                    "pii": {
+                        "header": "$?",
+                        "explanation": "$?"
                     }
                 },
                 "field": {
@@ -3987,7 +3992,11 @@
                     "anonymous": "您必須登入才能共享。"
                 },
                 "button": {
-                    "submit": "通过此电子邮件地址分享项目"
+                    "submit": "通过此电子邮件地址分享项目",
+                    "sensitive": {
+                        "tip": "$?",
+                        "label": "$?"
+                    }
                 },
                 "options": {
                     "gallery": "$?"

--- a/static/schemas/Locale.json
+++ b/static/schemas/Locale.json
@@ -5919,6 +5919,10 @@
                     "phone": {
                       "$ref": "#/definitions/InternalConflictText"
                     },
+                    "reminder": {
+                      "$ref": "#/definitions/Template",
+                      "description": "Note to remind users where they can manage sensitive information for their project."
+                    },
                     "resolution": {
                       "$ref": "#/definitions/Template",
                       "description": "How to describe the resolution of the sensitive information conflict."
@@ -5933,7 +5937,8 @@
                     "address",
                     "tin",
                     "handle",
-                    "resolution"
+                    "resolution",
+                    "reminder"
                   ],
                   "type": "object"
                 },
@@ -8454,10 +8459,15 @@
                         "submit": {
                           "description": "Description for the email submission button.",
                           "type": "string"
+                        },
+                        "sensitive": {
+                          "$ref": "#/definitions/ButtonText",
+                          "description": "Button to mark possible PII as sensitive."
                         }
                       },
                       "required": [
-                        "submit"
+                        "submit",
+                        "sensitive"
                       ],
                       "type": "object"
                     },
@@ -8554,12 +8564,17 @@
                         "public": {
                           "$ref": "#/definitions/DialogText",
                           "description": "The public/private toggle subheader and explanation"
+                        },
+                        "pii": {
+                          "$ref": "#/definitions/DialogText",
+                          "description": "The personal information subheader and explanation"
                         }
                       },
                       "required": [
                         "collaborators",
                         "gallery",
-                        "public"
+                        "public",
+                        "pii"
                       ],
                       "type": "object"
                     }


### PR DESCRIPTION
Tasks Completed: 
- Added ability for users to unmark text as non-sensitive through the sharing dialog. Now when a user clicks on the "sensitive" button next to some text they previously marked as nonPII, it is removed from the nonPII list and the sharing dialog and the PossiblePII conflict reappears in the conflicts section. 
- Verified that new changes work for different types of PII and that the nonPII list and sharing dialog are updated as expected through manual testing.
- Added translation placeholders for all new properties in the es-MX, example, and zh-CHI files.