### PR TITLE
move printAccessibilityScanResults outside of try/catch block

### DIFF
--- a/tests/WCAG2.AxeBuilder.Subtitle.test.ts
+++ b/tests/WCAG2.AxeBuilder.Subtitle.test.ts
@@ -38,9 +38,9 @@ test('Test Wordplay homepage subtitles for WCAG violations', async ({
             // Limit analysis to WCAGs.
             .withTags(['wcag2a', 'wcag2aa', 'wcag2aaa'])
             .analyze();
-        printAccessibilityScanResults(accessibilityScanResults);
     } catch (cannotFindSubtitleLink) {
         console.log('No subtitle found');
         return;
     }
+    printAccessibilityScanResults(accessibilityScanResults);
 });


### PR DESCRIPTION
This change is to move printAccessibilityScanResults() outside of the try/catch block. Otherwise failed test would cause the program to incorrectly print "no subtitles found", because it would be executed in the catch block without causing an error.

This is a minor revision of PR #400  