### PR TITLE
Updating subtitle colors in dark mode

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -116,12 +116,12 @@
                 --color-black: #000000;
                 --color-light-grey: #484848;
                 --color-very-light-grey: #373636;
-                --color-dark-grey: #595256;
+                --color-dark-grey: #a3a3a3;
                 --color-shadow: rgb(32, 32, 32, 0.2);
 
                 --wordplay-foreground: var(--color-white);
                 --wordplay-background: var(--color-black);
-                --wordplay-header: var(--wordplay-foreground);
+                --wordplay-header: var(--color-dark-grey);
                 --wordplay-chrome: var(--color-dark-grey);
                 --wordplay-border-color: var(--color-dark-grey);
                 --wordplay-hover: #463000;

--- a/src/app.html
+++ b/src/app.html
@@ -121,7 +121,7 @@
 
                 --wordplay-foreground: var(--color-white);
                 --wordplay-background: var(--color-black);
-                --wordplay-header: var(--color-dark-grey);
+                --wordplay-header: var(--wordplay-foreground);
                 --wordplay-chrome: var(--color-dark-grey);
                 --wordplay-border-color: var(--color-dark-grey);
                 --wordplay-hover: #463000;


### PR DESCRIPTION
Issue: #399 
Subtitle colors were too dark and violated WCAG guidelines.

Work I did:
Changed the header color from dark gray to white, using the --wordplay-foreground variable in app.html

What the reviewer may need to consider:
From a design standpoint, the reviewer may need to consider whether the color is visually different enough from the rest of the text. The reviewer may also need to consider how this change impacts the rest of the website, other than just the subtitles on the front page. I've provided screenshots at #399, showing how this change impacts other pages. Generally, I think any switch from the previous gray to white should be good for visibility but it's good to check other parts of the website to see if there are any unwanted changes.