### PR TITLE
643 page resizing button

### DIFF
--- a/src/components/app/TutorialHighlight.svelte
+++ b/src/components/app/TutorialHighlight.svelte
@@ -54,8 +54,10 @@
     style:left={bounds ? `${bounds.left}px` : undefined}
     style:top={bounds ? `${bounds.top}px` : undefined}
 >
-    {#if index !== undefined && uiids.length > 1}
-        <span class="number">{index}</span>
+    {#if bounds} <!-- Only render when bounds exists -->
+        {#if index !== undefined && uiids.length > 1}
+            <span class="number">{index}</span>
+        {/if}
     {/if}
 </span>
 

--- a/src/components/app/TutorialHighlight.svelte
+++ b/src/components/app/TutorialHighlight.svelte
@@ -50,11 +50,11 @@
     class:source
     data-uiidtohighlight={id}
     class:hovering={bounds !== undefined && id !== undefined}
-    
     style:left={bounds ? `${bounds.left}px` : undefined}
     style:top={bounds ? `${bounds.top}px` : undefined}
 >
-    {#if bounds} <!-- Only render when bounds exists -->
+    {#if bounds}
+        <!-- Only render when bounds exists -->
         {#if index !== undefined && uiids.length > 1}
             <span class="number">{index}</span>
         {/if}
@@ -78,7 +78,6 @@
 
         transform-origin: center;
         position: relative;
-
     }
 
     .hovering {
@@ -88,10 +87,6 @@
         transform: translate(-50%, -50%);
         z-index: 2;
         pointer-events: none;
-    }
-
-    .hidden {
-        display: none;
     }
 
     .number {

--- a/src/components/app/TutorialHighlight.svelte
+++ b/src/components/app/TutorialHighlight.svelte
@@ -50,6 +50,7 @@
     class:source
     data-uiidtohighlight={id}
     class:hovering={bounds !== undefined && id !== undefined}
+    
     style:left={bounds ? `${bounds.left}px` : undefined}
     style:top={bounds ? `${bounds.top}px` : undefined}
 >
@@ -72,6 +73,10 @@
         animation-duration: 1s;
         animation-iteration-count: infinite;
         align-items: center;
+
+        transform-origin: center;
+        position: relative;
+
     }
 
     .hovering {
@@ -81,6 +86,10 @@
         transform: translate(-50%, -50%);
         z-index: 2;
         pointer-events: none;
+    }
+
+    .hidden {
+        display: none;
     }
 
     .number {
@@ -97,10 +106,10 @@
 
     @keyframes glow {
         from {
-            transform: scale(1);
+            transform: scale(0.3);
         }
         to {
-            transform: scale(2);
+            transform: scale(1);
         }
     }
 </style>


### PR DESCRIPTION
# **Context**  

This PR fixes a bug where clicking the button covered by the "highlight button" caused the highlight to be displaced to the bottom-right corner of the screen. Additionally, this increased and decreased the screen size, leading to a disruptive user experience. The issue was caused by the `TutorialHighlight.svelte`  continuing to render even when the target element was no longer available. The fix ensures that the highlight is not rendered when `bounds` is `undefined`, preventing the UI from shifting unexpectedly.  Additionally, to fix this bug, I also adjusted the size of the highlight effect from **2 to 1** to **1 to 0.3**, making the highlight more subtle and visually refined.

# **Verification**  

To reproduce the original bug, clicking on any highlight button at the full screen would cause the highlight to shift to the bottom-right corner of the screen. This was due to the highlight continuing to render despite the target element being removed. Additionally, the highlight animation was too large for its current space.  

To verify the fix, I tested clicking multiple highlight buttons across different window sizes to ensure that the highlight no longer resizes the screen. The highlight now appears only when relevant and disappears when necessary, improving both usability and visual clarity.  

# **Final Improvements**  

This fix makes sure that the highlight functionality behaves as expected without interfering with other elements. It also improves the overall user experience by making the highlight less overwhelming by not causing the screen to flash.

