### PR TITLE
Update BasketballStar.wp

### DIFF
--- a/static/examples/BasketballStar.wp
+++ b/static/examples/BasketballStar.wp
@@ -17,7 +17,8 @@ basketball: Phrase(
 basketXPlace: Random(-9000m 9000m) ÷ 1000 … (click & ((clickCount % 2) = 1)) … Random(-9000m 9000m) ÷ 1000
 
 `` Keep track of scores and attempts ``
-score: 0 … (click & ((clickCount % 2) = 1) & ((basketXPlace + 1m) > basketball.place.x) & ((basketXPlace - 1m) < basketball.place.x)) … 1 + .
+score: 0 … (click & ((clickCount % 2) = 1) & ((basketXPlace + 0.81m) > basketball.place.x) & ((basketXPlace - 0.8m) < basketball.place.x)) & (2.1m > basketball.place.y) … 1 + . 
+
 attempt: (clickCount ÷ 2).roundUp()
 
 basketballStar: Group(Stack() [


### PR DESCRIPTION
The was an issue regarding the basketball star game, where the player does not earn a score when the basketball is in the hoop. Furthermore, the player sometimes earns a score even if the basketball is not in the hoop. Through trial and error, I changed the range of the basketXPlace and included the y position of the basketball in consideration of the score, since the ball can sometimes drift away from the basket as it goes down. An issue I ran into was that sometimes, the score wouldn't go up if the ball touches the rim and rolls into the basket.