### PR TITLE
Fix the tab selection

### DIFF
--- a/src/components/settings/LocaleChooser.svelte
+++ b/src/components/settings/LocaleChooser.svelte
@@ -80,8 +80,9 @@
             .concretize((l) => l.ui.dialog.locale.subheader.selected)
             .toText()}</h2
     >
+
     <div class="languages">
-        {#each selectedLocales as selected}
+        {#each selectedLocales as selected (selected)}
             <Button
                 action={() => select(selected, 'remove')}
                 tip={(l) => l.ui.dialog.locale.button.remove}
@@ -98,20 +99,21 @@
             .toText()}</h2
     >
     <div class="supported">
-        {#each SupportedLocales.filter((supported) => !selectedLocales.some((locale) => locale === supported)) as supported}
+        {#each SupportedLocales.filter((supported) => !selectedLocales.includes(supported)) as supported (supported)}
             <div class="option">
                 <Button
                     action={() => select(supported, 'replace')}
                     tip={(l) => l.ui.dialog.locale.button.replace}
-                    ><LocaleName locale={supported} supported /></Button
                 >
+                    <LocaleName locale={supported} supported />
+                </Button>
+
                 <Button
                     action={() => select(supported, 'add')}
                     tip={(l) => l.ui.dialog.locale.button.add}
                     icon="+"
-                ></Button>
+                />
             </div>
-        {:else}&mdash;
         {/each}
     </div>
 


### PR DESCRIPTION
# Context

<!--  When navigating the “Language” dialog with Tab + Enter, Svelte was reusing DOM nodes by index (because our `{#each}` blocks weren’t keyed), so the wrong locale button stayed focused and fired. This patch adds explicit keys to both loops so that each `<Button>` is tracked by its locale code rather than its array index.-->

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #760 
-   Closes #760

## Verification

<!-- I verified these changes locally on my development machine by manually navigating the Language dialog using both keyboard and mouse. In LanguagePicker.svelte, I updated the two {#each} loops inside the <Dialog>: the selectedLocales loop was changed from {#each selectedLocales as selected} to {#each selectedLocales as selected (selected)}. And the SupportedLocales loop was changed from {#each SupportedLocales.filter(...) as supported} to {#each SupportedLocales.filter(...) as supported (supported)}--> After adding those keys, Tab+Enter correctly targets the focused button (e.g. “China” or the “+” next to “France”), and I confirmed with mouse-clicks that all click behavior remains unchanged.


## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
