### PR TITLE
665: Project previews should show custom emoji

### DIFF
--- a/functions/.env.local
+++ b/functions/.env.local
@@ -1,0 +1,1 @@
+SMTP_PASSWORD=

--- a/functions/.env.local
+++ b/functions/.env.local
@@ -1,1 +1,0 @@
-SMTP_PASSWORD=

--- a/src/components/app/ProjectPreview.svelte
+++ b/src/components/app/ProjectPreview.svelte
@@ -16,12 +16,12 @@
     import CreatorView from './CreatorView.svelte';
     import Link from './Link.svelte';
     import Spinning from './Spinning.svelte';
-    // new added
     import type { Character } from '../../db/characters/Character';
     import { characterToSVG } from '../../db/characters/Character';
     import ConceptLink, { CharacterName } from '../../nodes/ConceptLink';
     import MarkupValue from '../../values/MarkupValue';
     import Value from '../../values/Value';
+    import StructureValue from '@values/StructureValue';
 
     interface Props {
         project: Project;
@@ -52,24 +52,13 @@
         }
 
         // If it's a StructureValue, check all its fields recursively
-        if (
-            value &&
-            value.constructor &&
-            value.constructor.name === 'StructureValue' &&
-            (value as any).context &&
-            (value as any).context.getBindingsByNames
-        ) {
-            const structureValue = value as any;
-            // Get all bindings from the context
-            const bindings = structureValue.context.getBindingsByNames();
-
-            // Loop through each binding and check if it contains a character name
-            for (const [_, fieldValue] of bindings) {
-                const result = findCharacterName(fieldValue);
-                if (result) return result;
+        if (value instanceof StructureValue) {
+            const bindings = value.context.getBindingsByNames();
+            for (const [, fieldValue] of bindings) {
+            const result = findCharacterName(fieldValue);
+            if (result) return result;
             }
         }
-
         return null;
     }
 


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->
This pull request addresses an issue in the ProjectPreview component where custom emoji characters were not being displayed properly. The bug was caused by incomplete parsing of character names from StructureValue or MarkupValue instances, which led to fallback rendering instead of the correct emoji SVG.

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue # 665 Project previews should show custom emoji

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->
npm run dev-Manually tested in Chrome
Checked that regular character previews continue to render properly.

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->

Fixed character preview rendering issue in `ProjectPreview.svelte`
Updated `findCharacterName` to support `StructureValue`
Verified custom emoji characters display correctly
Manually tested in Chrome