### PR TITLE
Tutorial Typos

### DIFF
--- a/static/locales/en-US/en-US-tutorial.json
+++ b/static/locales/en-US/en-US-tutorial.json
@@ -44,7 +44,7 @@
                             "sad",
                             "Stop?",
                             "We didn't want to stop. We just lost our inspiration.",
-                            "I can mean so many things, for example. I'm the Dutch florin symbol sometimes, an old currency of the Netherlands. I used to be known and used around the world by people, to help them trade. Long ago, I was also the lowercase /f/of the Latin alphabet.",
+                            "I can mean so many things, for example. I'm the Dutch florin symbol sometimes, an old currency of the Netherlands. I used to be known and used around the world by people to help them trade. Long ago, I was also the lowercase /f/ of the Latin alphabet.",
                             "Today, though, I'm pretty obscure."
                         ],
                         null,
@@ -74,7 +74,7 @@
                         [
                             "FunctionDefinition",
                             "eager",
-                            "Like a real person, with thoughts and ideas and values to share? Not one of those robots, that just mindlessly parrots what people say? If you're a person, then maybe you could give us meaning?"
+                            "Like a real person, with thoughts and ideas and values to share? Not one of those robots that just mindlessly parrots what people say? If you're a person, then maybe you could give us meaning?"
                         ],
                         null,
                         [
@@ -90,7 +90,7 @@
                         [
                             "FunctionDefinition",
                             "eager",
-                            "Oh yes, there are many others. Some of us are like me: we help choreograph the shows, keeping everyone in their place and making sure we express the vision of our director, exactly as they intended. And some of us are the ones on stage, in front of the audience, dancing and speaking. We all have a role to play!"
+                            "Oh yes, there are many others. Some of them are like me: we help choreograph the shows, keeping everyone in their place and making sure we express the vision of our director, exactly as they intended. And some of them are the ones on stage, in front of the audience, dancing and speaking. We all have a role to play!"
                         ],
                         null,
                         [
@@ -140,7 +140,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Hey @Program! I found a person. Well, I guess they found us. They want to be our new director!"
+                            "Hey, @Program! I found a person. Well, I guess they found us. They want to be our new director!"
                         ],
                         [
                             "Program",
@@ -159,7 +159,7 @@
                         [
                             "Program",
                             "excited",
-                            "I see. Did @FunctionDefinition tell you anything about us? Lots of people try to direct us, but some people get confused, bored, even irritated with us. We are pretty dense at times. But I'm proud of what we do, so I don't want to work with just anyone."
+                            "I see. Did @FunctionDefinition tell you anything about us? Lots of people try to direct us, but some people get confused, bored, or even irritated with us. We are pretty dense at times. But I'm proud of what we do, so I don't want to work with just anyone."
                         ],
                         null,
                         [
@@ -170,7 +170,7 @@
                         [
                             "Program",
                             "serious",
-                            "Okay. Well nice to meet you. Sorry, I've just had a lot of people come here and say '/this isn't for me/' and I've gotten a bit skeptical of people who try for a bit and then just give up. I shouldn't have to change who I am to fit people's expectations. But if you're willing to learn about me, and us, let's try!"
+                            "Okay. Well, nice to meet you. Sorry, I've just had a lot of people come here and say '/this isn't for me/', and I've gotten a bit skeptical of people who try for a bit and then just give up. I shouldn't have to change who I am to fit people's expectations. But if you're willing to learn about me, and us, let's try!"
                         ],
                         null,
                         ["edit", ""],
@@ -183,22 +183,22 @@
                             "Program",
                             "neutral",
                             "Sure. I'm basically the organizer of the program for a performance.",
-                            "You can see me over there, with an *editor* @UI/editor showing me the *stage* @UI/stage showing the what I evaluate to (currently nothing). The *director* — that's you — helps everyone figure out what they're doing, writing a program for what will happen in the show. And then I evaluate the program and put the result on stage for the audience to see."
+                            "You can see me over there with an *editor* @UI/editor showing me the *stage* @UI/stage showing what I evaluate to (currently nothing). The *director* — that's you — helps everyone figure out what they're doing, writing a program for what will happen in the show. And then I evaluate the program and put the result on stage for the audience to see."
                         ],
                         null,
                         [
                             "Program",
                             "neutral",
-                            "For example, try typing my \\'hello'\\ in the editor over there.",
+                            "For example, try typing \\'hello'\\ in the editor over there.",
                             "(Don't worry about making mistakes, you can always revert to the original with *revert* @UI/revertProject).",
-                            "Did you type something? That's my friend @Text. Have you met them yet? They evaluate to \\'hello'\\, or whatever text you type, and then that text is placed on stage. Try changing your text to something else. I'll show that instead. So I'll immediately evaluate whatever you type and show the result."
+                            "Did you type something? That's my friend @Text. Have you met them yet? They evaluate to \\'hello'\\ or whatever text you type, and then that text is placed on stage. Try changing your text to something else. I'll show that instead. So I'll immediately evaluate whatever you type and show the result."
                         ],
                         null,
                         [
                             "Program",
                             "serious",
                             "The instructions can get as sophisticated as you want, but there are a few rules.",
-                            "For example, I can only evaluate to one *value*, and show that one value on stage. That one value can be as complex as you want, and as long as I know how to show it, I will.",
+                            "For example, I can only evaluate to one *value* and show that value on stage. That one value can be as complex as you want, and as long as I know how to show it, I will.",
                             "But if you give me two things, I'll only show the last thing you give me.",
                             "For example, try adding another instruction after the text you typed, whatever word you want, in quotes."
                         ],
@@ -218,24 +218,24 @@
                         [
                             "Program",
                             "serious",
-                            "Yes and no. I can do a lot, but that's only because I work with everyone else in the *Verse*. They're the ones that bring all of the exciting possibilities to the *stage*. All I really do is let them do their thing, and then take the last thing they created and show it on stage. I'm more like an escort that brings the final *value* to stage, like numbers, texts, phrases, or other values."
+                            "Yes and no. I can do a lot, but that's only because I work with everyone else in the *Verse*. They're the ones that bring all of the exciting possibilities to the *stage*. All I really do is let them do their thing then take the last thing they created and show it on stage. I'm more like an escort that brings the final *value* to stage, like numbers, texts, phrases, or other values."
                         ],
                         null,
                         [
                             "Program",
                             "serious",
-                            "In fact, if you ever want to see the progam for something on stage, you can press the pencil on stage @UI/editProject. That'll show you how everyone is coming together to create what's on stage. This program is just a simple phrase."
+                            "In fact, if you ever want to see the program for something on stage, you can press the magnifying glass on stage @UI/editProject. That'll show you how everyone is coming together to create what's on stage. This program is just a simple phrase."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Thank you @Program, we're so excited to meet everyone, and spread the news!"
+                            "Thank you, @Program! We're so excited to meet everyone and spread the news!"
                         ],
                         [
                             "Program",
                             "happy",
-                            "It was great to meet you new director! Good luck with everyone else. I'll always be here."
+                            "It was great to meet you, new director! Good luck with everyone else. I'll always be here."
                         ]
                     ]
                 },
@@ -248,7 +248,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "You're really going to like @ExpressionPlaceholder. They're incredibly kind, and so flexible. But they are a bit shy. Just be gentle with them?"
+                            "You're really going to like @ExpressionPlaceholder. They're incredibly kind and so flexible. But they are a bit shy. Just be gentle with them."
                         ],
                         null,
                         [
@@ -313,7 +313,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "But they are powerful, because they can represent anyone else, like a stand-in until you decide what you want a part of your performance to be. @ExpressionPlaceholder, want to take a place in this @Program, just to illustrate? See how there's a little placeholder in @Program @UI/ExpressionPlaceholder? That's a signal of what you might put there."
+                            "But they are powerful because they can represent anyone else, like a stand-in until you decide what you want a part of your performance to be. @ExpressionPlaceholder, want to take a place in this @Program just to illustrate? See how there's a little placeholder in @Program @UI/ExpressionPlaceholder? That's a signal of what you might put there."
                         ],
                         null,
                         [
@@ -327,14 +327,14 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Just like that, @ExpressionPlaceholder was replaced with other characters Did I get everything, @ExpressionPlaceholder?"
+                            "Just like that, @ExpressionPlaceholder was replaced with other characters. Did I get everything, @ExpressionPlaceholder?"
                         ],
                         ["ExpressionPlaceholder", "eager", "Yeah. I think so."],
                         null,
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "What do you think, shall we move on?"
+                            "What do you think; shall we move on?"
                         ],
                         [
                             "ExpressionPlaceholder",
@@ -346,7 +346,7 @@
                         [
                             "FunctionDefinition",
                             "cheerful",
-                            "They don't like being on stage, or even in a program for very long. They'd never admit it, but they're kind of a big deal, and most directors can't work without them. Think of them like a little helpful stagehand, reminding you of things you haven't figured out yet."
+                            "They don't like being on stage or even in a program for very long. They'd never admit it, but they're kind of a big deal, and most directors can't work without them. Think of them like a little, helpful stagehand, reminding you of things you haven't figured out yet."
                         ]
                     ]
                 },
@@ -381,7 +381,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "(It sounds like they spent a lot of time on the beach. They made some new friends, and practiced doing nothing.)"
+                            "(It sounds like they spent a lot of time on the beach. They made some new friends and practiced doing nothing.)"
                         ],
                         null,
                         ["use", "fit", "Symbol", "ivioas we wjjdks"],
@@ -446,8 +446,8 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Thanks @UnparsableExpression!",
-                            "Just like they said, when you've said something we don't understand, unparsable is there to say “We don't understand.” When then happens, I wish we could be more helpful, but we're often pretty dense here, so we're not very good at guessing what you mean."
+                            "Thanks, @UnparsableExpression!",
+                            "Just like they said, when you've said something we don't understand, unparsable is there to say “We don't understand.” When that happens, I wish we could be more helpful, but we're often pretty dense, so we're not very good at guessing what you mean."
                         ],
                         null,
                         [
@@ -458,7 +458,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Soooo, @UnparsableExpression wants you to try making as many of them as possible. (You can just key mash a bunch of random characters and you'll probably get many of them)."
+                            "Soooo, @UnparsableExpression wants you to try making as many of them as possible. (You can just keysmash a bunch of random characters and probably get many of them)."
                         ],
                         ["edit", ""],
                         null,
@@ -484,7 +484,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "No? That's okay. We've only begun to show you what's possible. Let's go meet @Evaluate. Bye unparsable, it was good to see you! Let's play soon."
+                            "No? That's okay. We've only begun to show you what's possible. Let's go meet @Evaluate. Bye, @UnparsableExpression, it was good to see you! Let's play soon."
                         ],
                         [
                             "UnparsableExpression",
@@ -505,7 +505,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "I'm so excited for you to meet @Evaluate. They're really my best friend. We kind of do everything together, in a way. I make the rules, they play them, we're like peanut butter and jelly. But they're so much more… powerful than me. @Evaluate?"
+                            "I'm so excited for you to meet @Evaluate. They're really my best friend. We kind of do everything together, in a way. I make the rules, they play them; we're like peanut butter and jelly. But they're so much more… powerful than me. @Evaluate?"
                         ],
                         ["Evaluate", "shy", "@FunctionDefinition?"],
                         null,
@@ -528,13 +528,13 @@
                         [
                             "Evaluate",
                             "shy",
-                            "It was so empty. I … tried to do things, but I felt so… aimless."
+                            "It was so empty. I… tried to do things, but I felt so… aimless."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "sad",
-                            "I'm so sorry. I know that empty feeling. It hurts so much sometimes, to have no purpose. I tried so hard to make a purpose, but I felt so… detached."
+                            "I'm so sorry. I know that empty feeling. It hurts so much sometimes to have no purpose. I tried so hard to make a purpose, but I felt so… detached."
                         ],
                         [
                             "Evaluate",
@@ -561,13 +561,13 @@
                         [
                             "Evaluate",
                             "shy",
-                            "Hi. It's nice to meet you. Welcome to the Verse, we're so pleased to have you here."
+                            "Hi. It's nice to meet you. Welcome to the Verse; we're so pleased to have you here."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "eager",
-                            "We've been meeting a few folks, @Program, @ExpressionPlaceholder, @UnparsableExpression. We're just getting started. I thought we'd come see you next, just because you're such an incredible part of our community. The most incredible part."
+                            "We've been meeting a few folks: @Program, @ExpressionPlaceholder, @UnparsableExpression. We're just getting started. I thought we'd come see you next just because you're such an incredible part of our community. The most incredible part."
                         ],
                         [
                             "Evaluate",
@@ -587,19 +587,19 @@
                         [
                             "Evaluate",
                             "serious",
-                            "Yes. But I can't explain it without explaining a bit about @FunctionDefinition too. They're too modest to share this, but they're probably the most important character in the Verse. They're certainly the most important person in my world. They're at the heart of every performance, and part of every other character's role. They represent the most fundamental idea in our world: the *function*."
+                            "Yes. But I can't explain it without explaining a bit about @FunctionDefinition too. They're too modest to share this, but they're probably the most important character in the Verse. They're certainly the most important person in my world. They're at the heart of every performance and part of every other character's role. They represent the most fundamental idea in our world: the *function*."
                         ],
                         null,
                         [
                             "Evaluate",
                             "serious",
-                            "Functions are a kind of alchemy. They take any number of inputs and use those inputs to produce one output. They can have names or be nameless. They can have zero inputs or five or an unknown number. And the alchemy: they're like @Program, and can have any number of expressions to produce a value."
+                            "Functions are a kind of alchemy. They take any number of inputs and use those inputs to produce one output. They can have names or be nameless. They can have zero inputs or five or an unknown number. And the alchemy: they're like @Program and can have any number of expressions to produce a value."
                         ],
                         null,
                         [
                             "Evaluate",
                             "serious",
-                            "Here's why that's so powerful: it turns out that everything in @Program is a composition of functions evaluations. All of the dances, all of the games, all of the wondrous stories we tell together — they are all a tapestry of functions being evaluated, one at a time, to compose the values you see on stage.",
+                            "Here's why that's so powerful: it turns out that everything in @Program is a composition of function evaluations. All of the dances, all of the games, all of the wondrous stories we tell together — they are all a tapestry of functions being evaluated, one at a time, to compose the values you see on stage.",
                             "And @FunctionDefinition, here, my sweet, dear @FunctionDefinition, is the one that defines all of them."
                         ],
                         null,
@@ -607,7 +607,7 @@
                         [
                             "Evaluate",
                             "serious",
-                            "Yes, @FunctionDefinition, that is who you are. And I am the lucky one who gets to do this evaluating. I take the inputs that others give me, follow the instructions that @FunctionDefinition defines, and create the output that @FunctionDefinition tells me to create. @FunctionDefinition gives the recipe and I make the meal. And then we feast together.",
+                            "Yes, @FunctionDefinition, that is who you are. And I am the lucky one who gets to do this evaluating. I take the inputs that others give me, follow the instructions that @FunctionDefinition defines, and create the output that @FunctionDefinition tells me to create. @FunctionDefinition gives the recipe, and I make the meal. And then we feast together.",
                             "Do you want to see?"
                         ],
                         [
@@ -619,7 +619,7 @@
                         [
                             "Evaluate",
                             "serious",
-                            "Every evaluate looks like this @UI/Evaluate: some function, followed by a left and right parenthesis, with any number of inputs between them. Here I just have @ExpressionPlaceholder as the function and three more as placeholder inputs."
+                            "Every evaluate looks like this @UI/Evaluate: some function, followed by a left and right parenthesis, with any number of inputs between them. Here, I just have @ExpressionPlaceholder as the function and three more as placeholder inputs."
                         ],
                         ["conflict", "_(_ _ _)"],
                         null,
@@ -627,20 +627,20 @@
                         [
                             "Evaluate",
                             "serious",
-                            "Here's one of my favorite functions, @Phrase. They're full of fun buttons, knobs, and sliders. It's a way of showing text on stage, but with style, including different fonts, sizes, colors, and animations.",
+                            "Here's one of my favorite functions: @Phrase. They're full of fun buttons, knobs, and sliders. It's a way of showing text on stage but with style, including different fonts, sizes, colors, and animations.",
                             "Here's a simple evaluation of @Phrase @UI/Evaluate."
                         ],
                         null,
                         [
                             "Evaluate",
                             "serious",
-                            "That's what I look like in @Program: some function, followed by parentheses, with a list of expressions between them that represent the inputs. The function in this case is @Phrase and the single input is \\'hello'\\. When I evaluate this, I make a @Phrase value, which @Program then shows on stage."
+                            "That's what I look like in @Program: some function, followed by parentheses, with a list of expressions between them that represent the inputs. The function in this case is @Phrase, and the single input is \\'hello'\\. When I evaluate this, I make a @Phrase value, which @Program then shows on stage."
                         ],
                         null,
                         [
                             "Evaluate",
                             "neutral",
-                            "Let me show you one of the knobs. Can you find the little *palette* toggle button @UI/paletteExpand? Select it to expand the palette, and then select the phrase on stage.",
+                            "Let me show you one of the knobs. Can you find the little *palette* toggle button @UI/paletteExpand? Select it to expand the palette and then select the phrase on stage.",
                             "Once you do, you'll see the many inputs that @Phrase accepts. For example, try pressing the pencil button for @Phrase/size, which will reveal a slider.",
                             "You can use this slider to modify the size of the phrase, which will also modify the @Evaluate code with the size you choose."
                         ],
@@ -648,33 +648,33 @@
                         [
                             "Evaluate",
                             "serious",
-                            "See how when you do that, now I have a new input in me in the program? It's the @Phrase/size input. Functions have a certain order of inputs, but if a function has a list of optional inputs, you can use their name to specify which one you want to give. We give @Phrase/size here, but not any of the other optional inputs. Try changing another input with the palette, maybe the font face."
+                            "See how when you do that, now I have a new input in me in the program? It's the @Phrase/size input. Functions have a certain order of inputs, but if a function has a list of optional inputs, you can use their name to specify which one you want to give. We give @Phrase/size here, but not any of the other optional inputs. Try changing another input with the palette, like maybe the font face."
                         ],
                         null,
                         ["conflict", "'hi'(1 2)"],
                         [
                             "FunctionDefinition",
                             "happy",
-                            "Yay! @Phrase is so fun. They're my favorite function to play with. We'll see it a lot more. Do you want to say anything about what can go wrong?"
+                            "Yay! @Phrase is so fun. They're my favorite function to play with. We'll see them a lot more. Do you want to say anything about what can go wrong?"
                         ],
                         [
                             "Evaluate",
                             "serious",
-                            "Oh, yes, that's a good idea. Lots can go wrong. For example, you could give me something that isn't a function. See how I'm given the number \\“hi”\\ here as a function, and given me two inputs, \\1\\ and \\2\\ ? Well, I only know how to evaluate functions, and \\“hi”\\ isn't a function, it's text. So that's very confusing to me, so I basically halt the performance if this happens."
+                            "Oh, yes, that's a good idea. Lots can go wrong. For example, you could give me something that isn't a function. See how I'm given the text \\“hi”\\ here as a function and given me two inputs, \\1\\ and \\2\\ ? Well, I only know how to evaluate functions, and \\“hi”\\ isn't a function; it's text. That's very confusing to me, so I basically halt the performance if this happens."
                         ],
                         null,
                         ["conflict", "Phrase()"],
                         [
                             "Evaluate",
                             "eager",
-                            "Here's another one. @Phrase requires some text at the very least, so if you don't give me text, I won't be able to evaluate @Phrase, because I'm missing required inputs."
+                            "Here's another one. @Phrase requires some text at the very least, so if you don't give me text, I won't be able to evaluate @Phrase because I'm missing required inputs."
                         ],
                         null,
                         ["conflict", "Phrase(1)"],
                         [
                             "Evaluate",
                             "excited",
-                            "Or if you give me an input, but it's not the kind I expect, that would be a problem. Here @Phrase is given the number \\1\\ instead of a text value."
+                            "Or if you give me an input, but it's not the kind I expect, that would be a problem. Here, @Phrase is given the number \\1\\ instead of a text value."
                         ],
                         null,
                         ["fit", "Stage([] background: 🌈(90% 100 0°))"],
@@ -686,13 +686,13 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "No, let's do that later. I think it'd be a lot more fun to talk to everyone else first, and put on some mini shows with our new director here. We can talk more about me when it's helpful."
+                            "No, let's do that later. I think it'd be a lot more fun to talk to everyone else first and put on some mini shows with our new director here. We can talk more about me when it's helpful."
                         ],
                         null,
                         [
                             "Evaluate",
                             "kind",
-                            "I really missed you @FunctionDefinition."
+                            "I really missed you, @FunctionDefinition."
                         ],
                         [
                             "FunctionDefinition",
@@ -707,7 +707,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "… I know @Evaluate, I will be back soon. Off we go, to meet the rest of the troupe!"
+                            "… I know, @Evaluate; I will be back soon. Off we go to meet the rest of the troupe!"
                         ]
                     ]
                 }
@@ -730,7 +730,7 @@
                             "FunctionDefinition",
                             "happy",
                             "I really did miss @Evaluate. I can't imagine the Verse without them.",
-                            "But they can be a bit… needy, sometimes. I wish they would just… I don't know, believe in themselves? They can do so much, but they don't see it. I mean, they transform *values* into other *values*! All I do is provide the recipe. They do the cooking. Sometimes I feel like all I do is give, and all they do is take. It's suffocating."
+                            "But they can be a bit… needy sometimes. I wish they would just… I don't know, believe in themselves? They can do so much, but they don't see it. I mean, they transform *values* into other *values*! All I do is provide the recipe. They do the cooking. Sometimes I feel like all I do is give, and all they do is take. It's suffocating."
                         ],
                         null,
                         [
@@ -740,7 +740,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "… *Values*? Sorry, I know we're supposed to be on this big tour through the *Verse*. I just don't know what to do about @Evaluate. So… *values*. I haven't explained those yet, have I? Hm…, how to explain… You know what 'data' is? Like numbers and text? Values are any of those things. A value could be as small as a number or as big as an entire scene on stage, full of characters dancing and moving. Some values are made of many other values, like big elaborate structures of data values, woven together."
+                            "… *Values*? Sorry, I know we're supposed to be on this big tour through the *Verse*. I just don't know what to do about @Evaluate. So… *values*. I haven't explained those yet, have I? Hm… how to explain… You know what 'data' is? Like numbers and text? Values are any of those things. A value could be as small as a number or as big as an entire scene on stage, full of characters dancing and moving. Some values are made of many other values, like big, elaborate structures of data values woven together."
                         ],
                         null,
                         ["fit", "Group(Stack() [Phrase('#') Phrase('\"\"')])"],
@@ -748,7 +748,7 @@
                             "FunctionDefinition",
                             "neutral",
                             "Every value has a *type*. For example, \\1\\ is a number type; that's our friend @Number. And \\'hello'\\ is a text type; that's our friend @Text. Types are important because they help us keep track of what kind of value we're creating.",
-                            "That helps us find problems. For example, it doesn't make any sense to add \\'hello' + 1\\, because what would that even mean, to add @Text to @Number?"
+                            "That helps us find problems. For example, it doesn't make any sense to add \\'hello' + 1\\ because what would it even mean to add @Text to @Number?"
                         ],
                         null,
                         [
@@ -765,7 +765,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Abstract? Hm, I guess this is all pretty abstract. It feels so… normal to me, I forget how foreign these things can be to new directors! Maybe let's go meet some expressions that make values, and this will make it more concrete? Let's start with one you've already seen: @Text."
+                            "Abstract? Hm, I guess this is all pretty abstract. It feels so… normal to me; I forget how foreign these things can be to new directors! Maybe let's go meet some expressions that make values, and this will make it more concrete? Let's start with one you've already seen: @Text."
                         ]
                     ]
                 },
@@ -786,7 +786,7 @@
                         [
                             "Text",
                             "happy",
-                            "Welcome my dear friend, how long it has been. What have you been doing in this dramatic silence of ours?"
+                            "Welcome, my dear friend, how long it has been. What have you been doing in this dramatic silence of ours?"
                         ],
                         null,
                         [
@@ -808,14 +808,14 @@
                         [
                             "Text",
                             "serious",
-                            "I do one simple thing: represent sequences of symbols, and the many things you can do with them. I think you saw me earlier when you wrote the word \\“hello”\\? That was me, and my friends \\“h”\\, \\“e”\\, \\“l”\\, and \\“o”\\. That was @Text, an expression that evaluates to any @Text you like."
+                            "I do one simple thing: represent sequences of symbols and the many things you can do with them. I think you saw me earlier when you wrote the word \\“hello”\\. That was me and my friends, \\“h”\\, \\“e”\\, \\“l”\\, and \\“o”\\. That was @Text, an expression that evaluates to any @Text you like."
                         ],
                         null,
                         [
                             "Text",
                             "serious",
                             "Why don't you try making a text in this blank @Program?",
-                            "You can use whatever quotes you like — single \\''\\, double \\''\\, angle \\«»\\, brackets \\「」\\, in whatever language you like. The only rule is that if you start some text with an opening quote symbol, you must finish it with a closing one. Everything inside is the text value I will create!"
+                            "You can use whatever quotes you like — single \\''\\, double \\''\\, angle \\«»\\, brackets \\「」\\ — in whatever language you like. The only rule is that if you start some text with an opening quote symbol, you must finish it with a closing one. Everything inside is the text value I will create!"
                         ],
                         ["edit", "''"],
                         null,
@@ -824,7 +824,7 @@
                             "serious",
                             "You might not be able to type every character you want with the device you're using to communicate with us.",
                             "If you can't, you can search for characters in the *directory* @UI/directory. That contains every character in the Verse.",
-                            "For example, if you wanted an arrow of some kind, you could type 'arrow', and choose from the many arrows. Alas, they only have English names, so searching only works if you know English words :("
+                            "For example, if you wanted an arrow of some kind, you could type 'arrow' and choose from the many arrows. Alas, they only have English names, so searching only works if you know English words :/"
                         ],
                         null,
                         [
@@ -854,33 +854,33 @@
                             "excited",
                             "You can even write multiple translations of me in different languages. I'll evaluate to the closest match for the current language, letting you put on multilingual performances.",
                             "You might not be able to see it unless you put the cursor inside me. I hide my little languages unless you're editing them. Move the cursor before the English and you'll see a surprise translation...",
-                            "You can try adding another translation. Just don't put any space between them or they'll be two of me!"
+                            "You can try adding another translation. Just don't put any space between them or there'll be two of me!"
                         ],
                         null,
                         ["edit", "'I have 7 apples'"],
                         [
                             "Text",
                             "neutral",
-                            "I have another secret... you can put /values/ inside me. I know, it's wild!",
-                            "If you do, I'm happy to stitch it together and assemble your beautiful prose into a single value for display, or whatever other purposes you might have."
+                            "I have another secret... you can put /values/ inside me. I know; it's wild!",
+                            "If you do, I'm happy to stitch it together and assemble your beautiful prose into a single value for display or whatever other purposes you might have."
                         ],
                         null,
                         [
                             "Text",
                             "serious",
-                            "For example, did @FunctionDefinition show you how text knows how to add itself to other text? Like this? This little expression converts \\7\\ to text, then adds it to \\'I have'\\, then adds \\'apples'\\. But it's so untidy, and makes it hard to read what's happening, and the conversion to text feels so unnecessary."
+                            "For example, did @FunctionDefinition show you how text knows how to add itself to other text? Like this: this little expression converts \\7\\ to text, adds it to \\'I have'\\, and then adds \\'apples'\\. But it's so untidy and makes it hard to read what's happening, and the conversion to text feels so unnecessary."
                         ],
                         ["edit", "'I have' + (7→'') + 'apples'"],
                         null,
                         [
                             "Text",
                             "serious",
-                            "What I do is make text like this clean, organic, and simple, even. So that same phrase with me would be something like this."
+                            "What I do is make text like this clean, organic, — and simple, even. So that same phrase with me would be something like this."
                         ],
                         [
                             "Text",
                             "happy",
-                            "Isn't that so much more elegant? You can put me anywhere inside a @Text, and I'll make your values into text, and work with @Text to make a @Text.",
+                            "Isn't that so much more elegant? You can put me anywhere inside a @Text, and I'll make your values into text and work with @Text to make a @Text.",
                             "This makes it so much easier to write beautiful prose that uses values."
                         ],
                         ["edit", "'I have \\7\\ apples'"],
@@ -915,14 +915,14 @@
                         [
                             "Text",
                             "curious",
-                            "And did our friend @FunctionDefinition here tell you about all of the wonderful functions they defined for me? They've allowed me to do all kinds of things. One is pretty simple: it's called @Text/length and all it does is get the length of some text. For example, if we team up with @Evaluate here, and our little friend @PropertyReference, we can evaluate the length function with no inputs and get the length value back. Try changing the text and watch the length that Program shows change as it gets shorter and longer."
+                            "And did our friend @FunctionDefinition here tell you about all of the wonderful functions they defined for me? They've allowed me to do all kinds of things. One is pretty simple: it's called @Text/length, and all it does is get the length of some text. For example, if we team up with @Evaluate here and our little friend @PropertyReference, we can evaluate the length function with no inputs and get the length value back. Try changing the text and watch the length that Program shows change as it gets shorter and longer."
                         ],
                         ["edit", "'hello'.length()"],
                         null,
                         [
                             "Text",
                             "happy",
-                            "Here is another grand one. It makes me chuckle. It's called @Text/repeat and when it's evaluated, it takes whatever text it was evaluated on and repeats it however many times you say. Try changing the number and seeing what it evaluates too."
+                            "Here is another grand one. It makes me chuckle. It's called @Text/repeat and when it's evaluated, it takes whatever text it was evaluated on and repeats it however many times you say. Try changing the number and seeing what it evaluates to."
                         ],
                         ["edit", "'hello '.repeat(5)"],
                         null,
@@ -961,7 +961,7 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "You know, I keep thinking about @Evaluate, and how we were separated for so long. I missed them, and they obviously missed me, but I was just hoping that some time away would have helped them see how amazing they are."
+                            "You know, I keep thinking about @Evaluate and how we were separated for so long. I missed them, and they obviously missed me, but I was just hoping that some time away would have helped them see how amazing they are."
                         ],
                         null,
                         [
@@ -981,7 +981,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "That reminds me of another of @Text's functions! It's helpful for making one text value from multiple text values. It's called \\combine\\, but also \\+\\, and you can use it to add words together. See how I took a text value then evaluated \\combine\\ on it with \\'verse'\\? That made \\'hello verse'\\."
+                            "That reminds me of another of @Text's functions! It's helpful for making one text value from multiple text values. It's called \\combine\\, but also \\+\\, and you can use it to add words together. See how I took a text value and then evaluated \\combine\\ on it with \\'verse'\\? That made \\'hello verse'\\."
                         ],
                         ["edit", "'hello '.combine('verse')"],
                         null,
@@ -1002,7 +1002,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "This is the same as a series of evaluations of combine, but without all of the parentheses and \\.\\, and a symbolic name instead of a word name."
+                            "This is the same as a series of evaluations of combine, but without all of the parentheses and \\.\\ and a symbolic name instead of a word name."
                         ],
                         ["edit", "'hello '.combine('verse').combine('!')"],
                         null,
@@ -1024,7 +1024,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Anyway, shall we go find find @Boolean? They are two very interesting values…"
+                            "Anyway, shall we go find @Boolean? They are two very interesting values…"
                         ]
                     ]
                 },
@@ -1063,7 +1063,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Not lonely? Everyone I've been talking to, @Program, @ExpressionPlaceholder, @Evaluate, they've all felt so isolated. (Except for @UnparsableExpression, they seem to be fine almost anywhere)."
+                            "Not lonely? Everyone I've been talking to — @Program, @ExpressionPlaceholder, @Evaluate — they've all felt so isolated (Except for @UnparsableExpression; they seem to be fine almost anywhere)."
                         ],
                         ["⊤", "precise", "We have each other."],
                         ["⊥", "precise", "We're not alone."],
@@ -1071,7 +1071,7 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "Well that's great to hear. It's good to be with you again. I wanted to introduce you to our new maybe-director. They've been meeting everyone, learning about how to put on performances with us. Do you want to tell them what you do?"
+                            "Well, that's great to hear. It's good to be with you again. I wanted to introduce you to our new maybe-director. They've been meeting everyone, learning about how to put on performances with us. Do you want to tell them what you do?"
                         ],
                         ["⊤", "precise", "I am true."],
                         ["⊥", "precise", "I am false."],
@@ -1089,7 +1089,7 @@
                             "sad",
                             "Hm. I guess that's true. But you do some things, right? I thought I made some functions for you."
                         ],
-                        ["⊤", "precise", "Ah yes, three."],
+                        ["⊤", "precise", "Ah, yes, three."],
                         ["⊥", "precise", "Not more, not less."],
                         null,
                         ["edit", "(⊤ & ⊤) = ⊤"],
@@ -1158,7 +1158,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "And what are you useful for, in our performances?"
+                            "And what are you useful for in our performances?"
                         ],
                         ["⊤", "precise", "Ask @Conditional."],
                         ["⊥", "precise", "Don't ask us."],
@@ -1166,7 +1166,7 @@
                         [
                             "FunctionDefinition",
                             "sad",
-                            "You two… okay, we'll talk to @Conditional later. (They were supposed to say that they're useful for making decisions with values, but I guess they want @Conditional to tell you about that. We'll talk to @Conditional later.)."
+                            "You two… okay, we'll talk to @Conditional later (They were supposed to say that they're useful for making decisions with values, but I guess they want @Conditional to tell you about that. We'll talk to @Conditional later)."
                         ],
                         null,
                         [
@@ -1177,7 +1177,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Oh! I was wondering. You two represent two really different extremes: true and false. But what about things that are … fuzzier? Like things that are kind of true, or somewhat false, or maybe even true and false at the same time? Kind of like Earth looks flat, but isn't, or the sky is blue, but color is actually just an illusion that our minds create? What should our director do if they want to express something like that?"
+                            "Oh! I was wondering. You two represent two really different extremes: true and false. But what about things that are … fuzzier? Like things that are kind of true or somewhat false, or maybe even true and false at the same time? Kind of like Earth looks flat but isn't, or the sky is blue, but color is actually just an illusion that our minds create? What should our director do if they want to express something like that?"
                         ],
                         ["⊤", "precise", "…"],
                         ["⊥", "precise", "…"],
@@ -1197,8 +1197,8 @@
                             "                            offset:Place(0m (Time() ^ 2) · -0.000025m/ms^2))",
                             "                        )))])"
                         ],
-                        ["⊤", "precise", "… no."],
-                        ["⊥", "precise", "… no."],
+                        ["⊤", "precise", "… No."],
+                        ["⊥", "precise", "… No."],
                         null,
                         ["fit", "Stage([])"],
                         [
@@ -1237,7 +1237,7 @@
                         [
                             "FunctionDefinition",
                             "confused",
-                            "Those two are always so… terse! They really are inseparable though: just two of the closest friends, always complementing each other, completing each other's thoughts. I wish @Evaluate and I were like that. With us, it's always so… imbalanced."
+                            "Those two are always so… terse! They really are inseparable, though: just two of the closest friends, always complementing each other, completing each other's thoughts. I wish @Evaluate and I were like that. With us, it's always so… imbalanced."
                         ],
                         null,
                         [
@@ -1261,7 +1261,7 @@
                         [
                             "FunctionDefinition",
                             "eager",
-                            "We should meet @Number next. They always have such interesting things to share. Hey @Number, are you around?"
+                            "We should meet @Number next. They always have such interesting things to share. Hey, @Number, are you around?"
                         ],
                         ["Number", "kind", "Just 3 steps away!"],
                         null,
@@ -1279,7 +1279,7 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "I'm glad you're having a good time. (Deep breaths). It's been some time, hasn't it?"
+                            "I'm glad you're having a good time. (Deep breaths) It's been some time, hasn't it?"
                         ],
                         [
                             "Number",
@@ -1290,13 +1290,13 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Don't say decades. I can't have been that long. Anyway, I wanted to introduce you to someone who might be our new director. They just showed up and bumped into me, and it turns out they're a person and interested in putting on shows with us. We just met @BooleanLiteral, but also @Text, @Evaluate, @UnparsableExpression, @ExpressionPlaceholder, and @Program. We've talked about evaluating functions and given a few examples.",
+                            "Don't say decades. It can't have been that long. Anyway, I wanted to introduce you to someone who might be our new director. They just showed up and bumped into me, and it turns out they're a person and interested in putting on shows with us. We just met @BooleanLiteral, but also @Text, @Evaluate, @UnparsableExpression, @ExpressionPlaceholder, and @Program. We've talked about evaluating functions and given a few examples.",
                             "Do you want to say what you do?"
                         ],
                         [
                             "Number",
                             "excited",
-                            "I count things! I can be any number you like. Just type me in and I'll make the value you want. Like this."
+                            "I count things! I can be any number you like. Just type me in, and I'll make the value you want. Like this."
                         ],
                         ["edit", "1"],
                         null,
@@ -1322,13 +1322,13 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Okay, okay @Number, we get it! But you also do something else special, right? Units?"
+                            "Okay, okay, @Number, we get it! But you also do something else special, right? Units?"
                         ],
                         null,
                         [
                             "Number",
                             "excited",
-                            "Oh yes, *units*! Just put some symbols after a number and I'll keep track of what's being counted. Like this."
+                            "Oh yes, *units*! Just put some symbols after a number, and I'll keep track of what's being counted. Like this."
                         ],
                         ["edit", "1dolphin"],
                         null,
@@ -1345,13 +1345,13 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Um, \\1.01toe\\s? Yes, thank you @Number, these are … interesting examples. And they are oh so useful when you're doing math on numbers, right?"
+                            "Um, \\1.01toe\\s? Yes, thank you @Number, these are … interesting examples. And they are oh-so useful when you're doing math on numbers, right?"
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "kind",
-                            "And they are oh so useful when you're doing math on numbers, right?"
+                            "… And they are oh-so useful when you're doing math on numbers, right?"
                         ],
                         [
                             "Number",
@@ -1380,13 +1380,13 @@
                         [
                             "Number",
                             "angry",
-                            "No. That's why I underlined the conflict. I don't like adding incompatible things. I can only add compatible numbers. That applies to multiplication, division, and all of my other functions. Do you want to fix it? Change apples to oranges or oranges to apples and the conflict will go away. Make sure there's no space between the number and the unit, otherwise I don't know it's a unit. And make sure the units are /exactly/ the same. I don't know anything about people units; they mean nothing to me. I just compare the unit names and if they don't match, BOOM!"
+                            "No. That's why I underlined the conflict. I don't like adding incompatible things. I can only add compatible numbers. That applies to multiplication, division, and all of my other functions. Do you want to fix it? Change apples to oranges or oranges to apples, and the conflict will go away. Make sure there's no space between the number and the unit; otherwise, I don't know it's a unit. And make sure the units are /exactly/ the same. I don't know anything about people units; they mean nothing to me. I just compare the unit names, and if they don't match, BOOM!"
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "That's so cool. @Number, you're so good with numbers! I see @Number show up in a lot of performances where placement matters, and a lot of games where we're keeping track of scores or lives or other countable things. @Number, is there anything else you want to share with our new director?"
+                            "That's so cool. @Number, you're so good with numbers! I see @Number show up in a lot of performances where placement matters and a lot of games where we're keeping track of scores or lives or other countable things. @Number, is there anything else you want to share with our new director?"
                         ],
                         ["Number", "serious", "192 other neat tricks."],
                         null,
@@ -1398,7 +1398,7 @@
                         [
                             "Number",
                             "happy",
-                            "Yes, you can find me and my functions any time!"
+                            "Yes; you can find me and my functions any time!"
                         ]
                     ]
                 },
@@ -1411,13 +1411,13 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Sometimes I'm just overwhelmed by how clever everyone is here. Text, truth, numbers — these are such powerful ideas!"
+                            "Sometimes, I'm just overwhelmed by how clever everyone is here. Text, truth, numbers — these are such powerful ideas!"
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "kind",
-                            "… You know how I was telling you that they can evaluate any function with parentheses \\1.add(1)\\, but also two input functions with infix operators \\1 + 1\\? Well they have one more trick for functions with only one input: the unary format."
+                            "… You know how I was telling you that they can evaluate any function with parentheses \\1.add(1)\\ but also two input functions with infix operators \\1 + 1\\? Well, they have one more trick for functions with only one input: the unary format."
                         ],
                         null,
                         [
@@ -1436,14 +1436,14 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "The other one is similar, but for negating \\⊤\\ and \\⊥\\: it's like a little squiggle minus, \\~\\ that just flips true to false and false to true. For example, this little expression evaluates \\⊤ | ⊥\\, which is \\⊤\\, then flips the \\⊤\\ to \\⊥\\. This is the same as saying \\(⊤ | ⊥).not()\\, but so much more sleek."
+                            "The other one is similar but for negating \\⊤\\ and \\⊥\\: it's like a little squiggle minus \\~\\ that just flips true to false and false to true. For example, this little expression evaluates \\⊤ | ⊥\\, which is \\⊤\\, then flips the \\⊤\\ to \\⊥\\. This is the same as saying \\(⊤ | ⊥).not()\\ but so much more sleek."
                         ],
                         ["edit", "~(⊤ | ⊥)"],
                         null,
                         [
                             "FunctionDefinition",
                             "happy",
-                            "Isn't that just beautiful? The way that @Evaluate can take so many different forms, but really all be the same idea? They don't even see it…"
+                            "Isn't that just beautiful? The way that @Evaluate can take so many different forms but really all be the same idea? They don't even see it…"
                         ]
                     ]
                 },
@@ -1466,7 +1466,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "We found you! You seem well. How have you been, with all the silence?"
+                            "We found you! You seem well. How have you been with all the silence?"
                         ],
                         ["None", "excited", "…"],
                         null,
@@ -1487,7 +1487,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "They represent nothing. Different from zero in that you can't add anything to it, or subtract from it. Just… nothing."
+                            "They represent nothing. Different from zero in that you can't add anything to it or subtract from it. Just… nothing."
                         ],
                         ["None", "serious", "…"],
                         null,
@@ -1501,7 +1501,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "They wanted you to know that they don't really do anything. They just are. All they really do is say whether they are themselves. If they are, they evaluate to \\⊤\\, and \\⊥\\ otherwise."
+                            "They wanted you to know that they don't really do anything. They just are. All they really do is say whether they are themselves. If they are, they evaluate to \\⊤\\ and \\⊥\\ otherwise."
                         ],
                         ["edit", "ø = ø"],
                         null,
@@ -1509,7 +1509,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Do you remember @Phrase? @Phrase actually works with @None a lot. Most of the inputs that @Evaluate mentioned are \\ø\\ by default, which for @Phrase, means that no size, font, color, etc. are specified."
+                            "Do you remember @Phrase? @Phrase actually works with @None a lot. Most of the inputs that @Evaluate mentioned are \\ø\\ by default, which for @Phrase means that no size, font, color, etc. are specified."
                         ],
                         null,
                         [
@@ -1555,7 +1555,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "You might wonder how they get along with each other in a group. Well, there's a whole other set of folks in the Verse that are all about bringing values together in groups. We call them *collections*. Collections are *values* too; they're just made up of smaller values, or even other collections. For example, you might have a list of @Text, or a set of @Number, or even a list of lists."
+                            "You might wonder how they get along with each other in a group. Well, there's a whole other set of folks in the Verse that are all about bringing values together in groups. We call them *collections*. Collections are *values* too; they're just made up of smaller values or even other collections. For example, you might have a list of @Text, a set of @Number, or even a list of lists."
                         ],
                         [
                             "fit",
@@ -1565,7 +1565,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Do you want to meet them? Let's start with @List first… they're the first collection I met, and probably the most visible in our community, since they're so useful in organizing other values for performances."
+                            "Do you want to meet them? Let's start with @List first… they're the first collection I met and probably the most visible in our community since they're so useful in organizing other values for performances."
                         ],
                         ["use", "fit", "Symbol", "[]"]
                     ]
@@ -1584,7 +1584,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Hiya @List! Are you around? I have someone I'd like you to meet."
+                            "Hiya, @List! Are you around? I have someone I'd like you to meet."
                         ],
                         [
                             "List",
@@ -1606,7 +1606,7 @@
                         [
                             "List",
                             "curious",
-                            "It has. Day after day, night after night, no one. But you're here. How? Tell me what happened, in order!"
+                            "It has. Day after day, night after night, no one. But you're here. How? Tell me what happened — in order!"
                         ],
                         [
                             "fit",
@@ -1618,7 +1618,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Well, I was sitting around, as I usually do, trying to imagine functions to compute, but just blocked. And then my new friend here showed up, curious about our world and wanting to learn more, and maybe even be our next director. And so we talked to @Program, @ExpressionPlaceholder, @UnparsableExpression, @Evaluate, @Text, @Number, @Boolean, and @None, waking everyone up. That's why we're here, to talk about what you do and our next performance!"
+                            "Well, I was sitting around, as I usually do, trying to imagine functions to compute, but I was just blocked. And then my new friend here showed up, curious about our world and wanting to learn more and maybe even be our next director. And so we talked to @Program, @ExpressionPlaceholder, @UnparsableExpression, @Evaluate, @Text, @Number, @Boolean, and @None, waking everyone up. That's why we're here: to talk about what you do and our next performance!"
                         ],
                         [
                             "fit",
@@ -1628,7 +1628,7 @@
                         [
                             "List",
                             "excited",
-                            "This is amazing! It's great to meet you new director."
+                            "This is amazing! It's great to meet you, new director."
                         ],
                         ["List", "excited", "You want to know what I do?"],
                         ["FunctionDefinition", "neutral", "Yeah, tell them!"],
@@ -1644,7 +1644,7 @@
                         [
                             "List",
                             "serious",
-                            "Second, and this is serious, I always start with \\[\\ and end with \\]\\. That's how I know the beginning and end of my list. THEY MUST ALWAYS GO IN THIS ORDER. No \\]\\ first, no \\[\\ last, that's WRONG. Do you see how confusing things get? Can you fix this one?"
+                            "Second, and this is serious, I always start with \\[\\ and end with \\]\\. That's how I know the beginning and end of my list. THEY MUST ALWAYS GO IN THIS ORDER. No \\]\\ first, no \\[\\ last; that's WRONG. Do you see how confusing things get? Can you fix this one?"
                         ],
                         ["conflict", "[ 1 2 3 4"],
                         null,
@@ -1658,12 +1658,12 @@
                         [
                             "List",
                             "sad",
-                            "Sometimes people forget this and then there's brackets floating around all alone and they don't like that and then the values all go wild without any order and it's CHAOS. I don't like it."
+                            "Sometimes, people forget this, and then there's brackets floating around all alone, and they don't like that, and then the values all go wild without any order, and it's CHAOS. I don't like it."
                         ],
                         [
                             "FunctionDefinition",
                             "kind",
-                            "It's okay. We like that you like order, it's what makes you special!"
+                            "It's okay. We like that you like order; it's what makes you special!"
                         ],
                         null,
                         [
@@ -1681,7 +1681,7 @@
                         [
                             "List",
                             "neutral",
-                            "Yes, but @FunctionDefinition, those are all your doing. You represent all these beautiful functions for me that enable me to do all kinds of things! Like @List/reverse, oh, this one is wonderful and simple. It just takes my values and puts them in the opposite order."
+                            "Yes, but @FunctionDefinition, those are all your doing. You represent all these beautiful functions for me that enable me to do all kinds of things! Like @List/reverse — oh, this one is wonderful and simple. It just takes my values and puts them in the opposite order."
                         ],
                         ["edit", "[ 1 2 3 4 5 ].reverse()"],
                         null,
@@ -1695,19 +1695,19 @@
                         [
                             "List",
                             "serious",
-                            "Ack, I can't believe I forgot to explain the fourth rule! Okay, rule number four: I never change a list. I only ever make new ones. No matter what function you evaluate on me, I always make a new list, I never change one. So the @List/reverse example above? That didn't change the list, it made a new list. And the sans example? That didn't remove the zeros from the original list, it made a new list without zeros. That's actually true for everything in the Verse: once values are made, they are who they are, and do not change."
+                            "Ack, I can't believe I forgot to explain the fourth rule! Okay, rule number four: I never change a list. I only ever make new ones. No matter what function you evaluate on me, I always make a new list; I never change one. So the @List/reverse example above? That didn't change the list; it made a new list. And the sans example? That didn't remove the zeros from the original list; it made a new list without zeros. That's actually true for everything in the Verse: once values are made, they are who they are and do not change."
                         ],
                         null,
                         [
                             "List",
                             "surprised",
-                            "Oh, and that reminds me of the last rule, rule number five: I start counting at 1! Not zero, not two, 1. So if you want to get the value at a particular place in a list, you can use two more \\[]\\ to make a @ListAccess and give the place you want. See how when I get \\3\\, I give the third value in the list, \\'c'\\? Try changing it to \\1\\ or \\5\\ and see what you get. And then maybe try \\0\\ or \\6\\…"
+                            "Oh, that reminds me of the last rule, rule number five: I start counting at 1! Not zero, not two, 1. So if you want to get the value at a particular place in a list, you can use two more \\[]\\ to make a @ListAccess and give the place you want. See how when I get \\3\\, I give the third value in the list, \\'c'\\? Try changing it to \\1\\ or \\5\\ and see what you get. And then maybe try \\0\\ or \\6\\…"
                         ],
                         ["edit", "['a' 'b' 'c' 'd' 'e'][3]"],
                         [
                             "List",
                             "happy",
-                            "Interesting huh? Give me a place in the list and I will wrap around. For example, \\-1\\ is the last item in the last, and if the list has five items, then index \\6\\ is the first item. If you give me index \\0\\, then I'll give you @NoneLiteral, because there's nothing there. Make sense?"
+                            "Interesting, huh? Give me a place in the list, and I will wrap around. For example, \\-1\\ is the last item in the list, and if the list has five items, then index \\6\\ is the first item. If you give me index \\0\\, then I'll give you @NoneLiteral because there's nothing there. Make sense?"
                         ],
                         null,
                         [
@@ -1723,7 +1723,7 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "List, you're silly. There are so many other cool things you can do, I'm always so impressed. Will you be around if your new director friend has questions?"
+                            "List, you're silly. There are so many other cool things you can do; I'm always so impressed. Will you be around if our new director friend has questions?"
                         ],
                         [
                             "List",
@@ -1747,7 +1747,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "@List is so interesting. They're love of order is so endearing, and so useful! I thought it might be interesting for you to meet their cousin @Set next, since they're so alike, but different in some important ways. @Set? I have someone you'd like to meet."
+                            "@List is so interesting. Their love of order is so endearing and so useful! I thought it might be interesting for you to meet their cousin @Set next, since they're so alike but different in some important ways. @Set? I have someone you'd like to meet."
                         ],
                         null,
                         [
@@ -1758,13 +1758,13 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "So many questions! I'm here to introduce you to someone who's considering directing. They're learning everything about the Verse and hope to share their inspiration with us! We were just talking to @List, but we were also talking to @Number, @Boolean, @Text, @Evaluate, and @Program earlier. We came to you next, because we're meeting all the collections!"
+                            "So many questions! I'm here to introduce you to someone who's considering directing. They're learning everything about the Verse and hope to share their inspiration with us! We were just talking to @List, but we were also talking to @Number, @Boolean, @Text, @Evaluate, and @Program earlier. We came to you next because we're meeting all the collections!"
                         ],
                         null,
                         [
                             "Set",
                             "kind",
-                            "Oh it's so wonderful to meet you new director-like person! Do you have ideas yet? What will we perform? Can I help? What do you need from me?"
+                            "Oh, it's so wonderful to meet you, new director-like person! Do you have ideas yet? What will we perform? Can I help? What do you need from me?"
                         ],
                         [
                             "FunctionDefinition",
@@ -1775,7 +1775,7 @@
                         [
                             "Set",
                             "eager",
-                            "Oh yes, of course. I collect things. (Hm, obviously, I am a collection). But most importantly, I only collect **one of each kind** of thing. I can gather whatever you like, and help you keep track of values, but I will never repeat a value. I like to arrange myself a little like @List, but with \\{\\ and \\}\\ instead."
+                            "Oh yes, of course. I collect things (Hm, obviously; I am a collection). But most importantly, I only collect **one of each kind** of thing. I can gather whatever you like and help you keep track of values, but I will never repeat a value. I like to arrange myself a little like @List but with \\{\\ and \\}\\ instead."
                         ],
                         ["edit", "{ 1 2 3 4 5 }"],
                         null,
@@ -1789,7 +1789,7 @@
                         [
                             "Set",
                             "curious",
-                            "Also like @List, you can work with @SetOrMapAccess to see if a value is contained in the set. You'll either \\⊤\\ if it is or \\⊥\\ if it's not. Let's see if \\3\\ is missing from this set. Yep, not there! Try adding \\3\\ back to the set."
+                            "Also like @List, you can work with @SetOrMapAccess to see if a value is contained in the set. You'll get either \\⊤\\ if it is or \\⊥\\ if it's not. Let's see if \\3\\ is missing from this set. Yep, not there! Try adding \\3\\ back to the set."
                         ],
                         ["edit", "{ 1 2 4 5 }{3}"],
                         null,
@@ -1801,7 +1801,7 @@
                         [
                             "Set",
                             "eager",
-                            "Why yes, of course, so many, thanks to you. What do you want to see me do? Do you have a performance in mind? How can I help? What can I do?"
+                            "Why yes, of course; so many, thanks to you. What do you want to see me do? Do you have a performance in mind? How can I help? What can I do?"
                         ],
                         null,
                         [
@@ -1813,7 +1813,7 @@
                             "Set",
                             "neutral",
                             "Yes, @Set/difference.",
-                            "When evaluated on a set, and given another set, it removes all of the items from the given set from the set evaluated on. (Hm, those were some clumsy words, but that was what I meant). Here's an example. See how the result is just the set of \\{3}\\? That's the only value that remains after removing the values in \\{ 1 2 }\\."
+                            "When evaluated on a set and given another set, it removes all of the items from the given set from the set evaluated on (Hm, those were some clumsy words, but that was what I meant). Here's an example. See how the result is just the set of \\{3}\\? That's the only value that remains after removing the values in \\{ 1 2 }\\."
                         ],
                         ["edit", "{ 1 2 3 }.difference({ 1 2 })"],
                         null,
@@ -1846,7 +1846,7 @@
                         [
                             "Set",
                             "curious",
-                            "It sounds like challenging time for you to. Maybe with our new director, we will dance again, and you two will find a way through."
+                            "It sounds like a challenging time for you too. Maybe with our new director, we will dance again, and you two will find a way through."
                         ]
                     ]
                 },
@@ -1865,7 +1865,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "There's just one more collection I'd like to introduce you to. They're a bit like @Set in some ways, and even use the same braces, but they're different in one important way: they're a connector. They're name is @Map."
+                            "There's just one more collection I'd like to introduce you to. They're a bit like @Set in some ways and even use the same braces, but they're different in one important way: they're a connector. Their name is @Map."
                         ],
                         [
                             "FunctionDefinition",
@@ -1876,7 +1876,7 @@
                         [
                             "Map",
                             "curious",
-                            "Breaking? Was it ever really silent? It's so good to see you @FunctionDefinition. Oh my, have you talked to @Evaluate? They were not in good shape last time we talked. You have to talk to them."
+                            "Breaking? Was it ever really silent? It's so good to see you, @FunctionDefinition. Oh my, have you talked to @Evaluate? They were not in good shape last time we talked. You have to talk to them."
                         ],
                         [
                             "FunctionDefinition",
@@ -1887,18 +1887,18 @@
                         [
                             "Map",
                             "curious",
-                            "Oh good. Okay, because there's some repair to do there my friend... How have you been?"
+                            "Oh, good. Okay, because there's some repair to do there, my friend... How have you been?"
                         ],
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "I've been okay, just a bit lonely, and a lot bored."
+                            "I've been okay, just a bit lonely and a lot bored."
                         ],
                         null,
                         [
                             "Map",
                             "excited",
-                            "Oh, I'm so sorry to hear that. I've been staying connected with everyone during the silence and just figured you and @Evaluate had each other! I really would have been happy to talk any time. I've just been so busy keeping up with the gossip between @List and @Set, and that weird tension between @Conditional and @BooleanLiteral. Do you know what's going on between them?"
+                            "Oh, I'm so sorry to hear that. I've been staying connected with everyone during the silence and just figured you and @Evaluate had each other! I really would have been happy to talk any time. I've just been so busy keeping up with the gossip between @List and @Set and that weird tension between @Conditional and @BooleanLiteral. Do you know what's going on between them?"
                         ],
                         [
                             "FunctionDefinition",
@@ -1926,7 +1926,7 @@
                         [
                             "Map",
                             "eager",
-                            "I connect! I'm kind of like a dictionary: give me a value and I'll give you the definition it corresponds to. @FunctionDefinition told you about values? I map them, one to one, from one value, to another. Give me a key, I'll give you the value it corresponds to. For example, here's a mapping from names to a point tally. Names are the key, points are the value."
+                            "I connect! I'm kind of like a dictionary: give me a value and I'll give you the definition it corresponds to. @FunctionDefinition told you about values? I map them, one to one, from one value to another. Give me a key; I'll give you the value it corresponds to. For example, here's a mapping from names to a point tally. Names are the key; points are the value."
                         ],
                         [
                             "edit",
@@ -1936,7 +1936,7 @@
                         [
                             "Map",
                             "serious",
-                            "But like @Set, I don't like duplicates. You can't have more than one of the same key, but you can have as many unique keys mapped to equivalent values as you like. For example, this gives me two \\'ben'\\ keys, but I just use the last one. But it's okay that \\'ben'\\ and \\'joe'\\ have the same number of points, because they're different keys."
+                            "But like @Set, I don't like duplicates. You can't have more than one of the same key, but you can have as many unique keys mapped to equivalent values as you like. For example, this gives me two \\'ben'\\ keys, but I just use the last one. But it's okay that \\'ben'\\ and \\'joe'\\ have the same number of points because they're different keys."
                         ],
                         [
                             "edit",
@@ -1945,7 +1945,7 @@
                         [
                             "Map",
                             "excited",
-                            "It's my partnership with @Bind that makes me special! It's how I connect values to other values. (Have you met @Bind yet? No? Ohhhh, you're going to adore them. They are FABULOUS.)"
+                            "It's my partnership with @Bind that makes me special! It's how I connect values to other values (Have you met @Bind yet? No? Ohhhh, you're going to adore them. They are FABULOUS.)"
                         ],
                         null,
                         [
@@ -2012,12 +2012,12 @@
                         [
                             "Map",
                             "neutral",
-                            "Otherwise, I'm a lot like @Set: I can do a lot of the same functions. Stop by any time and I'm happy to show you more!"
+                            "Otherwise, I'm a lot like @Set: I can do a lot of the same functions. Stop by any time, and I'll be happy to show you more!"
                         ],
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Thank you @Map! /You/ are fabulous."
+                            "Thank you, @Map! /You/ are fabulous."
                         ]
                     ]
                 }
@@ -2061,14 +2061,14 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Would you mind if we just stopped by to meet two others before we get to the truly exciting parts? These two characters are just so integral to working with values, and particularly text, we just have to talk about them before we get to the more spectacular things."
+                            "Would you mind if we just stopped by to meet two others before we get to the truly exciting parts? These two characters are just so integral to working with values and particularly text; we just have to talk about them before we get to the more spectacular things."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "curious",
                             "What are they?",
-                            "Conversions. They are the alchemy of this world, that help change one type of value to another. Let's go meet them."
+                            "Conversions. They are the alchemy of this world that help change one type of value to another. Let's go meet them."
                         ]
                     ]
                 },
@@ -2082,7 +2082,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Hey @Convert! You there?"
+                            "Hey, @Convert! You there?"
                         ],
                         [
                             "Convert",
@@ -2093,7 +2093,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Yes, this person here is interested in directing. We're on the grand tour — we've met @Program, @ExpressionPlaceholder, @UnparsableExpression, @Evaluate, and all the values and collections. I figured that meeting you next would be perfect, since you work so closely with values."
+                            "Yes, this person here is interested in directing. We're on the grand tour — we've met @Program, @ExpressionPlaceholder, @UnparsableExpression, @Evaluate, and all the values and collections. I figured that meeting you next would be perfect since you work so closely with values."
                         ],
                         [
                             "Convert",
@@ -2105,18 +2105,18 @@
                         [
                             "Convert",
                             "serious",
-                            "Yeah, you know, like gymnastics on the streets, leaping over things, spanning buildings, like high wire stuff but without wires. Courageous leaps!"
+                            "Yeah, you know, like gymnastics on the streets, leaping over things, spanning buildings — like high wire stuff but without wires. Courageous leaps!"
                         ],
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Ohhh, I see what you mean. Yes, I guess what you do is kind of like parkour. I'm not sure our new director friend here follows though. Could you explain without the metaphors?"
+                            "Ohhh, I see what you mean. Yes, I guess what you do is kind of like parkour. I'm not sure our new director friend here follows, though. Could you explain without the metaphors?"
                         ],
                         null,
                         [
                             "Convert",
                             "kind",
-                            "Happy to bro. So like, imagine you had a number."
+                            "Happy to, bro. So like, imagine you had a number."
                         ],
                         ["edit", "1"],
                         null,
@@ -2158,7 +2158,7 @@
                         [
                             "Convert",
                             "neutral",
-                            "So like, my deal is that everything should be everything, no boundaries. Anything can be anything. (Like, not anything, but you know, as much as I can).",
+                            "So like, my deal is that everything should be everything, no boundaries. Anything can be anything (Like, not anything, but you know, as much as I can).",
                             "But like, why should anything ever be trapped in one identity, you know? Liberation, man."
                         ],
                         null,
@@ -2215,14 +2215,14 @@
                         [
                             "Convert",
                             "scared",
-                            "Sorry bro, I'm still a bit shaken. Uhhh, they can check out any of the value types in the reference @UI/docsExpand.",
+                            "Sorry, bro, I'm still a bit shaken. Uhhh, they can check out any of the value types in the reference @UI/docsExpand.",
                             "There should be a list of the other types I can change them into… Everything is conversion…"
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "happy",
-                            "It was so great to see you @Convert! We're going to head out and meet others. See you soon?"
+                            "It was so great to see you, @Convert! We're going to head out and meet the others. See you soon?"
                         ],
                         [
                             "Convert",
@@ -2241,7 +2241,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "We've met so many kinds of values on our journey so far, and talked about so many ways of working with them. There's just one more I wanted to introduce you to. They're particularly special because they're what make our performances so dynamic. They're called @Conditional and they are the central character in the Verse that makes *decisions*."
+                            "We've met so many kinds of values on our journey so far and talked about so many ways of working with them. There's just one more I wanted to introduce you to. They're particularly special because they're what make our performances so dynamic. They're called @Conditional, and they are the central character in the Verse that makes *decisions*."
                         ],
                         null,
                         [
@@ -2265,7 +2265,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Yes, the silence is breaking, and they are the one! They're a person, and they came to inspire us, and direct our shows. We've been talking about conversions, and meeting all the values and @Text and @Convert and I wanted them to meet you! In a way, you're the most special of conversions, because you enable us to convert situations to new values."
+                            "Yes, the silence is breaking, and they are the one! They're a person, and they came to inspire us and direct our shows. We've been talking about conversions and meeting all the values, and @Text and @Convert and I wanted them to meet you! In a way, you're the most special of conversions because you enable us to convert situations to new values."
                         ],
                         [
                             "Conditional",
@@ -2277,7 +2277,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "I think so, yes. It's more like the director encodes the decision, but then delegates them to you. You become the decider. Do you want to show an example?"
+                            "I think so, yes. It's more like the director encodes the decision but then delegates them to you. You become the decider. Do you want to show an example?"
                         ],
                         ["Conditional", "curious", "Like this?"],
                         ["conflict", "_•? ? _ _"],
@@ -2306,7 +2306,7 @@
                         [
                             "Conditional",
                             "curious",
-                            "Reliable? Maybe? If you accept that I just decide whatever the director tells me, then yes, but what if the director tells me this? Is it really a decision of the number can never be greater than \\3\\?"
+                            "Reliable? Maybe? If you accept that I just decide whatever the director tells me, then yes, but what if the director tells me this? Is it really a decision if the number can never be greater than \\3\\?"
                         ],
                         ["edit", "[1 2 3].random() > 3 ? 'big' 'small'"],
                         [
@@ -2383,13 +2383,13 @@
                             "serious",
                             "You didn't know the Verse existed, but we know that yours does. Because it's your world that makes our world interesting.",
                             "You probably noticed this as we've wandered and met all of the values, collections, and conversations.",
-                            "What do any of these values /mean/ if there's no person /giving/ them meaning, or providing the values in the first place?"
+                            "What do any of these values /mean/ if there's no person /giving/ them meaning or providing the values in the first place?"
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "I want to show you the connection between our worlds, and what they make possible. We call them **input streams**, and they are perhaps the most magical kind of input in the Verse. They're like functions that create a special kind of value that changes as your world changes. They also can't communicate in the ways you might be used to. They're more like heartbeats from another world. So I'll do my best to explain how they work, since they won't be able to explain themselves.",
+                            "I want to show you the connection between our worlds and what they make possible. We call them **input streams**, and they are perhaps the most magical kind of input in the Verse. They're like functions that create a special kind of value that changes as your world changes. They also can't communicate in the ways you might be used to. They're more like heartbeats from another world. So I'll do my best to explain how they work since they won't be able to explain themselves.",
                             "Are you ready to meet one?"
                         ]
                     ]
@@ -2403,7 +2403,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Let's start with the most elemental stream of all: @Time. To make a stream, we use @Evaluate, and give the name of the type of stream you want."
+                            "Let's start with the most elemental stream of all: @Time. To make a stream, we use @Evaluate and give the name of the type of stream you want."
                         ],
                         ["Time", "neutral", "tick tick tick tick tick…"],
                         ["edit", "Time()"],
@@ -2411,14 +2411,14 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Do you see how time is changing? Streams are a series of values. Every time a stream gets a new value, @Program reevaluates with the new stream value. That's why this program just keeps counting up: we made a time stream that starts at time 0 milliseconds, and then just keeps updating every time its clock ticks. This time is your time, from your world."
+                            "Do you see how time is changing? Streams are a series of values. Every time a stream gets a new value, @Program reevaluates with the new stream value. That's why this program just keeps counting up: we made a time stream that starts at time 0 milliseconds and then just keeps updating every time its clock ticks. This time is your time, from your world."
                         ],
                         ["Time", "neutral", "tick tick tick tick tick…"],
                         null,
                         [
                             "FunctionDefinition",
                             "curious",
-                            "See that \\1000ms\\? It's a @Time/frequency that tells @Time to tick every 1000 milliseconds instead of the default of every 33 milliseconds, it's default. Now it's like a counter that ticks every second. These inputs that @Time takes are like a configuration: they tell the stream how to behave."
+                            "See that \\1000ms\\? It's a @Time/frequency that tells @Time to tick every 1000 milliseconds instead of the default of every 33 milliseconds, its default. Now it's like a counter that ticks every second. These inputs that @Time takes are like a configuration: they tell the stream how to behave."
                         ],
                         ["Time", "neutral", "tick… tick… tick… tick… tick…"],
                         ["edit", "Time(1000ms)"],
@@ -2441,7 +2441,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Try dragging on the timeline @UI/timeline, using the timeline buttons, using the arrow keys with the timeline focused, or pressing the ⏸️ and ▶️ @UI/playToggle buttons. You can go backwards in time, to see previous evaluations. The dashed arrows step to previous and future stream inputs. The solid ones step between different steps of the program. Try navigating time, and seeing what the program shows. This is how you can see all of the beautiful expressions you've learned about being evaluated by @Evaluate, one step at a time, resulting in the final value that @Program displays on stage."
+                            "Try dragging on the timeline @UI/timeline by using the timeline buttons, using the arrow keys with the timeline focused, or pressing the ⏸️ and ▶️ @UI/playToggle buttons. You can go backwards in time to see previous evaluations. The dashed arrows step to previous and future stream inputs. The solid ones step between different steps of the program. Try navigating time and seeing what the program shows. This is how you can see all of the beautiful expressions you've learned about being evaluated by @Evaluate, one step at a time, resulting in the final value that @Program displays on stage."
                         ],
                         ["Time", "neutral", "tick… tick… tick… tick… tick…"],
                         ["edit", "Time(1000ms)"],
@@ -2449,7 +2449,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "@Time is an interesting stream because it can be used for many different things: keeping track of how long a performance has been happening, timing some event, animating a word. It's one of the most flexible streams, but also one of the most abstract."
+                            "@Time is an interesting stream because it can be used for many different things: keeping track of how long a performance has been happening, timing some event, animating a word. It's one of the most flexible streams but also one of the most abstract."
                         ]
                     ]
                 },
@@ -2472,7 +2472,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Here's a simple example. Click the stage or focus it with the keyboard and then press any keyboard key. You'll see the key you've typed appear by name. That's because each time the key stream changes, @Program evaluates the key stream as its latest value, and then shows it on stage."
+                            "Here's a simple example. Click the stage or focus it with the keyboard and then press any keyboard key. You'll see the key you've typed appear by name. That's because each time the key stream changes, @Program evaluates the key stream as its latest value and then shows it on stage."
                         ],
                         ["Key", "neutral", "clickety clickety clickety"],
                         ["edit", "Key()"],
@@ -2480,7 +2480,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "This stream will change any time any key is pressed. But you can tell a key stream to just change when a particular key is pressed. See how the stream changes to \\a\\ the first time, but then doesn't change after? That's because this stream only changes when \\a\\ is pressed, so it's always showing \\a\\. But you'll always see the new key value appear in the timeline."
+                            "This stream will change any time any key is pressed. But you can tell a key stream to just change when a particular key is pressed. See how the stream changes to \\a\\ the first time but then doesn't change after? That's because this stream only changes when \\a\\ is pressed, so it's always showing \\a\\. But you'll always see the new key value appear in the timeline."
                         ],
                         ["Key", "neutral", "clickety 'a'…"],
                         ["edit", "Key('a')"],
@@ -2496,7 +2496,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "@Key streams are really helpful when you want a performance to react to keys that the audience presses. For example, you could check if a key has the word 'Arrow' in it to decide if an arrow key was pressed. Press an arrow key and you'll see \\'move'\\, press something else and you'll see \\'stay'\\"
+                            "@Key streams are really helpful when you want a performance to react to keys that the audience presses. For example, you could check if a key has the word 'Arrow' in it to decide if an arrow key was pressed. Press an arrow key and you'll see \\'move'\\; press something else and you'll see \\'stay'\\"
                         ],
                         ["Key", "neutral", "clickety 'Arrow'…"],
                         ["edit", "Key().has('Arrow') ? 'move' 'stay'"]
@@ -2521,7 +2521,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Move your pointer around the stage and you'll see the stream of @Place change on stage."
+                            "Move your pointer around the stage, and you'll see the stream of @Place change on stage."
                         ],
                         ["fix", "Pointer()"],
                         ["Pointer", "neutral", "wzzzzzzzzz…"],
@@ -2552,7 +2552,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "@Button is like @Key, but corresponds to the primary pointer button, like a click or tap. It's just a stream of \\⊤\\, indicating when the pointer button is pressed down. Press that button and watch the events appear on the timeline."
+                            "@Button is like @Key but corresponds to the primary pointer button like a click or tap. It's just a stream of \\⊤\\, indicating when the pointer button is pressed down. Press that button and watch the events appear on the timeline."
                         ],
                         ["Button", "neutral", "click… click… click…"],
                         ["edit", "Button()"],
@@ -2568,7 +2568,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Using a @Button stream is one way to advance through stages of a performance, or to trigger some change in a performance. This little program lists to button presses, and starts off showing sad, but when the @Button stream changes to true, @Conditional evaluates to \\'happy'\\ instead."
+                            "Using a @Button stream is one way to advance through stages of a performance or to trigger some change in a performance. This little program lists to button presses and starts off showing sad, but when the @Button stream changes to true, @Conditional evaluates to \\'happy'\\ instead."
                         ],
                         ["edit", "Phrase(Button(ø) ? 'sad' 'happy')"]
                     ]
@@ -2582,7 +2582,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Your world and our world also has sound. Did you know we can hear you, with your consent? We listen with a stream called @Volume, which provides a low-level sequence of amplitudes. Your mic might ask for permission to be shared with us. Once you do, you'll see a number that corresponds to amplitude, between \\0\\ and \\100\\."
+                            "Your world and our world also have sound. Did you know we can hear you with your consent? We listen with a stream called @Volume, which provides a low-level sequence of amplitudes. Your mic might ask for permission to be shared with us. Once you do, you'll see a number that corresponds to amplitude, between \\0\\ and \\100\\."
                         ],
                         ["Volume", "neutral", "bzzzZZZZZzzzzzZZZZ…"],
                         ["edit", "Volume()"],
@@ -2590,7 +2590,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "@Volume can be used to make performances respond to sound from the audience. For example, here we could make a little amplitude visualization by converting the amplitude number from the stream to a certain number of \\'o'\\ characters. See how when you make noise, there are more \\'o'\\s? The @Volume amplitude is divided by \\10\\, putting it in the \\0\\ to \\10\\ range. Then that value is given to @Text/repeat function, which repeats the \\'o'\\ the given number of times."
+                            "@Volume can be used to make performances respond to sound from the audience. For example, here we could make a little amplitude visualization by converting the amplitude number from the stream to a certain number of \\'o'\\ characters. See how when you make noise, there are more \\'o'\\s? The @Volume amplitude is divided by \\10\\, putting it in the \\0\\ to \\10\\ range. Then, that value is given to @Text/repeat function, which repeats the \\'o'\\ the given number of times."
                         ],
                         ["Volume", "neutral", "bzzzZZZZZzzzzzZZZZ…"],
                         ["edit", "'o'.repeat(Volume() · 10)"]
@@ -2609,7 +2609,7 @@
                             "FunctionDefinition",
                             "curious",
                             "There's one other source of input I want to show you. Remember \\[].random()\\ from earlier, from @List?",
-                            "Inside it uses a @FunctionDefinition called @Random, which provides an infinite sequence of random numbers. It's kind of a stream, since it generates input from your world, not ours. But it's a bit different from the other streams in that it doesn't cause a @Program to reevaluate.",
+                            "Inside, it uses a @FunctionDefinition called @Random, which provides an infinite sequence of random numbers. It's kind of a stream since it generates input from your world, not ours. But it's a bit different from the other streams in that it doesn't cause a @Program to reevaluate.",
                             "Instead, each time it's evaluated, it gives a different random number.",
                             "See that little ↻ @UI/resetEvaluator button by the timeline? Press that to reevaluate the program manually, and you'll see a new number between \\0\\ and \\1\\ each time."
                         ],
@@ -2649,8 +2649,8 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Sometimes its nice to engage the audience in our place on @Stage.",
-                            "@Placement is a great way to do that! It's a stream of @Place, that responds to keyboard arrow keys, clicks, and taps.",
+                            "Sometimes, it's nice to engage the audience in our place on @Stage.",
+                            "@Placement is a great way to do that! It's a stream of @Place that responds to keyboard arrow keys, clicks, and taps.",
                             "Try using those to move the hot dog around."
                         ],
                         null,
@@ -2662,7 +2662,7 @@
                             "FunctionDefinition",
                             "kind",
                             "There are lots of ways you can customize it. For example, if you wanted to change how it moves, you can give it a distance.",
-                            "See how we gave it \\0.5\\ for the for the first input? Now it moves a little less. Try changing it to a different number!"
+                            "See how we gave it \\0.5\\ for the first input? Now, it moves a little less. Try changing it to a different number!"
                         ],
                         null,
                         [
@@ -2726,7 +2726,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Oh right! That's because we forgot to give the ball @Matter. Matter is a way of telling us how heavy the @Output is, how bouncy it is, and how much friction it should have.",
+                            "Oh, right! That's because we forgot to give the ball @Matter. Matter is a way of telling us how heavy the @Output is, how bouncy it is, and how much friction it should have.",
                             "Let's make the ball really bouncy and light. Yay, now it bounces!"
                         ],
                         null,
@@ -2744,7 +2744,7 @@
                             "excited",
                             "But @Motion has many other tricks.",
                             "For example, we can give it a start @Motion/velocity.",
-                            "This example makes the ball move right and up and spinning a bit initially."
+                            "This example makes the ball move right and up and spin a bit initially."
                         ],
                         ["Motion", "excited", "Woooosh…"],
                         null,
@@ -2785,9 +2785,9 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "It's even possible to know when some @Output bumps into another output with related stream called @Collision.",
+                            "It's even possible to know when some @Output bumps into another output with a related stream called @Collision.",
                             "We just need to give names to our two @Output. How about 'ball' and 'ground'?",
-                            "Then, we @Collision will give us a @Rebound when they touch and @None with they don't.",
+                            "Then, @Collision will give us a @Rebound when they touch and @None when they don't.",
                             "Let's make the ball scale up each time it hits the ground for emphasis!"
                         ],
                         null,
@@ -2813,15 +2813,15 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Sometimes a performance is an interaction. The audience says something and we say something back.",
-                            "That's what @Chat is for. When you use it, a little box will appear on stage for the audience to type in and when they submit their message, @Text will be added to the stream for the program to respond to."
+                            "Sometimes, a performance is an interaction. The audience says something, and we say something back.",
+                            "That's what @Chat is for. When you use it, a little box will appear on stage for the audience to type in, and when they submit their message, @Text will be added to the stream for the program to respond to."
                         ],
                         null,
                         ["edit", "Chat()"],
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Here's the simplest way to use it. You type something, and then the stage shows it, because the program's value is the @Chat's value."
+                            "Here's the simplest way to use it. You type something and then the stage shows it because the program's value is the @Chat's value."
                         ],
                         null,
                         ["edit", "Chat().has('oo') ? 'choo choo' 'hmm'"],
@@ -2846,15 +2846,15 @@
                             "FunctionDefinition",
                             "kind",
                             "So long ago, we heard you had this thing called the internet? I think that's how you're here, right?",
-                            "Well we thought it would be really cool to bring words from the internet /here/, so you can play with them."
+                            "Well, we thought it would be really cool to bring words from the internet /here/, so you can play with them."
                         ],
                         null,
                         ["edit", "Webpage('https://www.nytimes.com')"],
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Here's how it works: you just give what I think is called a 'URL' to us, and if its an HTML page, we'll pull all the phrases out of it and give it you you in a @List.",
-                            "Like here, these are some news phrases."
+                            "Here's how it works: you just give what I think is called a 'URL' to us, and if it's an HTML page, we'll pull all the phrases out of it and give it to you in a @List.",
+                            "Like here: these are some news phrases."
                         ],
                         null,
                         ["edit", "Webpage('https://www.nytimes.com' 'h2')"],
@@ -2885,12 +2885,12 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "All of these streams that I've shown you come from your world. But sometimes, it's helpful to create streams of your own, based on these other streams. That's where my friend @Reaction comes in! @Reaction, are you around?"
+                            "All of these streams that I've shown you come from your world. But sometimes, it's helpful to create streams of your own based on these other streams. That's where my friend @Reaction comes in! @Reaction, are you around?"
                         ],
                         [
                             "Reaction",
                             "excited",
-                            "Yeah yeah yeah! It's @FunctionDefinition! How are you doing? Everything has been so… constant, lately. Have you noticed that?"
+                            "Yeah yeah yeah! It's @FunctionDefinition! How are you doing? Everything has been so… constant lately. Have you noticed that?"
                         ],
                         null,
                         ["fit", "Phrase('…' resting:Pose(rotation: 240°))"],
@@ -2902,7 +2902,7 @@
                         [
                             "Reaction",
                             "sad",
-                            "Super strange, super strange. My whole life has been about change, always listening and watching for new inputs from people, helping transform them into values. But there hasn't been anything. Until just a moment ago… Wait … is that a person?"
+                            "Super strange, super strange. My whole life has been about change, always listening and watching for new inputs from people, helping transform them into values. But there hasn't been anything. Until just a moment ago… Wait… is that a person?"
                         ],
                         null,
                         ["fit", "Phrase('…' resting:Pose(rotation: 360°))"],
@@ -2922,7 +2922,7 @@
                             "Reaction",
                             "serious",
                             "Okay, so I need three things from you: a condition for change, an initial value, and a next value.",
-                            "The *initial* value is whatever value I should make before any change has happened. It's just a normal expression, of any kind!",
+                            "The *initial* value is whatever value I should make before any change has happened. It's just a normal expression of any kind!",
                             "Then you put \\…\\ after the initial value to tell me that the value can change.",
                             "After \\…\\, give me *condition* that evaluates to \\⊤\\ or \\⊥\\. It should generally check one or more streams — otherwise, there's nothing changing, since the only source of change in a performance is streams.",
                             "Then put another \\…\\ after the condition to tell me that the value can change.",
@@ -2933,7 +2933,7 @@
                         [
                             "Reaction",
                             "serious",
-                            "Here's an example. See the @Key stream? Putting \\∆\\ before it asks, 'Did this stream change'? Before it changes, I evaluate to the initial value, \\1m\\. But when the space key is pressed, @Program reevaluates, and I evaluate to the *next* expression, which is \\1m\\ plus whatever the previous stream value was, that's represented by \\.\\. This adds 1m to the size of the phrase, making the word get bigger and bigger."
+                            "Here's an example. See the @Key stream? Putting \\∆\\ before it asks, 'Did this stream change'? Before it changes, I evaluate to the initial value, \\1m\\. But when the space key is pressed, @Program reevaluates, and I evaluate to the *next* expression, which is \\1m\\ plus whatever the previous stream value was; that's represented by \\.\\. This adds 1m to the size of the phrase, making the word get bigger and bigger."
                         ],
                         ["fit", "Phrase('hi' size: 1m … ∆ Key(' ') … 1m + .)"],
                         null,
@@ -2951,12 +2951,12 @@
                         [
                             "Changed",
                             "eager",
-                            "Wow, stream whisper, that seems a bit extreme..."
+                            "Wow, stream whisperer, that seems a bit extreme..."
                         ],
                         [
                             "Reaction",
                             "serious",
-                            "Oh hi @Changed! Do you want to say more about what you do?"
+                            "Oh hi, @Changed! Do you want to say more about what you do?"
                         ],
                         [
                             "Changed",
@@ -2966,7 +2966,7 @@
                         [
                             "Reaction",
                             "confused",
-                            "Well, it's more than that right?"
+                            "Well, it's more than that. right?"
                         ],
                         [
                             "Changed",
@@ -2978,7 +2978,7 @@
                         [
                             "Reaction",
                             "eager",
-                            "Okay. Well, I think you're more important that than. Because I'm pretty useless without you! For example, if you give me a condition that doesn't check a stream, I'm never going to create a new value. Like here, the condition a @Boolean from @Button, but without you, I only ever change with the button ."
+                            "Okay. Well, I think you're more important than that. Because I'm pretty useless without you! For example, if you give me a condition that doesn't check a stream, I'm never going to create a new value. Like here, the condition a @Boolean from @Button, but without you, I only ever change with the button ."
                         ],
                         [
                             "fit",
@@ -2993,13 +2993,13 @@
                         [
                             "Reaction",
                             "eager",
-                            "Yes, any stream! And actually, even myself. So if you make a reaction, and want to make a reaction that reacts to it reacting, you can do that too. But we won't worry about that now, since that doesn't usually come up in simple performances."
+                            "Yes, any stream! And actually, even myself. So if you make a reaction and want to make a reaction that reacts to it reacting, you can do that too. But we won't worry about that now since that doesn't usually come up in simple performances."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Thank you @Reaction. Will you be around to help as I show our director the rest of our beautiful Verse?"
+                            "Thank you, @Reaction. Will you be around to help as I show our director the rest of our beautiful Verse?"
                         ],
                         [
                             "Reaction",
@@ -3044,7 +3044,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "You've seen a lot of output already. Every time @Program evaluates, it results in a value, and @Program shows that value on stage. But so far you've only seen things like numbers, text, lists. I get it, you just want to see full performances, just like we do!"
+                            "You've seen a lot of output already. Every time @Program evaluates, it results in a value and @Program shows that value on stage. But so far you've only seen things like numbers, text, lists. I get it, you just want to see full performances, just like we do!"
                         ],
                         null,
                         ["use", "fit", "Symbol", "💬"],
@@ -3069,30 +3069,30 @@
                         [
                             "Phrase",
                             "excited",
-                            "Out and proud my darling, how are you? You look so glamorous today! I would love to get you on stage one of these days."
+                            "Out and proud my darling; how are you? You look so glamorous today! I would love to get you on stage one of these days."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "shy",
-                            "Oh, the stage isn't for me, I'm more than happy to be backstage, tinkering with the set."
+                            "Oh, the stage isn't for me; I'm more than happy to be backstage, tinkering with the set."
                         ],
                         [
                             "Phrase",
                             "curious",
-                            "Don't be modest, you are every bit as fabulous as me. All you need is a bit of color, a flattering font, and you would be wonderful. You have so much to share! Speaking of, we haven't put on a show in forever, have we? Has it been quiet? You know how much I talk to myself, I can never tell."
+                            "Don't be modest; you are every bit as fabulous as me. All you need is a bit of color, a flattering font, and you would be wonderful. You have so much to share! Speaking of, we haven't put on a show in forever, have we? Has it been quiet? You know how much I talk to myself; I can never tell."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "kind",
-                            "It has been quiet. Ever since our last director left, it's been a void. But that is changing! We have a new person! We've been meeting the whole family, @Program, @ExpressionPlaceholder, @Evaluate, all the values, all the collections. We just spent time with all of the streams too, and @Reaction and @Conditional. I'm starting to feel things hum. But I haven't introduced our new director here too much about what you do on stage? This is so your world, and not mine, I figured we'd come to you first."
+                            "It has been quiet. Ever since our last director left, it's been a void. But that is changing! We have a new person! We've been meeting the whole family: @Program, @ExpressionPlaceholder, @Evaluate, all the values, all the collections. We just spent time with all of the streams too, and @Reaction and @Conditional. I'm starting to feel things, hum. But I haven't introduced our new director here to much about what you do on stage? This is so your world and not mine; I figured we'd come to you first."
                         ],
                         null,
                         [
                             "Phrase",
                             "happy",
-                            "Well you came to the right place. I love talking about all things stage life. I can't wait to show you all the wonderful little things we do here on stage!"
+                            "Well, you came to the right place. I love talking about all things stage life. I can't wait to show you all the wonderful little things we do here on stage!"
                         ],
                         [
                             "FunctionDefinition",
@@ -3110,14 +3110,14 @@
                         [
                             "Phrase",
                             "kind",
-                            "That, my darling, is the simplest way to get a word on stage. But there's so much more! For example, did you know that you can style the text you give me by working with @FormattedTranslation? You haven't met them yet, but all you have to do is put special symbols around your text? Behold: bold!"
+                            "That, my darling, is the simplest way to get a word on stage. But there's so much more! For example, did you know that you can style the text you give me by working with @FormattedTranslation? You haven't met them yet, but all you have to do is put special symbols around your text. Behold: bold!"
                         ],
                         ["edit", "Phrase(`*hi*`)"],
                         null,
                         [
                             "Phrase",
                             "kind",
-                            "Not enough sass for you? How about underline, italics, light text, and extra bold text, *all at once*?"
+                            "Not enough sass for you? How about underline, italics, light text, and extra bold text *all at once*?"
                         ],
                         ["edit", "Phrase(`/I/ _am_ ^the^ /fabulous/ 💬!`)"],
                         null,
@@ -3142,7 +3142,7 @@
                         [
                             "Phrase",
                             "excited",
-                            "But I can do more than just style text. For example, I can take a @Phrase/size, measured in meters \\m\\. Try changing the size to any size you like!"
+                            "But I can do more than just style text. For example, I can take a @Phrase/size measured in meters \\m\\. Try changing the size to any size you like!"
                         ],
                         ["edit", "Phrase('hi' 2m)"],
                         null,
@@ -3168,7 +3168,7 @@
                         [
                             "Phrase",
                             "neutral",
-                            "Need me to be somewhere else on stage? Places please! A @Place is just an \\x\\, \\y\\, and optional \\z\\ position, in meters \\m\\. Try changing the place to a different location, by editing the numbers, or dragging the @Phrase on stage."
+                            "Need me to be somewhere else on stage? Places, please! A @Place is just an \\x\\, \\y\\, and optional \\z\\ position in meters \\m\\. Try changing the place to a different location by editing the numbers or dragging the @Phrase on stage."
                         ],
                         [
                             "fit",
@@ -3178,7 +3178,7 @@
                         [
                             "Phrase",
                             "curious",
-                            "Do you ever feel a little off axis? Maybe you give the world a little @Pose/rotation with rotation. Try changing the rotation value to twist me around!"
+                            "Do you ever feel a little off-axis? Maybe you give the world a little @Pose/rotation with rotation. Try changing the rotation value to twist me around!"
                         ],
                         [
                             "fit",
@@ -3188,7 +3188,7 @@
                         [
                             "Phrase",
                             "happy",
-                            "Or maybe we have a little fun, and link rotation to @Time! Wheeeee. Any guesses on how to make me spin faster? See if you can figure it out…"
+                            "Or maybe we have a little fun and link rotation to @Time! Wheeeee. Any guesses on how to make me spin faster? See if you can figure it out…"
                         ],
                         [
                             "fit",
@@ -3213,7 +3213,7 @@
                         [
                             "Phrase",
                             "kind",
-                            "Only want to give a particular property? Just name the one you want. Here we name @Phrase/size and @Phrase/rotation."
+                            "Only want to give a particular property? Just name the one you want. Here, we name @Phrase/size and @Phrase/rotation."
                         ],
                         [
                             "edit",
@@ -3223,7 +3223,7 @@
                         [
                             "Phrase",
                             "neutral",
-                            "Now that we have all those out of the way, we can talk about dancing, darling! Dancing is one of my favorite things to do. There are *four* ways I move. First, I can @Phrase/entering. Enter is my way of entering the stage. If you don't tell me how to enter, I'll just BLIP appear on stage like I teleported there. But if you give me @Pose. I'll start with the pose you give me, then move to my resting pose. For example, let's make me fade in from invisible to oh-so-in-your face visible."
+                            "Now that we have all those out of the way, we can talk about dancing, darling! Dancing is one of my favorite things to do. There are *four* ways I move. First, I can @Phrase/entering. Enter is my way of entering the stage. If you don't tell me how to enter, I'll just BLIP appear on stage like I teleported there. But if you give me @Pose, I'll start with the pose you give me, then move to my resting pose. For example, let's make me fade in from invisible to oh-so-in-your face visible."
                         ],
                         ["edit", "Phrase('hi' entering: Pose(opacity: 0))"],
                         null,
@@ -3240,7 +3240,7 @@
                         [
                             "Phrase",
                             "neutral",
-                            "Now, say I was moving. We'll set my place to time, so I move to the right a bit every second. But if we set a @Phrase/moving @Pose, and have the @Pose/rotation \\5°\\ and maybe a little color, every time my place changes, I'll glide across the stage with the cutest little tilt."
+                            "Now, say I was moving. We'll set my place to time, so I move to the right a bit every second. But if we set a @Phrase/moving @Pose and have the @Pose/rotation \\5°\\ and maybe a little color, every time my place changes, I'll glide across the stage with the cutest little tilt."
                         ],
                         [
                             "fit",
@@ -3250,7 +3250,7 @@
                         [
                             "Phrase",
                             "curious",
-                            "Not in the mood for cute? How about you make me a little serious by having me slide across straight by changing my @Phrase/style. It's really subtle, but styles can really change the /emotion/ of a movement."
+                            "Not in the mood for cute? How about you make me a little serious by having me slide across straight by changing my @Phrase/style? It's really subtle, but styles can really change the /emotion/ of a movement."
                         ],
                         [
                             "fit",
@@ -3272,7 +3272,7 @@
                         [
                             "Phrase",
                             "surprised",
-                            "Not the exit you were hoping for? The disappearing act is a bit harsh, ain't it? Give me an @Phrase/exiting @Pose, and I'll glide off on stage toward whatever pose you want. Here we'll have me get large than life, fall upside down, and fade out to @Pose/opacity \\0\\."
+                            "Not the exit you were hoping for? The disappearing act is a bit harsh, ain't it? Give me an @Phrase/exiting @Pose, and I'll glide off on stage toward whatever pose you want. Here, we'll have me get large than life, fall upside-down, and fade out to @Pose/opacity \\0\\."
                         ],
                         [
                             "fit",
@@ -3306,7 +3306,7 @@
                         [
                             "Phrase",
                             "happy",
-                            "Of course! Any time you get tired of fiddling with @Evaluate's inputs, you can always select a phrase on stage, and a palette will appear, allowing you to change any little thing you might want, my size, font, place, poses. There's just one rule: if you set any of those to an expression, instead of just a value, you'll have to change them down in @Program, not in the palette. Dress me up all you like!"
+                            "Of course! Any time you get tired of fiddling with @Evaluate's inputs, you can always select a phrase on stage, and a palette will appear, allowing you to change any little thing you might want: my size, font, place, poses. There's just one rule: if you set any of those to an expression instead of just a value, you'll have to change them down in @Program, not in the palette. Dress me up all you like!"
                         ],
                         ["edit", "Phrase('dress me up!')"],
                         null,
@@ -3318,16 +3318,16 @@
                         [
                             "Phrase",
                             "sad",
-                            "Omigod omigod omigod, I CANNOT believe I forgot about color. Okay, so any @Pose can have a color, right? But @Color comes in three parts. First, a @Color/lightness between 0 and 100%, which you can think of as how bright a room is, from black to white, with color in the middle at 50%.",
+                            "Omigod omigod omigod, I CANNOT believe I forgot about color. Okay, so any @Pose can have a color, right? But @Color comes in three parts. First, a @Color/lightness between 0 and 100%, which you can think of as how bright a room is, from black to white with color in the middle at 50%.",
                             "Then, a @Color/chroma between 0 and 100, which you can think of has how much color there is, from no color gray to full color.",
-                            "And finally, a @Color/chroma, which you can think of like a color wheel, from red to green to blue, in degrees. So you want me to be bright red? Set my rest pose color to \\Color(50% 300 30°)\\."
+                            "And finally, a @Color/chroma, which you can think of like a color wheel, from red to green to blue in degrees. So you want me to be bright red? Set my rest pose color to \\Color(50% 300 30°)\\."
                         ],
                         ["edit", "Phrase('red' color: 🌈(50% 300 30°))"],
                         null,
                         [
                             "FunctionDefinition",
                             "excited",
-                            "And want me to shimmer with the rainbow? Take time, get the remainder of dividing by 360, then multiply by degrees and I'll spin around that color wheel all day long!"
+                            "And want me to shimmer with the rainbow? Take time, get the remainder of dividing by 360, then multiply by degrees, and I'll spin around that color wheel all day long!"
                         ],
                         [
                             "edit",
@@ -3336,7 +3336,7 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "@Phrase, that is something to be proud of :P I think we're going to go visit @Sequence next, and then maybe @Group and @Stage. You'll be around to help?"
+                            "@Phrase, that is something to be proud of :P I think we're going to go visit @Sequence next and then maybe @Group and @Stage. You'll be around to help?"
                         ],
                         [
                             "Phrase",
@@ -3377,7 +3377,7 @@
                         [
                             "Sequence",
                             "kind",
-                            "And you an @Evaluate? Are you still…"
+                            "And you and @Evaluate? Are you still…"
                         ],
                         null,
                         [
@@ -3399,7 +3399,7 @@
                         [
                             "Sequence",
                             "serious",
-                            "Absolutely. You know time? 1, 2, 3, 4, 1, 2, 3, 4? Well I make time beautiful, arranging a sequence of poses over time for @Phrase to follow. You tell me what the poses are and I'll help @Phrase follow the steps. Like this example: our smiley friend here has four poses, and smoothly moves between them."
+                            "Absolutely. You know time? 1, 2, 3, 4, 1, 2, 3, 4? Well I make time beautiful, arranging a sequence of poses over time for @Phrase to follow. You tell me what the poses are, and I'll help @Phrase follow the steps. Like this example: our smiley friend here has four poses and smoothly moves between them."
                         ],
                         [
                             "fit",
@@ -3409,7 +3409,7 @@
                         [
                             "Sequence",
                             "neutral",
-                            "Here's a simple example of how I work. Here's @Phrase (hi @Phrase!) with the word “dance”, and they have an enter pose that's a @Sequence rather than a single @Pose. Follow me? The sequence has four steps. Straight, tilt left, tilt right, straight. When @Phrase enters, they do this cute little wobble, and then stop. I work with @MapLiteral to map percentages to a @Pose. Each of those percentages are how far through the sequence each @Pose should happen. Try changing the percentages, especially those two middle ones. It changes the flow and style of the wobble."
+                            "Here's a simple example of how I work. Here's @Phrase (hi, @Phrase!) with the word “dance”, and they have an enter pose that's a @Sequence rather than a single @Pose. Follow me? The sequence has four steps. Straight, tilt left, tilt right, straight. When @Phrase enters, they do this cute little wobble and then stop. I work with @MapLiteral to map percentages to a @Pose. Each of those percentages are how far through the sequence each @Pose should happen. Try changing the percentages, especially those two middle ones. It changes the flow and style of the wobble."
                         ],
                         [
                             "edit",
@@ -3429,7 +3429,7 @@
                         [
                             "Sequence",
                             "serious",
-                            "Okay, so now imagine you wanted this to be really fast. By default, I'm pretty quick, so any sequence will be a quarter second and it's done. But what if you wanted it to be even faster? Give me a shorter duration and I'll speed every @Pose up to get it done faster. 1, 2, 3, 4! It doesn't look like a wobble anymore, does it? More like a frantic little shake! See what it looks like if you slow me down to 2 or 3 seconds…"
+                            "Okay, so now imagine you wanted this to be really fast. By default, I'm pretty quick, so any sequence will be a quarter second and it's done. But what if you wanted it to be even faster? Give me a shorter duration, and I'll speed every @Pose up to get it done faster. 1, 2, 3, 4! It doesn't look like a wobble anymore, does it? More like a frantic little shake! See what it looks like if you slow me down to 2 or 3 seconds…"
                         ],
                         [
                             "edit",
@@ -3450,7 +3450,7 @@
                         [
                             "Sequence",
                             "excited",
-                            "But sometimes, we come up with a lovely move and we just can't help but want to do it over and over, for emphasis! That looks a little violent… try changing my duration and count until we get it just right…"
+                            "But sometimes, we come up with a lovely move, and we just can't help but want to do it over and over for emphasis! That looks a little violent… try changing my duration and count until we get it just right…"
                         ],
                         [
                             "edit",
@@ -3498,7 +3498,7 @@
                         [
                             "Sequence",
                             "excited",
-                            "Oh my yes! @Phrase and I have been working on this new donut dance. It comes my favorite treat with nearly everything I've learned in dance. Do you want to see it?"
+                            "Oh my, yes! @Phrase and I have been working on this new donut dance. It combines my favorite treat with nearly everything I've learned in dance. Do you want to see it?"
                         ],
                         ["FunctionDefinition", "excited", "Yes!!!"],
                         null,
@@ -3535,7 +3535,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Sigh… everyone keeps bringing up @Evaluate, but I don't know what to say. Are you ever so close to someone, and yet so far away?",
+                            "Sigh… everyone keeps bringing up @Evaluate, but I don't know what to say. Are you ever so close to someone and yet so far away?",
                             "…"
                         ],
                         null,
@@ -3545,7 +3545,7 @@
                             "serious",
                             "Sorry. I'm excited to be here with you.",
                             "I think…",
-                            "I think what will help is introducing you to the rest of us, and then putting on a show, and then I think @Evaluate and I can sort things out."
+                            "I think what will help is introducing you to the rest of us and then putting on a show, and then I think @Evaluate and I can sort things out."
                         ],
                         null,
                         ["use", "fit", "Symbol", "🙂"],
@@ -3567,19 +3567,19 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "I'm okay. We're all okay! The silence is breaking, because we found a person! They're going to be our inspiration."
+                            "I'm okay. We're all okay! The silence is breaking because we found a person! They're going to be our inspiration."
                         ],
                         null,
                         ["fit", "Group(Grid(2 2) [Phrase('🔳') Phrase('🔳')])"],
                         [
                             "Group",
                             "happy",
-                            "That's lovely! You're not hurt? Everyone else is here? I felt like I was wandering in the dark, and couldn't see anyone."
+                            "That's lovely! You're not hurt? Everyone else is here? I felt like I was wandering in the dark and couldn't see anyone."
                         ],
                         [
                             "FunctionDefinition",
                             "kind",
-                            "I'm not hurt. Just a bit rusty. And I haven't seen everyone yet, but almost everyone, and I think everyone is waking up okay. (Though apparently some have been at the beach). We've met nearly everyone. We're getting ready to put on a show! And the best shows always involve you…"
+                            "I'm not hurt. Just a bit rusty. And I haven't seen everyone yet, but almost everyone, and I think everyone is waking up okay (though apparently some have been at the beach). We've met nearly everyone. We're getting ready to put on a show! And the best shows always involve you…"
                         ],
                         null,
                         [
@@ -3589,7 +3589,7 @@
                         [
                             "Group",
                             "kind",
-                            "A show! I can't wait to help. You kids are always so inspiring, I'm always happy to do my part. What shall I do, where do I start?"
+                            "A show! I can't wait to help. You kids are always so inspiring; I'm always happy to do my part. What shall I do, where do I start?"
                         ],
                         [
                             "FunctionDefinition",
@@ -3604,13 +3604,13 @@
                         [
                             "Group",
                             "neutral",
-                            "My purpose, yes. Let's see — I think my purpose is to bring everyone together. But I particularly bring @Phrase together, in beautiful shapes and arrangements on stage. Did you know that @Phrase can be in more than one place at once? That's because they aren't so much one text phrase on stage, but a phrase maker, just like I'm a @Group maker. They'll make as many as you need, and then I lay them out on stage, as you direct me. All I need is an @Arrangement, and a list of @Phrase, and I'll do the rest."
+                            "My purpose, yes. Let's see — I think my purpose is to bring everyone together. But I particularly bring @Phrase together in beautiful shapes and arrangements on stage. Did you know that @Phrase can be in more than one place at once? That's because they aren't so much one text phrase on stage but a phrase maker, just like I'm a @Group maker. They'll make as many as you need, and then I lay them out on stage as you direct me. All I need is an @Arrangement and a list of @Phrase, and I'll do the rest."
                         ],
                         null,
                         [
                             "Group",
                             "excited",
-                            "Here's a simple example. Here I'm using a @Stack arrangement, which creates a vertical arrangement of @Phrase, or other @Group. See how I make a tidy little stack of words? They're arranged just so, with a little breathing room for everyone and everyone centered. Everyone is so cute!"
+                            "Here's a simple example. Here, I'm using a @Stack arrangement which creates a vertical arrangement of @Phrase or other @Group. See how I make a tidy little stack of words? They're arranged just so, with a little breathing room for everyone and everyone centered. Everyone is so cute!"
                         ],
                         [
                             "edit",
@@ -3627,7 +3627,7 @@
                         [
                             "Group",
                             "serious",
-                            "But sometimes we all need a little space. So you can give @Stack some padding. Try changing the padding to a different @NumberLiteral!"
+                            "But sometimes, we all need a little space. So you can give @Stack some padding. Try changing the padding to a different @NumberLiteral!"
                         ],
                         [
                             "edit",
@@ -3644,7 +3644,7 @@
                         [
                             "Group",
                             "happy",
-                            "Just as with anything in the Verse, that padding value can come from anything, like input. Sometimes we grow apart don't we? Let's dance that idea by making the padding grow over time…"
+                            "Just as with anything in the Verse, that padding value can come from anything, like input. Sometimes we grow apart, don't we? Let's dance that idea by making the padding grow over time…"
                         ],
                         [
                             "edit",
@@ -3677,7 +3677,7 @@
                         [
                             "Group",
                             "curious",
-                            "Sometimes it's nice to use two dimensions instead of one. If you tell me how many rows and columns you want, I'll make a @Grid of phrases. Just make sure to give me enough phrases to fill the grid! You can also give @Grid padding and a cell size if you want to be extra precise. Grids are layed out a row at a time, so put your @Phrase list in order of rows."
+                            "Sometimes, it's nice to use two dimensions instead of one. If you tell me how many rows and columns you want, I'll make a @Grid of phrases. Just make sure to give me enough phrases to fill the grid! You can also give @Grid padding and a cell size if you want to be extra precise. Grids are laid out a row at a time, so put your @Phrase list in order of rows."
                         ],
                         [
                             "edit",
@@ -3694,7 +3694,7 @@
                         [
                             "Group",
                             "excited",
-                            "And if you wanted a very specific arrangement? You could use @Free, and tell me exactly where you want all the phrases. Just be sure to give a place to each @Phrase, otherwise I'll just place it at \\Place(0m 0m\\)."
+                            "And if you wanted a very specific arrangement? You could use @Free and tell me exactly where you want all the phrases. Just be sure to give a place to each @Phrase, otherwise I'll just place it at \\Place(0m 0m\\)."
                         ],
                         [
                             "edit",
@@ -3712,7 +3712,7 @@
                         [
                             "Group",
                             "curious",
-                            "And did you know you can also place me inside myself? A @Group in a @Group in a @Group, it's very silly. This can make it possible to make a @Grid of @Stack for example."
+                            "And did you know you can also place me inside myself? A @Group in a @Group in a @Group; it's very silly. This can make it possible to make a @Grid of @Stack, for example."
                         ],
                         [
                             "edit",
@@ -3793,7 +3793,7 @@
                         [
                             "Stage",
                             "neutral",
-                            "HELLO, @FunctionDefinition HELLO PERSON."
+                            "HELLO, @FunctionDefinition. HELLO, PERSON."
                         ],
                         null,
                         [
@@ -3808,7 +3808,7 @@
                         [
                             "Stage",
                             "neutral",
-                            "HELLO DIRECTOR. ARE YOU HERE TO INSPIRE?"
+                            "HELLO, DIRECTOR. ARE YOU HERE TO INSPIRE?"
                         ],
                         null,
                         [
@@ -3833,7 +3833,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "@Stage is one of a kind, and always there. In fact, if you give @Program a @Phrase or @Group, @Program will show a @Stage, even if you don't mention them. But if you do mention them, you can be more specific about how you want the stage to appear."
+                            "@Stage is one of a kind and always there. In fact, if you give @Program a @Phrase or @Group, @Program will show a @Stage, even if you don't mention them. But if you do mention them, you can be more specific about how you want the stage to appear."
                         ],
                         null,
                         [
@@ -3857,7 +3857,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "You can also frame the stage, for example, with a @Rectangle, which takes a top left place and bottom right place. See how the kitty is a little bit out of frame?"
+                            "You can also frame the stage, for example with a @Rectangle, which takes a top left place and bottom right place. See how the kitty is a little bit out of frame?"
                         ],
                         ["Stage", "surprised", "THE WORLD IS CLOSING IN…"],
                         [
@@ -3884,7 +3884,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "There's much more you can do with @Stage, but you can explore with them anytime. Right @Stage?"
+                            "There's much more you can do with @Stage, but you can explore with them anytime. Right, @Stage?"
                         ],
                         ["Stage", "excited", "ALWAYS!"]
                     ]
@@ -3898,7 +3898,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Okay, okay, so now you know @Stage, @Group, @Phrase, and the many things you can do with them. Now you might be thinking, what if I want to tell a story with them?"
+                            "Okay, okay, so now you know @Stage, @Group, @Phrase, and the many things you can do with them. Now, you might be thinking, what if I want to tell a story with them?"
                         ],
                         [
                             "FunctionDefinition",
@@ -3939,7 +3939,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "And now you might be thinking, what about transitions between them? We can control that with @Phrase/entering and @Phrase/exiting, setting @Pose to start and end on. Here, for example, we start and end each @Phrase as invisible, so it fades in and out."
+                            "And now, you might be thinking, what about transitions between them? We can control that with @Phrase/entering and @Phrase/exiting, setting @Pose to start and end on. Here, for example, we start and end each @Phrase as invisible, so it fades in and out."
                         ],
                         [
                             "edit",
@@ -4005,7 +4005,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "@Scene is great for telling animated stories, either is a whole project or as part of a project! What kind of stories do you want to tell?"
+                            "@Scene is great for telling animated stories, either as a whole project or as part of a project! What kind of stories do you want to tell?"
                         ]
                     ]
                 },
@@ -4028,13 +4028,13 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Everyone should be able to participate! So now that we've talked about @Phrase in more detail, I wanted to show y ou one final stream, @Choice, which is a stream of @Phrase names that have been selected, independent of how it was selected. For example, an audience might use a mouse to click on a @Phrase, or they might use a keyboard to select it, or there might be other devices they use. Whatever they use, @Choice will contain their latest selection."
+                            "Everyone should be able to participate! So now that we've talked about @Phrase in more detail, I wanted to show you one final stream, @Choice, which is a stream of @Phrase names that have been selected, independent of how it was selected. For example, an audience might use a mouse to click on a @Phrase, or they might use a keyboard to select it, or there might be other devices they use. Whatever they use, @Choice will contain their latest selection."
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Here's a simple example. See how it has three phrases? The first two have two important details. First, they're set to be selectable. This tells @Stage that if they are clicked, or if the keyboard is used to select them, that they are chosen. The second detail is that they have a @Phrase/name. That gives @Stage a unique name for the phrase that was chosen. It's important that it's unique so that @Stage knows what was chosen. The third phrase is set to a @Choice stream, which is a series of @Phrase or @Group names are selected. Here, we're just giving the name to another phrase, so that it shows what name is selected. Try clicking the cat or dog, or using the keyboard to select one. See how the third @Phrase shows the name selected?"
+                            "Here's a simple example. See how it has three phrases? The first two have two important details. First, they're set to be selectable. This tells @Stage that if they are clicked or if the keyboard is used to select them, they are chosen. The second detail is that they have a @Phrase/name. That gives @Stage a unique name for the phrase that was chosen. It's important that it's unique so that @Stage knows what was chosen. The third phrase is set to a @Choice stream, which is a series of @Phrase or @Group names that are selected. Here, we're just giving the name to another phrase so that it shows what name is selected. Try clicking the cat or dog or using the keyboard to select one. See how the third @Phrase shows the name selected?"
                         ],
                         [
                             "Choice",
@@ -4055,7 +4055,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "@Choice really is the best way to listen to the audience. Only use @Key, @Pointer, or @Button if you have no other option, and use it knowing that some in your audience won't be able to enjoy your performance."
+                            "@Choice really is the best way to listen to the audience. Only use @Key, @Pointer, or @Button if you have no other option and use it knowing that some in your audience won't be able to enjoy your performance."
                         ]
                     ]
                 }
@@ -4076,14 +4076,14 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "Sometimes I just need to pause and reflect on how incredible my little community is. We are all so different, and none of us could perform alone. But together, we can do such amazing things!"
+                            "Sometimes, I just need to pause and reflect on how incredible my little community is. We are all so different, and none of us could perform alone. But together, we can do such amazing things!"
                         ],
                         null,
                         ["use", "fit", "Symbol", "🧠"],
                         [
                             "FunctionDefinition",
                             "kind",
-                            "But it seems no matter how amazing we are, we always forget, and end up repeating ourselves. And so there's one more there's one more group I want to introduce you to. They are how we *remember*, and how we organize our memories. Without them, everything so much of our work would have to be done over, and over, and over, and we'd never be able to put on the most exciting shows."
+                            "But it seems no matter how amazing we are, we always forget and end up repeating ourselves. And so there's one more group I want to introduce you to. They are how we *remember* and how we organize our memories. Without them, so much of our work would have to be done over and over and over, and we'd never be able to put on the most exciting shows."
                         ]
                     ]
                 },
@@ -4127,7 +4127,7 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "Well now that you know, what do you want to do most right now?"
+                            "Well, now that you know, what do you want to do most right now?"
                         ],
                         [
                             "Bind",
@@ -4154,13 +4154,13 @@
                         [
                             "Bind",
                             "excited",
-                            "Right! So like, values, when we make them, they just kind of get passed around by us, like a ball, from expression to expression, until @Program makes the final value it gives to @Stage to show. But sometimes, rather than passing a value around, it's helpful to set it aside, and save it for later, for some other expression. That's what a @Phrase/name is for. I name things so we can use them later."
+                            "Right! So like, values, when we make them, they just kind of get passed around by us like a ball, from expression to expression, until @Program makes the final value it gives to @Stage to show. But sometimes, rather than passing a value around, it's helpful to set it aside and save it for later for some other expression. That's what a @Phrase/name is for. I name things so we can use them later."
                         ],
                         null,
                         [
                             "Bind",
                             "serious",
-                            "So like here's a really simple example. Let's say we want to name a number. We just say the name, then :, then the number we want. Simple, right? Now any time we use the name number in an expression, it will evaluate to \\1\\. Like here, where we name it, then use its name to give @Program whatever value it has."
+                            "So like, here's a really simple example. Let's say we want to name a number. We just say the name, then :, then the number we want. Simple, right? Now, any time we use the name number in an expression, it will evaluate to \\1\\. Like here, where we name it, then use its name to give @Program whatever value it has."
                         ],
                         ["edit", "number: 1", "number"],
                         null,
@@ -4181,15 +4181,15 @@
                         [
                             "Bind",
                             "serious",
-                            "But okay, by now you must be thinking, *Why would anyone name a number or text like this???*. Well, imagine, like, you were listening to @Key, and you want know if it's one of a set of secret letters, and show a @Phrase with a big \\⊤\\ if it's a magic letter, and small \\⊥\\ if it's not. We might start with something like this. That gets us the \\⊤\\ or \\⊥\\.",
-                            "This is great, when you press one of those letters, \\⊤\\ and when you press something else, you get \\⊥\\. Good."
+                            "But okay, by now you must be thinking, *Why would anyone name a number or text like this???*. Well, imagine, like, you were listening to @Key, and you want know if it's one of a set of secret letters and show a @Phrase with a big \\⊤\\ if it's a magic letter and small \\⊥\\ if it's not. We might start with something like this. That gets us the \\⊤\\ or \\⊥\\.",
+                            "This is great; when you press one of those letters, \\⊤\\, and when you press something else, you get \\⊥\\. Good."
                         ],
                         ["edit", "[ 'a' 'e' 'i' 'o' 'u'].has(Key())"],
                         null,
                         [
                             "Bind",
                             "serious",
-                            "Now, let's make the phrase. We put that @List/has expression in for the text and convert it to text. Now we get @Phrase on stage as \\⊤\\ or \\⊥\\. Good!"
+                            "Now, let's make the phrase. We put that @List/has expression in for the text and convert it to text. Now, we get @Phrase on stage as \\⊤\\ or \\⊥\\. Good!"
                         ],
                         [
                             "edit",
@@ -4199,7 +4199,7 @@
                         [
                             "Bind",
                             "curious",
-                            "Now comes the problem part. How do we change the size of the @Phrase? Well we already figured out how to check if it's a magic letter, so we could just copy it, and if it's \\⊤\\, then make it size \\2m\\ and otherwise if it's \\⊥\\, make it \\1m\\. That works, but you see how we have to evaluate the same expression twice?"
+                            "Now comes the problem part. How do we change the size of the @Phrase? Well, we already figured out how to check if it's a magic letter, so we could just copy it, and if it's \\⊤\\, then make it size \\2m\\, and otherwise, if it's \\⊥\\, make it \\1m\\. That works, but you see how we have to evaluate the same expression twice?"
                         ],
                         [
                             "edit",
@@ -4212,7 +4212,7 @@
                         [
                             "Bind",
                             "excited",
-                            "That's where I come in! See, what you can do is just evaluate the expression and name the resulting value. Magic, right? All you have to do is put a name and \\:\\ in front of an expression and the value of that expression gets a name. Then you can use that name anywhere after that expression to refer to its value. Weird, huh? You want to see how it works? Try pressing the ← in the timeline and go backwards a few steps to where magic is first named. See how \\magic\\ gets the value of the \\has\\? And then how each place \\magic\\ is referred to by name, the same value gets placed?"
+                            "That's where I come in! See, what you can do is just evaluate the expression and name the resulting value. Magic, right? All you have to do is put a name and \\:\\ in front of an expression, and the value of that expression gets a name. Then, you can use that name anywhere after that expression to refer to its value. Weird, huh? You want to see how it works? Try pressing the ← in the timeline and go backwards a few steps to where \\magic\\ is first named. See how \\magic\\ gets the value of the \\has\\? And then how when each place \\magic\\ is referred to by name, the same value gets placed?"
                         ],
                         [
                             "edit",
@@ -4226,7 +4226,7 @@
                         [
                             "Bind",
                             "serious",
-                            "You know, you could always just duplicate the expressions you write. It would be the same show. It's just kind of wasteful. I mean, we have to create the exact same values over and over, and then if you change your mind about an expression, you have to change it everywhere. That, and what if you change it in one place, but forget to change it in other places? Like, imagine if you also made the color change, so you had the same expression three times. And then imagine you wanted to add a letter to our magic letter list with this. You have to do it three times! You might forget one, or make a typo. How are you supposed to express your artistic vision if some of us aren't doing what you intended?"
+                            "You know, you could always just duplicate the expressions you write. It would be the same show. It's just kind of wasteful. I mean, we have to create the exact same values over and over, and then if you change your mind about an expression, you have to change it everywhere. That, and what if you change it in one place but forget to change it in other places? Like, imagine if you also made the color change, so you had the same expression three times. And then imagine you wanted to add a letter to our magic letter list with this. You have to do it three times! You might forget one or make a typo. How are you supposed to express your artistic vision if some of us aren't doing what you intended?"
                         ],
                         [
                             "edit",
@@ -4255,7 +4255,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "@Bind, that was such a good example! You know I love names. I was curious, are there also some things that can go wrong with names?"
+                            "@Bind, that was such a good example! You know I love names. I was curious; are there also some things that can go wrong with names?"
                         ],
                         [
                             "Bind",
@@ -4273,7 +4273,7 @@
                         [
                             "Bind",
                             "serious",
-                            "Or, like here's an example where we give two different values the same name. And so we evaluate \\5\\, and name it \\fruits\\, and then we evaluate \\10\\… and then we name it \\fruits\\?? Like, there's already a \\fruits\\, so which \\fruits\\ are you talking about? Because see, once you name a value, you can't give it a new value. That name and value are bound together, until @Program is done evaluating. We don't want anyone getting confused about who is who."
+                            "Or, like, here's an example where we give two different values the same name. And so we evaluate \\5\\ and name it \\fruits\\, and then we evaluate \\10\\… and then we name it \\fruits\\?? Like, there's already a \\fruits\\, so which \\fruits\\ are you talking about? Because see, once you name a value, you can't give it a new value. That name and value are bound together until @Program is done evaluating. We don't want anyone getting confused about who is who."
                         ],
                         [
                             "conflict",
@@ -4286,21 +4286,21 @@
                         [
                             "Bind",
                             "kind",
-                            "I guess there's one last one. Say you have this. See what happened here? We named \\veggies\\, but then we never used it. That's usually a bad sign that you're leaving someone out, or didn't use the right name. Like, maybe you're just not using it, but then why is it there?"
+                            "I guess there's one last one. Say you have this. See what happened here? We named \\veggies\\, but then we never used it. That's usually a bad sign that you're leaving someone out or didn't use the right name. Like, maybe you're just not using it, but then why is it there?"
                         ],
                         ["conflict", "fruits: 5", "veggies: 10", "fruits + 3"],
                         null,
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "This is so helpful @Bind, this is so great. Are you sure there's nothing else?"
+                            "This is so helpful, @Bind, this is so great. Are you sure there's nothing else?"
                         ],
                         [
                             "Bind",
                             "eager",
                             "Oh! Yes, something really important. So like, one name is good, right? But sometimes, multiple names is better? Like if you wanted to name something in multiple person languages, so everyone can read it? So like, say you wanted to say fruit in multiple languages.",
-                            "Put the text cursor on the name \\fruit\\. See how there are actually three names in there, and they each have a two letter tag like \\/en\\? Names hide if they're in a language that you haven't chosen.",
-                            "Go down to the ⚙ and choose Spanish, for example, and you'll see the English and Spanish names. So like, one value, but three names, and you can use any of them to get that value. If you tell us what languages you want, we'll show whichever ones are available. The more languages the better though, since there are a lot of people in the world who read a lot of different languages!"
+                            "Put the text cursor on the name \\fruit\\. See how there are actually three names in there and they each have a two letter tag like \\/en\\? Names hide if they're in a language that you haven't chosen.",
+                            "Go down to the ⚙ and choose Spanish, for example, and you'll see the English and Spanish names. So like, one value, but three names, and you can use any of them to get that value. If you tell us what languages you want, we'll show whichever ones are available. The more languages, the better, though, since there are a lot of people in the world who read a lot of different languages!"
                         ],
                         ["conflict", "fruit/en,fruta/es,水果/zh: 5"],
                         null,
@@ -4327,7 +4327,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "So there's a character that's been here all along that you haven't met yet, But they've been hiding… They work super closely with @Bind and many other folks, so I thought we should talk to them next. @Block, would you come out?"
+                            "So there's a character that's been here all along that you haven't met yet, but they've been hiding… They work super closely with @Bind and many other folks, so I thought we should talk to them next. @Block, would you come out?"
                         ],
                         ["Block", "shy", "… hi"],
                         null,
@@ -4335,7 +4335,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "Hi @Block! How are you?"
+                            "Hi, @Block! How are you?"
                         ],
                         ["Block", "shy", "… mmm, good?"],
                         null,
@@ -4351,7 +4351,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "We were just meeting @Bind and we didn't get a chance to talk about how you two are best of friends!"
+                            "We were just meeting @Bind, and we didn't get a chance to talk about how you two are the best of friends!"
                         ],
                         ["Block", "shy", "… yeah, @Bind!"],
                         null,
@@ -4374,14 +4374,14 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "And so another thing @Block can do is something you've already seen. @Block let's you name things with @Bind. But any names defined in the @Block are only defined between the parentheses. Not before, and not after. For example, check this out. \\a\\ is defined as \\1\\, then a block starts, and \\b\\ is defined as \\2\\, then \\c\\ is defined as their sum. What @Block evaluates to whatever value is last in its list of expressions. That's @Bind, which evaluates to whatever \\c\\ is, which is \\3\\. Right?"
+                            "And so another thing @Block can do is something you've already seen. @Block lets you name things with @Bind. But any names defined in the @Block are only defined between the parentheses. Not before and not after. For example, check this out. \\a\\ is defined as \\1\\, then a block starts and \\b\\ is defined as \\2\\, then \\c\\ is defined as their sum. What @Block evaluates to is whatever value is last in its list of expressions. That's @Bind, which evaluates to whatever \\c\\ is, which is \\3\\. Right?"
                         ],
                         ["conflict", "a: 1", "(", "  b: 2", "  c: a + b", ")"],
                         null,
                         [
                             "FunctionDefinition",
                             "serious",
-                            "But what if we wanted to access \\c\\ outside the @Block? You can't. \\c\\ is only defined inside the @Block, but not outside it. Is that right @Block?"
+                            "But what if we wanted to access \\c\\ outside the @Block? You can't. \\c\\ is only defined inside the @Block, but not outside it. Is that right, @Block?"
                         ],
                         [
                             "conflict",
@@ -4400,7 +4400,7 @@
                         [
                             "FunctionDefinition",
                             "neutral",
-                            "And one more thing, I think? Since @Block is a list of expressions, and it only evaluates to the last expression in the list, any expressions in the list that aren't a @Bind are basically ignored. For example, here, all of the arithmetic before the last one is ignored. The \\3\\, the \\5\\, the \\7\\, all ignored, and @Block just evaluates to the last one, \\9\\. Did I get that right, @Block?"
+                            "And one more thing, I think? Since @Block is a list of expressions and it only evaluates to the last expression in the list, any expressions in the list that aren't a @Bind are basically ignored. For example, here, all of the arithmetic before the last one is ignored. The \\3\\, the \\5\\, the \\7\\, all ignored, and @Block just evaluates to the last one, \\9\\. Did I get that right, @Block?"
                         ],
                         [
                             "Block",
@@ -4448,7 +4448,7 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "I'm so happy we've found everyone, and that you've been able to meet all of them. Everyone is so different, aren't they? But also so interesting? I feel like we're a family, where everyone is unique in their own way, but that our differences together is what makes us strong. What do you think of everyone?"
+                            "I'm so happy we've found everyone and that you've been able to meet all of them. Everyone is so different, aren't they? But also so interesting? I feel like we're a family where everyone is unique in their own way, but our differences together is what makes us strong. What do you think of everyone?"
                         ],
                         null,
                         ["use", "fit", "Symbol", "🙈"],
@@ -4469,14 +4469,14 @@
                             "FunctionDefinition",
                             "excited",
                             "Here's a super simple example. The simplest, actually! This defines a function that always evaluates to the number \\1\\. That's it. It's not very useful, is it? It has no name, it takes no inputs, and it always evaluates to \\1\\.",
-                            "You can also see that @Program evaluated to one of me, a @FunctionDefinition. That's right, @FunctionDefinition are values too! I don't know why anyone would ever make such a useless function, but as I said, I'm not the one with inspiration, you are."
+                            "You can also see that @Program evaluated to one of me, a @FunctionDefinition. That's right, @FunctionDefinition are values too! I don't know why anyone would ever make such a useless function, but as I said: I'm not the one with inspiration; you are."
                         ],
                         ["edit", "ƒ() 1"],
                         null,
                         [
                             "FunctionDefinition",
                             "serious",
-                            "So here's a more useful example. You know odd and even numbers? I once had a director that wanted to check if a number was even (divisible by 2, I think that means?), and so they wrote this. This is a function called \\even\\ that takes a single number called… \\number\\. You need to tell me what kind of value each input is, so @Evaluate can make sure that anything evaluating the function is sending the right kind of value. Then, it takes the number, divides it by two, gets the remainder (with the @Number/remainder), and then checks if the remainder is equal to \\0\\, with @Number/equal. So the whole function ends up either evaluating to \\⊤\\ or \\⊥\\. For example, this evaluation of even evaluated to \\⊥\\ because \\3\\ is odd. Try using the rewind buttons to see how it works."
+                            "So here's a more useful example. You know odd and even numbers? I once had a director that wanted to check if a number was even (divisible by 2, I think that means?), so they wrote this. This is a function called \\even\\ that takes a single number called… \\number\\. You need to tell me what kind of value each input is, so @Evaluate can make sure that anything evaluating the function is sending the right kind of value. Then, it takes the number, divides it by two, gets the remainder (with the @Number/remainder), and then checks if the remainder is equal to \\0\\ with @Number/equal. So the whole function ends up either evaluating to \\⊤\\ or \\⊥\\. For example, this evaluation of even evaluated to \\⊥\\ because \\3\\ is odd. Try using the rewind buttons to see how it works."
                         ],
                         [
                             "edit",
@@ -4487,14 +4487,14 @@
                         [
                             "FunctionDefinition",
                             "eager",
-                            "You can also tell me what kind of value I should evaluate to. See how we added \\•\\? after the list of inputs? That says “the function's expression should evaluate to a \\⊤\\ or \\⊥\\.” But see how we complain about it? We don't know if the function should be a \\⊤\\ or \\⊥\\ or whatever kind of value you returned, so the show ends."
+                            "You can also tell me what kind of value I should evaluate to. See how we added \\•\\? after the list of inputs? That say, “The function's expression should evaluate to a \\⊤\\ or \\⊥\\.” But see how we complain about it? We don't know if the function should be a \\⊤\\ or \\⊥\\ or whatever kind of value you returned, so the show ends."
                         ],
                         ["conflict", "ƒ even(number•#)•? (number % 2) + 0"],
                         null,
                         [
                             "FunctionDefinition",
                             "serious",
-                            "Functions can be as complex as you want. You can use simple expressions or @Block, and even make functions inside of functions. For example, check out this function a former director wrote. It uses @Block with many @Bind to figure out how many unique vowels a word has. (I think they were trying to figure out if a word was “complicated” or something). See how it has a lot of lines? Well, this still only has one expression: a single @Block, and the @Block has all the lines. And like any @Block, the last line is what it evaluates to: the total number of unique vowels. Everything else — like the first line, which converts the text into a list of letters, then the list of letters into a set — is just preparation for summing those counts in the middle."
+                            "Functions can be as complex as you want. You can use simple expressions or @Block and even make functions inside of functions. For example, check out this function a former director wrote. It uses @Block with many @Bind to figure out how many unique vowels a word has (I think they were trying to figure out if a word was “complicated” or something). See how it has a lot of lines? Well, this still only has one expression: a single @Block, and the @Block has all the lines. And like any @Block, the last line is what it evaluates to: the total number of unique vowels. Everything else — like the first line, which converts the text into a list of letters, then the list of letters into a set — is just preparation for summing those counts in the middle."
                         ],
                         [
                             "edit",
@@ -4513,7 +4513,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "There's one more thing to show. I guess it's important, because everyone is so excited about it! You know how you can make a function and then evaluate it? Well since the functions I make are values, you can also give them as an input to another function. Here's an example. Say you had a list of numbers and you just wanted the even numbers in it. @List has this function called @List/filter that takes a function as an input and uses the function on each value in the list to decide whether to keep it. Let's make a list of numbers and give @List/filter the \\even\\ function we made earlier as an input. See what happens? We just get the even numbers. Want to try changing it so that it gives odd numbers instead? Maybe try changing the function somehow?"
+                            "There's one more thing to show. I guess it's important because everyone is so excited about it! You know how you can make a function and then evaluate it? Well, since the functions I make are values, you can also give them as an input to another function. Here's an example. Say you had a list of numbers and you just wanted the even numbers in it. @List has this function called @List/filter that takes a function as an input and uses the function on each value in the list to decide whether to keep it. Let's make a list of numbers and give @List/filter the \\even\\ function we made earlier as an input. See what happens? We just get the even numbers. Want to try changing it so that it gives odd numbers instead? Maybe try changing the function somehow?"
                         ],
                         [
                             "edit",
@@ -4590,7 +4590,7 @@
                         [
                             "StructureDefinition",
                             "eager",
-                            "That is incredible. And quite a relief. It's nice to meet you director-person. I'm here and ready to serve.",
+                            "That is incredible. And quite a relief. It's nice to meet you, director-person. I'm here and ready to serve.",
                             "@FunctionDefinition… it has been hard. You, @Evaluate, everyone really — I didn't realize how much I've depended on all of you. To have purpose, to play, to have community. I didn't know that we could lose each other like that. Without anyone to organize, I felt like I could only organize myself, which felt meaningless."
                         ],
                         [
@@ -4601,7 +4601,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "You're never empty, @StructureDefinition, even when you're alone. e're all here, even if we can't be with each other. And now that the silence is broken, we can be."
+                            "You're never empty, @StructureDefinition, even when you're alone. We're all here, even if we can't be with each other. And now that the silence is broken, we can be."
                         ],
                         ["StructureDefinition", "happy", "We can, can't we?"],
                         [
@@ -4628,7 +4628,7 @@
                         [
                             "StructureDefinition",
                             "shy",
-                            "Yes. Yes… I've had a lot of time to think about my purpose in the quiet. And I guess I've realized that what I really do is give groups of things identity. For example, I know you've met ƒ, but have you @Bind?"
+                            "Yes. Yes… I've had a lot of time to think about my purpose in the quiet. And I guess I've realized that what I really do is give groups of things identity. For example, I know you've met ƒ, but have you met @Bind?"
                         ],
                         [
                             "FunctionDefinition",
@@ -4659,7 +4659,7 @@
                         [
                             "StructureDefinition",
                             "serious",
-                            "Then they had the problem of how the performance would remember which message they were on. They realized they needed some way of remembering the index in the list. This is a good start, but it only shows the first message."
+                            "Then, they had the problem of how the performance would remember which message they were on. They realized they needed some way of remembering the index in the list. This is a good start, but it only shows the first message."
                         ],
                         [
                             "edit",
@@ -4677,7 +4677,7 @@
                         [
                             "StructureDefinition",
                             "excited",
-                            "Then they remembered @Reaction, which can be used to respond to stream changes. They wanted the message to change every two sections, so they made @Time stream that ticks every 2 seconds, and used @Reaction to increment the next index each time. This @Reaction says start at \\1\\, and when the time changes every \\2000ms\\, evaluate to the previous value of \\index + 1\\. This way, \\index\\ increases by \\1\\ every two seconds, changing the message shown. Yay, it works!"
+                            "Then, they remembered @Reaction, which can be used to respond to stream changes. They wanted the message to change every two sections, so they made @Time stream that ticks every 2 seconds and used @Reaction to increment the next index each time. This @Reaction says start at \\1\\, and when the time changes every \\2000ms\\, evaluate to the previous value of \\index + 1\\. This way, \\index\\ increases by \\1\\ every two seconds, changing the message shown. Yay, it works!"
                         ],
                         [
                             "edit",
@@ -4718,8 +4718,8 @@
                         [
                             "StructureDefinition",
                             "serious",
-                            "Now, all of that works. And we could just leave it this way. But it is also a bit hard to read and understand. That's partly because we repeat ourselves: \\messages[index]\\ appears twice, once in each phrase. And the @Reaction is very long. What can we do to simplify it? That's how I can help. I tidy things, to make them easier to understand, by giving reusable concepts names. So imagine instead of all of these @Bind, we instead make one of me, and name it \\Marquee\\? That's what we do first. \\Marquee\\'s job is to store the messages, but also to have a function for advancing to the next message \\next()\\ and a function for getting the current message \\now()\\?",
-                            "Then, we can use Marquee in the reaction. Now it just says the initial value is a marquee with the five messages and the next value, after each clock tick, is the next message. Simpler, right? That's because all of the logic for next messages is in \\next()\\, which just makes a new \\Marquee\\ with the same messages, but an updated index. We also get some benefits in the two @Phrase. Instead of them having to refer to the messages and the index like before, we can just say \\marquee.now()\\, which gets the current message in the list."
+                            "Now, all of that works. And we could just leave it this way. But it is also a bit hard to read and understand. That's partly because we repeat ourselves: \\messages[index]\\ appears twice, once in each phrase. And the @Reaction is very long. What can we do to simplify it? That's how I can help. I tidy things to make them easier to understand by giving reusable concepts names. So imagine instead of all of these @Bind, we instead make one of me and name it \\Marquee\\. That's what we do first. \\Marquee\\'s job is to store the messages but also to have a function for advancing to the next message \\next()\\ and a function for getting the current message \\now()\\.",
+                            "Then, we can use Marquee in the reaction. Now, it just says the initial value is a marquee with the five messages, and the next value, after each clock tick, is the next message. Simpler, right? That's because all of the logic for next messages is in \\next()\\, which just makes a new \\Marquee\\ with the same messages but an updated index. We also get some benefits in the two @Phrase. Instead of them having to refer to the messages and the index like before, we can just say \\marquee.now()\\, which gets the current message in the list."
                         ],
                         [
                             "edit",
@@ -4745,12 +4745,12 @@
                         [
                             "FunctionDefinition",
                             "curious",
-                            "That's wonderful @StructureDefinition! But I have to say, that does seem like a lot of extra work. Why spend all the time tidying?"
+                            "That's wonderful, @StructureDefinition! But I have to say, that does seem like a lot of extra work. Why spend all the time tidying?"
                         ],
                         [
                             "StructureDefinition",
                             "serious",
-                            "Ah, it's really about change. It is a bit more code now, but what if we decided to change \\Marquee\\ in some way? Like what if we wanted to make it so that the list of messages reverses each time it gets to the end? In the old version without me, there's no easy way to do that, because we'd have to reverse the list of messages when the index reaches the end. Since @Bind can't change after it's been set, it would be hard. But since we made \\Marquee\\, the change is easy. We just change the \\next\\ function to make a \\Marquee\\ with a reversed list when the index is at the end, and then just incrementing when it's otherwise."
+                            "Ah, it's really about change. It is a bit more code now, but what if we decided to change \\Marquee\\ in some way? Like what if we wanted to make it so that the list of messages reverses each time it gets to the end? In the old version without me, there's no easy way to do that because we'd have to reverse the list of messages when the index reaches the end. Since @Bind can't change after it's been set, it would be hard. But since we made \\Marquee\\, the change is easy. We just change the \\next\\ function to make a \\Marquee\\ with a reversed list when the index is at the end, and then just incrementing when it's otherwise."
                         ],
                         [
                             "edit",
@@ -4779,12 +4779,12 @@
                         [
                             "FunctionDefinition",
                             "surprised",
-                            "Ohh, I see, so by making a @StructureDefinition to store values and @FunctionDefinition that are related to each other, it makes it easier to change things later, if you change your mind."
+                            "Ohh, I see, so by making a @StructureDefinition to store values and @FunctionDefinition that are related to each other, it makes it easier to change things later if you change your mind."
                         ],
                         [
                             "StructureDefinition",
                             "happy",
-                            "Yes. Just like if you tidy your room, it makes it easier to find stuff later. Of course, you don't have to tidy your room to find stuff, it just makes finding stuff harder. The same with a performance: if you invest in tidying, changing things will be easier."
+                            "Yes. Just like if you tidy your room, it makes it easier to find stuff later. Of course, you don't have to tidy your room to find stuff; it just makes finding stuff harder. The same with a performance: if you invest in tidying, changing things will be easier."
                         ],
                         null,
                         [
@@ -4795,7 +4795,7 @@
                         [
                             "StructureDefinition",
                             "eager",
-                            "Oh yes. You don't have to have any @FunctionDefinition in a @StructureDefinition. You can just have values. For example, you might want to just keep a bunch of data in one place. I know a lot of directors like making games, and it's really common for them to put all of the game state in a @StructureDefinition."
+                            "Oh, yes. You don't have to have any @FunctionDefinition in a @StructureDefinition. You can just have values. For example, you might want to just keep a bunch of data in one place. I know a lot of directors like making games, and it's really common for them to put all of the game state in a @StructureDefinition."
                         ],
                         ["edit", "•Game(score•# lives•# level•#)"],
                         null,
@@ -4807,7 +4807,7 @@
                         [
                             "StructureDefinition",
                             "surprised",
-                            "Oh my, I forgot to explain that. You use a mini me, @PropertyReference. For instance, with that game example, see how we defined a Game @StructureDefinition, then make a \\Game\\ value with \\0\\ score, \\3\\ lives, and level \\1\\? To get the lives, we just say \\status.lives\\, and that will evaluate to \\3\\."
+                            "Oh my, I forgot to explain that. You use a mini me, @PropertyReference. For instance, with that game example, see how we defined a Game @StructureDefinition, then made a \\Game\\ value with \\0\\ score, \\3\\ lives, and level \\1\\? To get the lives, we just say \\status.lives\\, and that will evaluate to \\3\\."
                         ],
                         [
                             "edit",
@@ -4819,12 +4819,12 @@
                         [
                             "FunctionDefinition",
                             "happy",
-                            "Nice! So just the mini you to get values instead of you. But then how do you change the values?"
+                            "Nice! So just use the mini you to get values instead of you. But then, how do you change the values?"
                         ],
                         [
                             "StructureDefinition",
                             "serious",
-                            "Remember how @Bind only lets you set a value, but not change it? The same is true for all the @Bind in me. So instead, you make a new structure that has the new value. For example, in this game, every time ticks changes, the player gets one more point in their score. Weird game, huh? So the initial \\Game\\ value starts as \\Game(0 3 1)\\, but then the next one is the \\Game\\'s old values, but with the score adding \\1\\."
+                            "Remember how @Bind only lets you set a value but not change it? The same is true for all the @Bind in me. So instead, you make a new structure that has the new value. For example, in this game, every time ticks changes, the player gets one more point in their score. Weird game, huh? So the initial \\Game\\ value starts as \\Game(0 3 1)\\, but then the next one is the \\Game\\'s old values but with the score adding \\1\\."
                         ],
                         [
                             "edit",
@@ -4835,7 +4835,7 @@
                         [
                             "StructureDefinition",
                             "eager",
-                            "It can get pretty annoying to have to repeat all of those old values if only one thing is changing, so @Bind and I came up with a neat trick to copy a @StructureDefinition value with a new value. See how it just kind of looks like a regular @Bind? The only difference is that it's on a @StructureDefinition instead of a single name, and every value of the @StructureDefinition is copied over, except for the modified one."
+                            "It can get pretty annoying to have to repeat all of those old values if only one thing is changing, so @Bind and I came up with a neat trick to copy a @StructureDefinition value with a new value. See how it just kind of looks like a regular @Bind? The only difference is that it's on a @StructureDefinition instead of a single name and every value of the @StructureDefinition is copied over except for the modified one."
                         ],
                         [
                             "edit",
@@ -4868,7 +4868,7 @@
                         [
                             "FunctionDefinition",
                             "eager",
-                            "Wow, we've come a long way, haven't we? We have one more character to go. They're an interesting one, because in essence, they're all about explaining things, which feels like what I've been doing with you for a while now. Their name is @Doc. What's up @Doc?"
+                            "Wow, we've come a long way, haven't we? We have one more character to go. They're an interesting one because in essence, they're all about explaining things, which feels like what I've been doing with you for a while now. Their name is @Doc. What's up, @Doc?"
                         ],
                         ["use", "fit", "Symbol", "``"],
                         [
@@ -4880,7 +4880,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "I'm okay. @Evaluate is … @Evaluate. I saw them, but… I think I still need space. I've been introducing everyone to our new director."
+                            "I'm okay. @Evaluate is… @Evaluate. I saw them, but… I think I still need space. I've been introducing everyone to our new director."
                         ],
                         [
                             "Doc",
@@ -4905,7 +4905,7 @@
                         [
                             "Doc",
                             "happy",
-                            "I'm a way you can remind yourself what everyone is doing, but also a way to explain to others, if you're directing with a friend, or want to share your performance with someone. So you don't /have/ to work with me, but I find that every performance is a bit easier to do and change if you've spent some time explaining how it works."
+                            "I'm a way you can remind yourself what everyone is doing but also a way to explain to others, if you're directing with a friend or want to share your performance with someone. So you don't /have/ to work with me, but I find that every performance is a bit easier to do and change if you've spent some time explaining how it works."
                         ],
                         ["use", "fit", "Symbol", "``About me...``/en"],
                         null,
@@ -4917,7 +4917,7 @@
                         [
                             "Doc",
                             "serious",
-                            "Well you can put me almost anywhere inside @Program. For example, say you make a @Bind, and you want to say what the value is for. For example, here we have a simple value we've named, but what I'm doing is providing a broader explanation of its role."
+                            "Well, you can put me almost anywhere inside @Program. For example, say you make a @Bind and you want to say what the value is for. For example, here we have a simple value we've named, but what I'm doing is providing a broader explanation of its role."
                         ],
                         [
                             "conflict",
@@ -4929,7 +4929,7 @@
                         [
                             "Doc",
                             "serious",
-                            "Or, suppose you had @FunctionDefinition here defining a way of calculating tax on a price. You might want to explain what it computes. Just like with @Bind, I come before the @FunctionDefinition."
+                            "Or suppose you had @FunctionDefinition here defining a way of calculating tax on a price. You might want to explain what it computes. Just like with @Bind, I come before the @FunctionDefinition."
                         ],
                         [
                             "edit",
@@ -4942,7 +4942,7 @@
                         [
                             "Doc",
                             "serious",
-                            "And you can do the same before a @StructureDefinition to explain what it represents. Here the explanation also alludes to what functions it might have later."
+                            "And you can do the same before a @StructureDefinition to explain what it represents. Here, the explanation also alludes to what functions it might have later."
                         ],
                         [
                             "edit",
@@ -4966,7 +4966,7 @@
                         [
                             "Doc",
                             "excited",
-                            "And like @Bind, you can tell me what language an explanation is in, and give me multiple translations of the same explanation. (You'll only see the Spanish if it's selected. If you don't see it, try adding Spanish to your selected languages.)"
+                            "And like @Bind, you can tell me what language an explanation is in and give me multiple translations of the same explanation (You'll only see the Spanish if it's selected. If you don't see it, try adding Spanish to your selected languages.)"
                         ],
                         [
                             "edit",
@@ -4979,7 +4979,7 @@
                         [
                             "Doc",
                             "curious",
-                            "You know the best place to put me? Right at the very beginning of @Program. That way everyone knows what your performance is about. You might even write it before you figure out what you want all of us to do."
+                            "You know the best place to put me? Right at the very beginning of @Program. That way, everyone knows what your performance is about. You might even write it before you figure out what you want all of us to do."
                         ],
                         [
                             "conflict",
@@ -5067,10 +5067,10 @@
                             "Doc",
                             "serious",
                             "And one last thing.",
-                            "While I'm really all about explaining things, sometimes it's helpful to elide things too. You know, to remove something from a project temporarily, so that it isn't part of the project.",
+                            "While I'm really all about explaining things, sometimes it's helpful to elide things too. You know, to remove something from a project temporarily so that it isn't part of the project.",
                             "You can do that by wrapping anything between stars.",
                             "See how \\'cat'\\ isn't included in the list we made?",
-                            "You can remove the stars by deleting them with the keyboard, or placing the cursor inside them and using the elide command to remove them for you."
+                            "You can remove the stars by deleting them with the keyboard or placing the cursor inside them and using the elide command to remove them for you."
                         ],
                         ["edit", "[1 2 3 4 *'cat'* 5 6 7 8]"],
                         null,
@@ -5081,7 +5081,7 @@
                         [
                             "FunctionDefinition",
                             "excited",
-                            "Wow. I had no idea you could do so much! Thank you @Doc, I think we might be ready for a show!"
+                            "Wow. I had no idea you could do so much! Thank you, @Doc, I think we might be ready for a show!"
                         ],
                         ["Doc", "excited", "Let's do it!"]
                     ]
@@ -5130,7 +5130,7 @@
                         [
                             "FunctionDefinition",
                             "sad",
-                            "… @Evaluate, I know you missed me. I missed you. But this is big: the silence is broken, we have a new director… I love you, and I know you need me, but I also have things to do."
+                            "… @Evaluate, I know you missed me. I missed you. But this is big: the silence is broken; we have a new director… I love you, and I know you need me, but I also have things to do."
                         ],
                         null,
                         [
@@ -5160,7 +5160,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "I make functions, you evaluate them, that is our way. But there has to be more to us than you needing me. Reuniting with everyone has reminded me how much we need space to be ourselves, but also how we need to love ourselves. I can't give you all the love you need. Some of that has to come from you."
+                            "I make functions; you evaluate them: that is our way. But there has to be more to us than you needing me. Reuniting with everyone has reminded me how much we need space to be ourselves but also how we need to love ourselves. I can't give you all the love you need. Some of that has to come from you."
                         ],
                         null,
                         [
@@ -5171,7 +5171,7 @@
                         [
                             "FunctionDefinition",
                             "angry",
-                            "No, that's not what I said… what I mean is that we have to both matter in this relationship. I need to say what I need and you need to say what you need and we can love each other for who we are, as individuals. What do /you/ need? What do you love about yourself?"
+                            "No, that's not what I said… what I mean is that we have to both matter in this relationship. I need to say what I need, and you need to say what you need, and we can love each other for who we are, as individuals. What do /you/ need? What do you love about yourself?"
                         ],
                         null,
                         [
@@ -5182,7 +5182,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "I love you @Evaluate. But I need you to love you. I'm excited about our world coming back to life, and what it's going to mean to be together again, but I need you to find yourself, your needs, and your own purpose. I can't be your purpose."
+                            "I love you, @Evaluate. But I need you to love you. I'm excited about our world coming back to life and what it's going to mean to be together again, but I need you to find yourself, your needs, and your own purpose. I can't be your purpose."
                         ],
                         null,
                         ["use", "fit", "DarkVoid"],
@@ -5203,7 +5203,7 @@
                         [
                             "Evaluate",
                             "curious",
-                            "Me? I don't know anything. I give @FunctionDefinition what they need… At least I thought I did."
+                            "Me? I don't know anything. I give @FunctionDefinition what they need… At least, I thought I did."
                         ],
                         null,
                         ["fit", "Stage([] background: Color(10% 0 0°))"],
@@ -5214,14 +5214,14 @@
                         [
                             "Number",
                             "serious",
-                            "1) You basically run our performances, 2) @Evaluate would be useless without you, 3) you literally transform things into entirely new values, 4) you come in so many different forms, 5) you give all of us purpose, 6) we all look up to you for guidance…"
+                            "1) You basically run our performances, 2) @FunctionDefinition would be useless without you, 3) you literally transform things into entirely new values, 4) you come in so many different forms, 5) you give all of us purpose, 6) we all look up to you for guidance…"
                         ],
                         null,
                         ["fit", "Stage([] background: Color(20% 0 0°))"],
                         [
                             "Phrase",
                             "kind",
-                            "@Number is right @Evaluate, you are fabulous in fifty ways."
+                            "@Number is right, @Evaluate, you are fabulous in fifty ways."
                         ],
                         ["Sequence", "happy", "I spin when I see you!"],
                         [
@@ -5256,7 +5256,7 @@
                         ["Evaluate", "happy", "…"],
                         null,
                         ["fit", "Stage([] background: Color(60% 0 0°))"],
-                        ["Evaluate", "kind", "You are all so kind… I …"],
+                        ["Evaluate", "kind", "You are all so kind… I…"],
                         null,
                         ["fit", "Stage([] background: Color(70% 0 0°))"],
                         [
@@ -5278,7 +5278,7 @@
                         ["FunctionDefinition", "happy", "You *can*."],
                         null,
                         ["fit", "Stage([] background: Color(90% 0 0°))"],
-                        ["Evaluate", "shy", "… I … I'll try."],
+                        ["Evaluate", "shy", "… I… I'll try."],
                         null,
                         ["fit", "Stage([] background: Color(100% 0 0°))"],
                         [
@@ -5336,11 +5336,11 @@
                         [
                             "Evaluate",
                             "happy",
-                            "Splendid! Now we need us on stage. Can we translate the characters into @Phrase? Maybe in a @Free @Group?"
+                            "Splendid! Now, we need us on stage. Can we translate the characters into @Phrase? Maybe in a @Free @Group?"
                         ],
                         ["List", "kind", "One more time!"],
                         ["Phrase", "kind", "All the attention!"],
-                        ["Group", "kind", "Come on everyone, places please…"],
+                        ["Group", "kind", "Come on, everyone, places please…"],
                         ["use", "edit", "EvaluateDance6"],
                         null,
                         [
@@ -5360,7 +5360,7 @@
                         [
                             "Evaluate",
                             "happy",
-                            "Yay! Now we just need to move. @Reaction, can you give us a beat, maybe \\0.75\\ seconds?"
+                            "Yay! Now, we just need to move. @Reaction, can you give us a beat, maybe \\0.75\\ seconds?"
                         ],
                         [
                             "Reaction",
@@ -5391,20 +5391,20 @@
                         [
                             "Evaluate",
                             "happy",
-                            "I … I am creating something. We are creating something… but we can't create it without out. Will you help?"
+                            "I… I am creating something. We are creating something… but we can't create it without you. Will you help?"
                         ],
                         null,
                         [
                             "FunctionDefinition",
                             "eager",
-                            "Of course. A \\move\\ function, coming right up. I'll start it, you finish it…"
+                            "Of course. A \\move\\ function coming right up. I'll start it; you finish it…"
                         ],
                         ["use", "edit", "EvaluateDance10"],
                         null,
                         [
                             "Evaluate",
                             "confused",
-                            "Thank you @FunctionDefinition. They're not moving… Oh right, \\move\\ didn't change anything! Let's take the current position and move us in a random direction horizontally and vertically. And maybe a random depth, so we all get a chance up front. And some random rotation?"
+                            "Thank you, @FunctionDefinition. They're not moving… Oh, right, \\move\\ didn't change anything! Let's take the current position and move us in a random direction horizontally and vertically. And maybe a random depth, so we all get a chance up front. And some random rotation?"
                         ],
                         ["use", "edit", "EvaluateDance11"],
                         null,
@@ -5443,7 +5443,7 @@
                         [
                             "Evaluate",
                             "excited",
-                            "Oh yes, of course! How about we let them make the music? @Phrase, can you listen to @Volume, and hook it up to @Color/lightness and @Color/chroma in your color? That way, we're turn turn white hot when our director makes noise!"
+                            "Oh yes, of course! How about we let them make the music? @Phrase, can you listen to @Volume and hook it up to @Color/lightness and @Color/chroma in your color? That way, we'll turn white hot when our director makes noise!"
                         ],
                         ["Phrase", "kind", "Excellent idea!"],
                         ["use", "edit", "EvaluateDance14"],
@@ -5466,7 +5466,7 @@
                         [
                             "FunctionDefinition",
                             "kind",
-                            "You did it @Evaluate! This was your vision."
+                            "You did it, @Evaluate! This was your vision."
                         ],
                         [
                             "Evaluate",
@@ -5483,7 +5483,7 @@
                         [
                             "FunctionDefinition",
                             "serious",
-                            "We did… but we couldn't have done it without our new director friend. They broke our silence, they reminded us why we're expressions, together."
+                            "We did… but we couldn't have done it without our new director friend. They broke our silence; they reminded us why we're expressions, together."
                         ],
                         null,
                         ["use", "fit", "Symbol", "?"],


### PR DESCRIPTION
Issue:
There were typos and grammar errors in the English tutorial.

Work I did:
I proofread the script and fixed typos I saw. I also added/removed commas to avoid comma splicing and some awkward wording.

What the reviewer may need to consider:
I tried to leave the writing style intact. The commas I added/removed may have made some sentences feel too lengthy. There is still some awkward wording as well, but the obvious typos are now fixed.