### PR TITLE
Fixed #675 - Update copy for invalidUsername in the sign up page

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -5073,7 +5073,7 @@
                     "expired": "This link expired.",
                     "invalid": "This link isn't valid.",
                     "email": "Not a valid email.",
-                    "invalidUsername": "Usernames must be emails or >5 letters with no spaces.",
+                    "invalidUsername": "Usernames must be emails or at least 5 letters with no spaces.",
                     "failure": "Unable to login :(",
                     "offline": "We couldn't reach the cloud ☁️.",
                     "unchanged": "We couldn't change your email address, but we don't know why.",


### PR DESCRIPTION
# Context
The usernames with length of 5 characters are allowed. Update copy to write at least instead of >5

Check #675 
<!-- Briefly describe what this issue is about -->

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Closes #675

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->
<img width="288" alt="Screenshot 2025-02-12 at 6 23 58 PM" src="https://github.com/user-attachments/assets/2d4ea0d0-6acf-4b91-96ae-f31b866cdb0e" />

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
- [x] - Manual test

