### PR TITLE
Add description to browser selection in defect issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -32,6 +32,8 @@ body:
       id: browsers
       attributes:
           label: What browsers are you seeing the problem on?
+          description: |
+              If the problem is on multiple browsers, reopen the dropdown and choose each one individually.
           multiple: true
           options:
               - Firefox


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->
The dropdown field in the browser selection prompt allows the reporter to select multiple options, but the GitHub UI doesn't make that obvious. Add a description that clarifies that the reporter needs to select options one by one if they wish to specify multiple browsers.

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->
-   Closes #714 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
