### PR TITLE
Added large deletion warning popup above experimental message

### DIFF
--- a/src/components/project/ProjectView.svelte
+++ b/src/components/project/ProjectView.svelte
@@ -5,125 +5,125 @@
 
 <!-- svelte-ignore state_referenced_locally -->
 <script lang="ts">
-    import { onDestroy, onMount, tick, untrack } from 'svelte';
-    import { writable, type Writable } from 'svelte/store';
-    import {
-        getConceptPath,
-        IdleKind,
-        type EditorState,
-        type KeyModifierState,
-        setConceptIndex,
-        setDragged,
-        setProjectCommandContext,
-        setKeyboardEditIdle,
-        setKeyboardModifiers,
-        setEvaluation,
-        setAnimatingNodes,
-        setEditors,
-        setConflicts,
-        setSelectedOutput,
-        getFullscreen,
-        getUser,
-        getAnnounce,
-    } from './Contexts';
-    import type Project from '@db/projects/Project';
-    import Documentation from '@components/concepts/Documentation.svelte';
-    import Annotations from '../annotations/Annotations.svelte';
-    import type Conflict from '@conflicts/Conflict';
-    import RootView from './RootView.svelte';
-    import Highlight from '../editor/Highlight.svelte';
-    import getOutlineOf, { getUnderlineOf } from '../editor/util/outline';
-    import type { HighlightSpec } from '../editor/util/Highlights';
-    import TileView, { type ResizeDirection } from './TileView.svelte';
-    import Tile, { TileKind, TileMode } from './Tile';
-    import OutputView from '../output/OutputView.svelte';
-    import Editor from '../editor/Editor.svelte';
-    import Layout from './Layout';
-    import NonSourceTileToggle from './NonSourceTileToggle.svelte';
-    import Button from '../widgets/Button.svelte';
-    import Palette from '../palette/Palette.svelte';
-    import type Bounds from './Bounds';
-    import Source from '@nodes/Source';
-    import SourceTileToggle from './SourceTileToggle.svelte';
-    import type MenuInfo from '../editor/util/Menu';
-    import Menu from '../editor/Menu.svelte';
-    import Node from '@nodes/Node';
-    import ConceptIndex from '../../concepts/ConceptIndex';
-    import type Concept from '../../concepts/Concept';
-    import ConfirmButton from '../widgets/ConfirmButton.svelte';
-    import { isName } from '@parser/Tokenizer';
     import { goto } from '$app/navigation';
-    import TextField from '../widgets/TextField.svelte';
-    import Evaluator from '@runtime/Evaluator';
     import { page } from '$app/state';
-    import type Caret from '../../edit/Caret';
-    import CharacterChooser from '../editor/GlyphChooser.svelte';
-    import Timeline from '../evaluator/Timeline.svelte';
-    import type PaintingConfiguration from '../output/PaintingConfiguration';
-    import {
-        DB,
-        locales,
-        arrangement,
-        camera,
-        mic,
-        Settings,
-        Projects,
-        blocks,
-        Creators,
-        animationFactor,
-        Chats,
-    } from '../../db/Database';
-    import Arrangement from '../../db/settings/Arrangement';
-    import type Value from '../../values/Value';
-    import {
-        EnterFullscreen,
-        ExitFullscreen,
-        Restart,
-        ShowKeyboardHelp,
-        VisibleModifyCommands,
-        VisibleNavigateCommands,
-        handleKeyCommand,
-        type CommandContext,
-    } from '../editor/util/Commands';
-    import CommandButton from '../widgets/CommandButton.svelte';
-    import Shortcuts from './Shortcuts.svelte';
-    import type Color from '../../output/Color';
-    import Sharing from './Sharing.svelte';
-    import Toggle from '../widgets/Toggle.svelte';
-    import Spinning from '../app/Spinning.svelte';
-    import CreatorView from '../app/CreatorView.svelte';
-    import Moderation from './Moderation.svelte';
-    import { isFlagged } from '../../db/projects/Moderation';
-    import Dialog from '../widgets/Dialog.svelte';
-    import Separator from './Separator.svelte';
-    import Emoji from '../app/Emoji.svelte';
-    import {
-        PROJECT_PARAM_EDIT,
-        PROJECT_PARAM_PLAY,
-    } from '../../routes/project/constants';
-    import Switch from '@components/widgets/Switch.svelte';
-    import { withMonoEmoji } from '../../unicode/emoji';
-    import FullscreenIcon from './FullscreenIcon.svelte';
-    import Characters from '../../lore/BasisCharacters';
-    import Speech from '@components/lore/Speech.svelte';
-    import Translate from './Translate.svelte';
-    import { AnimationFactorIcons } from '@db/settings/AnimationFactorSetting';
-    import { CANCEL_SYMBOL, LOCALE_SYMBOL } from '@parser/Symbols';
-    import CopyButton from './CopyButton.svelte';
-    import type Locale from '@locale/Locale';
-    import Mode from '@components/widgets/Mode.svelte';
-    import OutputLocaleChooser from './OutputLocaleChooser.svelte';
-    import setKeyboardFocus from '@components/util/setKeyboardFocus';
     import CollaborateView from '@components/app/chat/CollaborateView.svelte';
-    import type Chat from '@db/chats/ChatDatabase.svelte';
-    import Checkpoints from './Checkpoints.svelte';
     import Link from '@components/app/Link.svelte';
-    import EditorLocaleChooser from './EditorLocaleChooser.svelte';
-    import SelectedOutput from './SelectedOutput.svelte';
+    import Documentation from '@components/concepts/Documentation.svelte';
+    import Speech from '@components/lore/Speech.svelte';
+    import setKeyboardFocus from '@components/util/setKeyboardFocus';
+    import Mode from '@components/widgets/Mode.svelte';
+    import Switch from '@components/widgets/Switch.svelte';
     import {
         getConceptFromURL,
         setConceptInURL,
     } from '@concepts/ConceptParams';
+    import type Conflict from '@conflicts/Conflict';
+    import type Chat from '@db/chats/ChatDatabase.svelte';
+    import type Project from '@db/projects/Project';
+    import { AnimationFactorIcons } from '@db/settings/AnimationFactorSetting';
+    import type Locale from '@locale/Locale';
+    import Node from '@nodes/Node';
+    import Source from '@nodes/Source';
+    import { CANCEL_SYMBOL, LOCALE_SYMBOL } from '@parser/Symbols';
+    import { isName } from '@parser/Tokenizer';
+    import Evaluator from '@runtime/Evaluator';
+    import { onDestroy, onMount, tick, untrack } from 'svelte';
+    import { writable, type Writable } from 'svelte/store';
+    import type Concept from '../../concepts/Concept';
+    import ConceptIndex from '../../concepts/ConceptIndex';
+    import {
+        animationFactor,
+        arrangement,
+        blocks,
+        camera,
+        Chats,
+        Creators,
+        DB,
+        locales,
+        mic,
+        Projects,
+        Settings,
+    } from '../../db/Database';
+    import { isFlagged } from '../../db/projects/Moderation';
+    import Arrangement from '../../db/settings/Arrangement';
+    import type Caret from '../../edit/Caret';
+    import Characters from '../../lore/BasisCharacters';
+    import type Color from '../../output/Color';
+    import {
+        PROJECT_PARAM_EDIT,
+        PROJECT_PARAM_PLAY,
+    } from '../../routes/project/constants';
+    import { withMonoEmoji } from '../../unicode/emoji';
+    import type Value from '../../values/Value';
+    import Annotations from '../annotations/Annotations.svelte';
+    import CreatorView from '../app/CreatorView.svelte';
+    import Emoji from '../app/Emoji.svelte';
+    import Spinning from '../app/Spinning.svelte';
+    import Editor, { largeDeletionNotification } from '../editor/Editor.svelte';
+    import CharacterChooser from '../editor/GlyphChooser.svelte';
+    import Highlight from '../editor/Highlight.svelte';
+    import Menu from '../editor/Menu.svelte';
+    import {
+        EnterFullscreen,
+        ExitFullscreen,
+        handleKeyCommand,
+        Restart,
+        ShowKeyboardHelp,
+        VisibleModifyCommands,
+        VisibleNavigateCommands,
+        type CommandContext,
+    } from '../editor/util/Commands';
+    import type { HighlightSpec } from '../editor/util/Highlights';
+    import type MenuInfo from '../editor/util/Menu';
+    import getOutlineOf, { getUnderlineOf } from '../editor/util/outline';
+    import Timeline from '../evaluator/Timeline.svelte';
+    import OutputView from '../output/OutputView.svelte';
+    import type PaintingConfiguration from '../output/PaintingConfiguration';
+    import Palette from '../palette/Palette.svelte';
+    import Button from '../widgets/Button.svelte';
+    import CommandButton from '../widgets/CommandButton.svelte';
+    import ConfirmButton from '../widgets/ConfirmButton.svelte';
+    import Dialog from '../widgets/Dialog.svelte';
+    import TextField from '../widgets/TextField.svelte';
+    import Toggle from '../widgets/Toggle.svelte';
+    import type Bounds from './Bounds';
+    import Checkpoints from './Checkpoints.svelte';
+    import {
+        getAnnounce,
+        getConceptPath,
+        getFullscreen,
+        getUser,
+        IdleKind,
+        setAnimatingNodes,
+        setConceptIndex,
+        setConflicts,
+        setDragged,
+        setEditors,
+        setEvaluation,
+        setKeyboardEditIdle,
+        setKeyboardModifiers,
+        setProjectCommandContext,
+        setSelectedOutput,
+        type EditorState,
+        type KeyModifierState,
+    } from './Contexts';
+    import CopyButton from './CopyButton.svelte';
+    import EditorLocaleChooser from './EditorLocaleChooser.svelte';
+    import FullscreenIcon from './FullscreenIcon.svelte';
+    import Layout from './Layout';
+    import Moderation from './Moderation.svelte';
+    import NonSourceTileToggle from './NonSourceTileToggle.svelte';
+    import OutputLocaleChooser from './OutputLocaleChooser.svelte';
+    import RootView from './RootView.svelte';
+    import SelectedOutput from './SelectedOutput.svelte';
+    import Separator from './Separator.svelte';
+    import Sharing from './Sharing.svelte';
+    import Shortcuts from './Shortcuts.svelte';
+    import SourceTileToggle from './SourceTileToggle.svelte';
+    import Tile, { TileKind, TileMode } from './Tile';
+    import TileView, { type ResizeDirection } from './TileView.svelte';
+    import Translate from './Translate.svelte';
 
     interface Props {
         project: Project;
@@ -1692,6 +1692,13 @@
                                             >
                                         </div>
                                     {/if}
+                                    {#if $largeDeletionNotification}
+                                        <div
+                                            class="large-deletion-notification"
+                                        >
+                                            {$largeDeletionNotification}
+                                        </div>
+                                    {/if}
                                     {#if $blocks}
                                         <div class="editor-warning"
                                             >This editing mode is experimental. <Link
@@ -2010,5 +2017,28 @@
         padding: var(--wordplay-spacing);
         background: var(--wordplay-error);
         color: var(--wordplay-background);
+    }
+
+    .large-deletion-notification {
+        width: 100%;
+        padding: var(--wordplay-spacing);
+        background: black;
+        color: white;
+        border: 1px solid black;
+        animation: popUp 0.6s ease-out;
+    }
+
+    @keyframes popUp {
+        0% {
+            transform: scale(0.8);
+            opacity: 0;
+        }
+        50% {
+            transform: scale(1.05);
+            opacity: 1;
+        }
+        100% {
+            transform: scale(1);
+        }
     }
 </style>

--- a/src/locale/UITexts.ts
+++ b/src/locale/UITexts.ts
@@ -2,9 +2,12 @@ import type { SupportedFace } from '../basis/Fonts';
 import type { TileKind } from '../components/project/Tile';
 import type { DocText, Template } from './LocaleText';
 
+import type CheckpointsText from '@components/project/CheckpointsText';
 import type ErrorText from '../routes/ErrorText';
 import type LandingPageText from '../routes/PageText';
 import type AboutPageText from '../routes/about/PageText';
+import type CharacterPageText from '../routes/character/[id]/PageText';
+import type CharactersPageText from '../routes/characters/PageText';
 import type DonatePageText from '../routes/donate/PageText';
 import type GalleriesPageText from '../routes/galleries/PageText';
 import type GalleryPageText from '../routes/gallery/[galleryid]/PageText';
@@ -18,9 +21,6 @@ import type TeachPageText from '../routes/teach/PageText';
 import type ClassPageText from '../routes/teach/class/[classid]/PageText';
 import type NewClassPageText from '../routes/teach/class/new/PageText';
 import type EditTexts from './EditTexts';
-import type CheckpointsText from '@components/project/CheckpointsText';
-import type CharactersPageText from '../routes/characters/PageText';
-import type CharacterPageText from '../routes/character/[id]/PageText';
 
 export type ButtonText = {
     /** The buttons label */
@@ -347,6 +347,8 @@ type UITexts = {
             tidy: string;
             /** Toggle elision */
             elide: string;
+            /** Large deletion notification */
+            largeDelete: string;
         };
         error: {
             /** An invalid source name */

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -4315,7 +4315,7 @@
                 "search": "search for special characters to insert",
                 "tidy": "tidy spacing",
                 "elide": "toggle elision",
-                "largeDelete": "Are you sure you want to delete this selection? You can use the undo button (↺) if you change your mind."
+                "largeDelete": "That was a big deletion. You can undo if it was an accident."
             },
             "error": {
                 "invalidName": "This must be a valid Wordplay name.",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1546,9 +1546,9 @@
         },
         "Text": {
             "doc": [
-                "I can be any text you like, from any language, and using any of these symbols opening and closing symbols: \\\"\"\\, \\“”\\, \\„“\\, \\''\\, \\‘’\\, \\‹›\\, \\«»\\, \\「」\\, or \\『』\\.",
+                "I can be any text you like, from any language, and using any of these symbols as opening and closing symbols: \"\" , “”, „”, '' , ‘’, ‹›, «», 「」, or 『』.",
                 "To illustrate, consider these beautiful phrases",
-                "\\“There are only two ways to live your life. One is as though nothing is a miracle. The other is as though everything is a miracle.”\\",
+                "\"There are only two ways to live your life. One is as though nothing is a miracle. The other is as though everything is a miracle.\"",
                 "\\『一日三秋』\\",
                 "Just remember to close me if you open me, and use the matching symbol. Otherwise I won't know that you're done with your words.",
                 "\\'hello'/en'hola'/es-MX\\",
@@ -4314,7 +4314,8 @@
                 "redo": "redo undone edit",
                 "search": "search for special characters to insert",
                 "tidy": "tidy spacing",
-                "elide": "toggle elision"
+                "elide": "toggle elision",
+                "largeDelete": "Are you sure you want to delete this selection? You can use the undo button (↺) if you change your mind."
             },
             "error": {
                 "invalidName": "This must be a valid Wordplay name.",

--- a/static/schemas/LocaleText.json
+++ b/static/schemas/LocaleText.json
@@ -11958,6 +11958,10 @@
                       "description": "Insert • symbol",
                       "type": "string"
                     },
+                    "largeDelete": {
+                      "description": "Large deletion notification text",
+                      "type": "string"
+                    },
                     "lineEnd": {
                       "description": "Move cursor to line end",
                       "type": "string"
@@ -12085,7 +12089,8 @@
                     "redo",
                     "search",
                     "tidy",
-                    "elide"
+                    "elide",
+                    "largeDelete"
                   ],
                   "type": "object"
                 },


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue # 499
-   Closes #

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

 Verified on Chrome and Safari that when a large deletion occurs, the notification pops up with the desired black background, white text, and smooth pop-up animation.
• Confirmed that triggering undo via the undo button or pressing Ctrl/Cmd+Z immediately clears the notification.
• Checked that subsequent edits clear any existing notification as expected.
Accessibility:
• The notification message reads clearly with white text on a black background.
• The pop-up animation is subtle and does not impede interaction.

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->

[x] Inline the large deletion notification store in Editor.svelte
[x] Changed the notification message to display the actual arrow icon (↺).
[x] Updated ProjectView.svelte to import the inline store & apply custom styling (black background, white text, 1px solid black border, pop-up animation).
[x] Added logic to clear the notification on an undo event.


<img width="1470" alt="Screenshot 2025-02-07 at 8 40 45 PM" src="https://github.com/user-attachments/assets/4faa38a6-da07-4f6b-88ab-f1d5b2a0f5ce" />

