### PR TITLE
Bugfixes for how-to permission issues

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -168,7 +168,7 @@ service cloud.firestore {
       // 0) a moderator
       // 1) owner or collaborator
       // 2) curator of the gallery the how-to is in
-      // we also allow updating the social interactions of a how-to as long as the user can view it
+      // we also allow updating the social interactions of a how-to as long as the user can view it (viewer, owner, collaborator, gallery curator or collaborator)
       // and updating xcoord, ycoord by how-to owner/collaborator and gallery curator/collaborator
         if request.auth != null && 
           (
@@ -177,16 +177,19 @@ service cloud.firestore {
             ("galleryId" in request.resource.data && isRequestorCurator(request.auth.uid, request.resource.data.galleryId)) ||
             ('galleryId' in request.resource.data && 
               (
-                isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || 
-                isRequestorOwnerCollaborator(request.auth.uid)
-              ) && 
-              (
-                request.resource.data.diff(resource.data).affectedKeys().hasOnly(["xcoord", "ycoord"]) ||
                 (
-                  'galleryId' in request.resource.data && request.resource.data.diff(resource.data).affectedKeys().hasOnly(["social"]) && 
-                  (isGalleryPublic(resource.data.galleryId) || isRequestorViewer(request.auth.uid))
+                  isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || 
+                  isRequestorOwnerCollaborator(request.auth.uid)
+                ) && 
+                request.resource.data.diff(resource.data).affectedKeys().hasOnly(["xcoord", "ycoord"])
+              ) ||
+              (
+                request.resource.data.diff(resource.data).affectedKeys().hasOnly(["social"]) && 
+                (
+                  isGalleryPublic(resource.data.galleryId) || isRequestorViewer(request.auth.uid) || 
+                  isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || isRequestorOwnerCollaborator(request.auth.uid)
                 )
-              )
+              )  
             )
           );
       allow delete: if request.auth != null && (resource.data.creator == request.auth.uid || isRequestorCurator(request.auth.uid, resource.data.galleryId));

--- a/src/components/concepts/Documentation.svelte
+++ b/src/components/concepts/Documentation.svelte
@@ -161,7 +161,12 @@
         if (gallery) {
             HowTos.getHowTos(gallery.getHowTos()).then(
                 (hts: GalleryHowTo[] | undefined | false) => {
-                    if (hts) galleryHowTos = hts;
+                    if (hts) {
+                        galleryHowTos = hts;
+                        galleryHowTos = galleryHowTos.filter((ht) =>
+                            ht.isPublished(),
+                        );
+                    }
                 },
             );
         } else if (standalone) {

--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -179,6 +179,10 @@ export default class HowTo {
         return this.data.viewersFlat;
     }
 
+    hasViewer(userId: string) {
+        return this.data.viewersFlat.includes(userId);
+    }
+
     getLocales() {
         return this.data.locales;
     }

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1,7 +1,9 @@
 {
     "$schema": "../../static/schemas/LocaleText.json",
     "language": "en",
-    "regions": ["US"],
+    "regions": [
+        "US"
+    ],
     "wordplay": "Wordplay",
     "term": {
         "bind": "bind",
@@ -1682,7 +1684,10 @@
                 "Some use the keyboard (/ctrl+9/ for \\⊤\\ and /ctrl+0/ for \\⊥\\). Some use the character search at the bottom of the editor. Or you can drag us from here.",
                 "Check out our @FunctionDefinition below. They're very logical."
             ],
-            "name": ["⊤⊥", "Boolean"],
+            "name": [
+                "⊤⊥",
+                "Boolean"
+            ],
             "function": {
                 "and": {
                     "doc": [
@@ -1692,7 +1697,10 @@
                         "\\⊥ & ⊤\\",
                         "\\⊥ & ⊥\\"
                     ],
-                    "names": ["&", "and"],
+                    "names": [
+                        "&",
+                        "and"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other @Boolean to check. If the first is \\⊥\\, it doesn't matter what this is, the function will evaluate to \\⊥\\.",
@@ -1708,7 +1716,10 @@
                         "\\⊥ | ⊤\\",
                         "\\⊥ | ⊥\\"
                     ],
-                    "names": ["|", "or"],
+                    "names": [
+                        "|",
+                        "or"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other @Boolean to check. If the first is \\⊥\\, the function will only evaluate to \\⊤\\ if this is \\⊤\\.",
@@ -1718,12 +1729,18 @@
                 },
                 "not": {
                     "doc": "I get the opposite of myself: if \\⊤\\, it gives \\⊥\\, if \\⊥\\, it gives \\⊤\\.",
-                    "names": ["~", "not"],
+                    "names": [
+                        "~",
+                        "not"
+                    ],
                     "inputs": []
                 },
                 "equals": {
                     "doc": "\\⊤\\ if both are \\⊤\\ or both are \\⊥\\.",
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other value to check.",
@@ -1733,7 +1750,10 @@
                 },
                 "notequal": {
                     "doc": "\\⊤\\ if both are opposites.",
-                    "names": ["≠", "notequal"],
+                    "names": [
+                        "≠",
+                        "notequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other value to check.",
@@ -1751,11 +1771,17 @@
                 "/Hi, @FunctionDefinition here. @None doesn't like to say much, so I'll interpret./",
                 "I am @None. Invoke me with \\ø\\. I am helpful when you want to represent the absense of something."
             ],
-            "name": ["ø", "None"],
+            "name": [
+                "ø",
+                "None"
+            ],
             "function": {
                 "equals": {
                     "doc": "Is another value also nothing? It better be, otherwise, \\⊥\\.",
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other value.",
@@ -1765,7 +1791,10 @@
                 },
                 "notequals": {
                     "doc": "Is another value /not/ nothing?",
-                    "names": ["≠", "notequal"],
+                    "names": [
+                        "≠",
+                        "notequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other value.",
@@ -1795,7 +1824,10 @@
                 "See how 192 turned into @FunctionDefinition? I hear you call these numbers 'Unicode'.",
                 "Otherwise, there just so many glorious functions that @FunctionDefinition made for me to do all kinds of things with words!"
             ],
-            "name": ["''", "Text"],
+            "name": [
+                "''",
+                "Text"
+            ],
             "function": {
                 "length": {
                     "doc": [
@@ -1803,12 +1835,18 @@
                         "\\'hello'.length()\\",
                         "\\'🐈📚'.length()\\"
                     ],
-                    "names": ["📏", "length"],
+                    "names": [
+                        "📏",
+                        "length"
+                    ],
                     "inputs": []
                 },
                 "equals": {
                     "doc": "\\⊤\\ if I am the same character sequence as the given @Text.",
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Text to compare.",
@@ -1831,7 +1869,10 @@
                         "\\⊤\\ if the given @Text appears in me.",
                         "\\'did you find what you were looking for?'.has('you')\\"
                     ],
-                    "names": ["⊆", "has"],
+                    "names": [
+                        "⊆",
+                        "has"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Text to search for in me.",
@@ -1845,7 +1886,9 @@
                         "\\'hello verse!'.starts('hello')\\",
                         "\\'hello verse!'.starts('verse')\\"
                     ],
-                    "names": ["starts"],
+                    "names": [
+                        "starts"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Text to check for at the start of me.",
@@ -1859,7 +1902,9 @@
                         "\\'am I a question?'.ends('?')\\",
                         "\\'I am not a question.'.ends('?')\\"
                     ],
-                    "names": ["ends"],
+                    "names": [
+                        "ends"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Text to check for at the end of me.",
@@ -1877,7 +1922,12 @@
                         "\\'hi ' · -5\\",
                         "The longest text I can make is 65,535 characters. If you try to make a longer text, I'll repeat the text as many times as I can."
                     ],
-                    "names": ["·", "🔁", "repeated", "repeat"],
+                    "names": [
+                        "·",
+                        "🔁",
+                        "repeated",
+                        "repeat"
+                    ],
                     "inputs": [
                         {
                             "doc": "The number of times to repeat myself in the new text.",
@@ -1892,7 +1942,11 @@
                         "If the separator is an empty @Text, I divide myself into characters:",
                         "\\'🖌️🏠🥸' ÷ ''\\"
                     ],
-                    "names": ["÷", "segmented", "segment"],
+                    "names": [
+                        "÷",
+                        "segmented",
+                        "segment"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Text to use as a separator.",
@@ -1905,7 +1959,11 @@
                         "Sometimes it's helpful to combine to @Text into one. Give me another @Text and I'll make a new text that joins us together:",
                         "\\'hello ' + 'verse'\\"
                     ],
-                    "names": ["+", "combined", "combine"],
+                    "names": [
+                        "+",
+                        "combined",
+                        "combine"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Text to append.",
@@ -1943,7 +2001,10 @@
                 "There is no digit '2' in base 2, so it's not a valid number. NaN will also show up if you try to convert non-number text to number",
                 "\\'hi'→#\\"
             ],
-            "name": ["#", "Number"],
+            "name": [
+                "#",
+                "Number"
+            ],
             "function": {
                 "add": {
                     "doc": [
@@ -1954,7 +2015,10 @@
                         "If the units don't match, I halt the show.",
                         "\\3cat + 5dog\\"
                     ],
-                    "names": ["+", "add"],
+                    "names": [
+                        "+",
+                        "add"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to add.",
@@ -1971,7 +2035,10 @@
                         "If the units don't match, I halt the show.",
                         "\\3cat - 5dog\\"
                     ],
-                    "names": ["-", "subtract"],
+                    "names": [
+                        "-",
+                        "subtract"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to subtract from me.",
@@ -1986,7 +2053,10 @@
                         "\\5m · 5m\\",
                         "\\5m · 1/s\\"
                     ],
-                    "names": ["·", "multiply"],
+                    "names": [
+                        "·",
+                        "multiply"
+                    ],
                     "inputs": [
                         {
                             "doc": "The number to multiply.",
@@ -2001,7 +2071,10 @@
                         "\\5m ÷ 5m\\",
                         "\\5m ÷ 5s\\"
                     ],
-                    "names": ["÷", "divide"],
+                    "names": [
+                        "÷",
+                        "divide"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to divide me by.",
@@ -2016,7 +2089,10 @@
                         "\\10m % 2\\",
                         "\\10m/s % 3\\"
                     ],
-                    "names": ["%", "remainder"],
+                    "names": [
+                        "%",
+                        "remainder"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to divide me by.",
@@ -2029,7 +2105,9 @@
                         "I create a new @Number that makes me positive, if negative.",
                         "\\-200.positive()\\"
                     ],
-                    "names": ["positive"],
+                    "names": [
+                        "positive"
+                    ],
                     "inputs": []
                 },
                 "round": {
@@ -2039,7 +2117,9 @@
                         "\\9.5.round()\\",
                         "\\9.6.round()\\"
                     ],
-                    "names": ["round"],
+                    "names": [
+                        "round"
+                    ],
                     "inputs": []
                 },
                 "roundDown": {
@@ -2049,7 +2129,9 @@
                         "\\10.1.roundDown()\\",
                         "\\10.01.roundDown()\\"
                     ],
-                    "names": ["roundDown"],
+                    "names": [
+                        "roundDown"
+                    ],
                     "inputs": []
                 },
                 "roundUp": {
@@ -2059,7 +2141,9 @@
                         "\\10.9.roundUp()\\",
                         "\\10.99.roundUp()\\"
                     ],
-                    "names": ["roundUp"],
+                    "names": [
+                        "roundUp"
+                    ],
                     "inputs": []
                 },
                 "power": {
@@ -2069,7 +2153,10 @@
                         "\\10 ^ -2\\",
                         "\\5 ^ -.5\\"
                     ],
-                    "names": ["^", "power"],
+                    "names": [
+                        "^",
+                        "power"
+                    ],
                     "inputs": [
                         {
                             "doc": "The exponent to raise me to.",
@@ -2083,7 +2170,10 @@
                         "\\4 √ 2\\",
                         "\\1000 √ 3\\"
                     ],
-                    "names": ["√", "root"],
+                    "names": [
+                        "√",
+                        "root"
+                    ],
                     "inputs": [
                         {
                             "doc": "The root to compute.",
@@ -2097,7 +2187,10 @@
                         "\\1 < 2\\",
                         "\\2 < 1\\"
                     ],
-                    "names": ["<", "lessthan"],
+                    "names": [
+                        "<",
+                        "lessthan"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to compare me to.",
@@ -2112,7 +2205,10 @@
                         "\\2 ≤ 1\\",
                         "\\2 ≤ 2\\"
                     ],
-                    "names": ["≤", "lessorequal"],
+                    "names": [
+                        "≤",
+                        "lessorequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to compare me to.",
@@ -2126,7 +2222,10 @@
                         "\\1 > 2\\",
                         "\\2 > 1\\"
                     ],
-                    "names": [">", "greaterthan"],
+                    "names": [
+                        ">",
+                        "greaterthan"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to compare me to.",
@@ -2141,7 +2240,10 @@
                         "\\2 ≥ 1\\",
                         "\\2 ≥ 2\\"
                     ],
-                    "names": ["≥", "greaterorequal"],
+                    "names": [
+                        "≥",
+                        "greaterorequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to compare me to.",
@@ -2155,7 +2257,10 @@
                         "\\1 = 2\\",
                         "\\2 = 2\\"
                     ],
-                    "names": ["=", "equal"],
+                    "names": [
+                        "=",
+                        "equal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to compare me to.",
@@ -2169,7 +2274,10 @@
                         "\\1 ≠ 2\\",
                         "\\2 ≠ 2\\"
                     ],
-                    "names": ["≠", "notequal"],
+                    "names": [
+                        "≠",
+                        "notequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Number to compare me to.",
@@ -2178,13 +2286,25 @@
                     ]
                 },
                 "cos": {
-                    "doc": ["Compute the cosine of me.", "\\π.cos()\\"],
-                    "names": ["cos", "cosine"],
+                    "doc": [
+                        "Compute the cosine of me.",
+                        "\\π.cos()\\"
+                    ],
+                    "names": [
+                        "cos",
+                        "cosine"
+                    ],
                     "inputs": []
                 },
                 "sin": {
-                    "doc": ["Compute the sine of me.", "\\π.cos()\\"],
-                    "names": ["sin", "sine"],
+                    "doc": [
+                        "Compute the sine of me.",
+                        "\\π.cos()\\"
+                    ],
+                    "names": [
+                        "sin",
+                        "sine"
+                    ],
                     "inputs": []
                 },
                 "min": {
@@ -2283,7 +2403,10 @@
                 "\\['apple' 'banana' 'mango']!\\",
                 "That's kind of it. But I can do call kinds of exciting things with my @FunctionDefinition!"
             ],
-            "name": ["[]", "List"],
+            "name": [
+                "[]",
+                "List"
+            ],
             "kind": "Kind",
             "out": "Result",
             "outofbounds": "outofbounds",
@@ -2293,7 +2416,10 @@
                         "I create a new @List with the given item at the end.",
                         "\\['apple' 'banana' 'mango'].with('watermelon')\\"
                     ],
-                    "names": ["with", "add"],
+                    "names": [
+                        "with",
+                        "add"
+                    ],
                     "inputs": [
                         {
                             "doc": "I am the value you want to add.",
@@ -2308,7 +2434,10 @@
                         "It's a little bit easier to use @Spread though, like this:",
                         "\\['apple' 'banana' 'mango' :['watermelon' 'starfruit']]\\"
                     ],
-                    "names": ["withList", "append"],
+                    "names": [
+                        "withList",
+                        "append"
+                    ],
                     "inputs": [
                         {
                             "doc": "The list of values to add.",
@@ -2321,7 +2450,9 @@
                         "I create a new list that replaces the value at the given index with the given value.",
                         "\\['apple' 'banana' 'mango'].replace(1 'kiwi')\\"
                     ],
-                    "names": ["replace"],
+                    "names": [
+                        "replace"
+                    ],
                     "inputs": [
                         {
                             "doc": "The index of the value to replace",
@@ -2335,7 +2466,10 @@
                 },
                 "length": {
                     "doc": "The @Number of items in me.",
-                    "names": ["📏", "length"],
+                    "names": [
+                        "📏",
+                        "length"
+                    ],
                     "inputs": []
                 },
                 "random": {
@@ -2425,7 +2559,10 @@
                         "I create a list without my first item.",
                         "\\['apple' 'banana' 'mango'].sansFirst()\\"
                     ],
-                    "names": ["withoutFirst", "sansFirst"],
+                    "names": [
+                        "withoutFirst",
+                        "sansFirst"
+                    ],
                     "inputs": []
                 },
                 "sansLast": {
@@ -2433,7 +2570,10 @@
                         "I create a list without my last item.",
                         "\\['apple' 'banana' 'mango'].sansLast()\\"
                     ],
-                    "names": ["withoutLast", "sansLast"],
+                    "names": [
+                        "withoutLast",
+                        "sansLast"
+                    ],
                     "inputs": []
                 },
                 "sans": {
@@ -2441,7 +2581,10 @@
                         "Me, but without the first occurences of the given value.",
                         "\\['apple' 'banana' 'mango' 'apple'].sans('apple')\\"
                     ],
-                    "names": ["without", "sans"],
+                    "names": [
+                        "without",
+                        "sans"
+                    ],
                     "inputs": [
                         {
                             "doc": "The value to remove the first occurence of.",
@@ -2454,7 +2597,10 @@
                         "Me, but without all occurences of the given value.",
                         "\\['apple' 'banana' 'mango' 'apple'].sans('apple')\\"
                     ],
-                    "names": ["withoutAll", "sansAll"],
+                    "names": [
+                        "withoutAll",
+                        "sansAll"
+                    ],
                     "inputs": [
                         {
                             "doc": "The value to remove all occurences of from the list.",
@@ -2467,7 +2613,10 @@
                         "Me, but in reverse!",
                         "\\['apple' 'banana' 'mango'].reverse()\\"
                     ],
-                    "names": ["reversed", "reverse"],
+                    "names": [
+                        "reversed",
+                        "reverse"
+                    ],
                     "inputs": []
                 },
                 "equals": {
@@ -2475,7 +2624,10 @@
                         "\\⊤\\ if my items and order are the exact same as the given @List.",
                         "\\['apple' 'banana' 'mango'] = ['apple' 'mango' 'banana']\\"
                     ],
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @List to compare me to.",
@@ -2488,7 +2640,10 @@
                         "\\⊤\\ if my items and order are /not/ the exact same as the given @List.",
                         "\\['apple' 'banana' 'mango'] ≠ ['apple' 'mango' 'banana']\\"
                     ],
-                    "names": ["≠", "notequal"],
+                    "names": [
+                        "≠",
+                        "notequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @List to compare me to.",
@@ -2642,7 +2797,10 @@
                         "This is really helpful for combining all of the items in me into a single value. For example, imagine you wanted to add a list of numbers:",
                         "\\[3 9 2 8 1 4].combine(0 ƒ(sum•# number•#) sum + number)\\"
                     ],
-                    "names": ["combined", "combine"],
+                    "names": [
+                        "combined",
+                        "combine"
+                    ],
                     "inputs": [
                         {
                             "doc": "The starting combination.",
@@ -2718,7 +2876,10 @@
                 "\\{'hey' 'hi' 'hello'}!{'yo'}\\",
                 "Is there something else you want to do with me? Check out all the neat @FunctionDefinition I have!"
             ],
-            "name": ["{}", "Set"],
+            "name": [
+                "{}",
+                "Set"
+            ],
             "kind": "Kind",
             "out": "Result",
             "function": {
@@ -2732,7 +2893,10 @@
                         "I'm \\⊤\\ if the given @Set and I have the exact same values:",
                         "\\{1 2 3} = {2 3 4}\\"
                     ],
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Set to compare.",
@@ -2745,7 +2909,10 @@
                         "I'm \\⊤\\ if the given @Set and I don't have the exact same values:",
                         "\\{1 2 3} ≠ {2 3 4}\\"
                     ],
-                    "names": ["≠", "notequal"],
+                    "names": [
+                        "≠",
+                        "notequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Set to compare.",
@@ -2758,7 +2925,11 @@
                         "Give me an item to add and I'll make a new @Set with my items and the given item.",
                         "\\{1 2 3} + 4\\"
                     ],
-                    "names": ["with", "add", "+"],
+                    "names": [
+                        "with",
+                        "add",
+                        "+"
+                    ],
                     "inputs": [
                         {
                             "doc": "The item to add",
@@ -2772,7 +2943,10 @@
                         "\\{1 2 3} - 2\\",
                         "If I don't have the item, I'll just evaluate to myself."
                     ],
-                    "names": ["remove", "-"],
+                    "names": [
+                        "remove",
+                        "-"
+                    ],
                     "inputs": [
                         {
                             "doc": "The item to remove.",
@@ -2785,7 +2959,10 @@
                         "Give me @Set and I'll create a new @Set that has my items and the set's items.",
                         "\\{1 2 3} ∪ {3 4 5}\\"
                     ],
-                    "names": ["union", "∪"],
+                    "names": [
+                        "union",
+                        "∪"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Set to combine with me.",
@@ -2798,7 +2975,10 @@
                         "Give me @Set and I'll create a new @Set that has only the items we have in common.",
                         "\\{1 2 3} ∩ {3 4 5}\\"
                     ],
-                    "names": ["intersection", "∩"],
+                    "names": [
+                        "intersection",
+                        "∩"
+                    ],
                     "inputs": [
                         {
                             "doc": "The set to compare with me.",
@@ -2891,7 +3071,10 @@
                 "\\{1:1 2:2 3:3}!{4}\\",
                 "I know how to many wonderful things with my pairings."
             ],
-            "name": ["{:}", "Map"],
+            "name": [
+                "{:}",
+                "Map"
+            ],
             "key": "Key",
             "value": "Value",
             "result": "Result",
@@ -2906,7 +3089,10 @@
                         "\\{⊤}\\ if my pairings are the exact same as the given @Map's.",
                         "\\{1:1 2:2} = {1:1 2:3}\\"
                     ],
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Map to compare me to.",
@@ -2919,7 +3105,10 @@
                         "\\{⊤}\\ if my pairings are /not/ the exact same as the given @Map's.",
                         "\\{1:1 2:2} ≠ {1:1 2:3}\\"
                     ],
-                    "names": ["≠", "notequal"],
+                    "names": [
+                        "≠",
+                        "notequal"
+                    ],
                     "inputs": [
                         {
                             "doc": "The @Map to compare me to.",
@@ -3049,12 +3238,18 @@
                 "And if you ever want to get specific values from me, you can convert any table to a list and access individual rows with @PropertyReference",
                 "\\rocks: ⎡name•'' color•''⎦\n⎡'obsidian' 'black'⎦\n⎡'pumice' 'grey'⎦\n⎡'citrine' 'yellow'⎦\n(rocks → [])[1].name\\"
             ],
-            "name": ["⎡⎦", "Table"],
+            "name": [
+                "⎡⎦",
+                "Table"
+            ],
             "row": "Row",
             "function": {
                 "equals": {
                     "doc": "I check if I have the exact same cells in the exact same order as another @Table.",
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other table to check.",
@@ -3064,7 +3259,10 @@
                 },
                 "notequal": {
                     "doc": "I check if any of my cells are different or in a different order from another @Table.",
-                    "names": ["≠", "notEquals"],
+                    "names": [
+                        "≠",
+                        "notEquals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other table to check.",
@@ -3080,11 +3278,16 @@
         },
         "Structure": {
             "doc": "See @StructureDefinition.",
-            "name": ["Structure"],
+            "name": [
+                "Structure"
+            ],
             "function": {
                 "equals": {
                     "doc": "I check if my properties are the same name and values as another structure's properties.",
-                    "names": ["=", "equals"],
+                    "names": [
+                        "=",
+                        "equals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other structure to check.",
@@ -3094,7 +3297,10 @@
                 },
                 "notequal": {
                     "doc": "I check if my properties are different in any way from the name and values as another structure's.",
-                    "names": ["≠", "notEquals"],
+                    "names": [
+                        "≠",
+                        "notEquals"
+                    ],
                     "inputs": [
                         {
                             "doc": "The other structure to check.",
@@ -3126,7 +3332,10 @@
                 "And if you give numbers with particular numbers of significant digits after the decimal point, that precision will be preserved.",
                 "\\Random(1.00 10.00)\\"
             ],
-            "names": ["🎲", "Random"],
+            "names": [
+                "🎲",
+                "Random"
+            ],
             "inputs": [
                 {
                     "names": "min",
@@ -3148,7 +3357,10 @@
                 "\\Group(\nStack() \n[\nPhrase('one' selectable:⊤ name:'1') \nPhrase('two' selectable:⊤ name:'2') \nPhrase(Choice())\n]\n)\\",
                 "Copy this into the editor and then select one of the two @Phrase. You'll see the third @Phrase shows the name that was selected."
             ],
-            "names": ["🔘", "Choice"]
+            "names": [
+                "🔘",
+                "Choice"
+            ]
         },
         "Button": {
             "doc": [
@@ -3160,7 +3372,10 @@
                 "\\Phrase(Button() → '')\\",
                 "This just makes a @Phrase that is the value of the stream as text. If you copy it into the editor and click, you'll see it toggle back and forth between \\⊥\\ and \\⊤\\."
             ],
-            "names": ["🖱️", "Button"],
+            "names": [
+                "🖱️",
+                "Button"
+            ],
             "down": {
                 "names": "down",
                 "doc": "If @None, the stream will provide both up and down values. If @Boolean, it will only provide value the given @Boolean value."
@@ -3176,7 +3391,10 @@
                 "\\Pointer()\\",
                 "The @Place it provides will correspond to where on @Stage the pointer is pointing."
             ],
-            "names": ["👆🏻", "Pointer"]
+            "names": [
+                "👆🏻",
+                "Pointer"
+            ]
         },
         "Key": {
             "doc": [
@@ -3193,7 +3411,10 @@
                 "And if you only want to know when when a @Key is released instead of pressed, you can provide a @Boolean:",
                 "\\Key('a' ⊥)\\"
             ],
-            "names": ["⌨️", "Key"],
+            "names": [
+                "⌨️",
+                "Key"
+            ],
             "key": {
                 "names": "key",
                 "doc": "If @None, than all keys are provided. If a specific @Text, then only that key is provided."
@@ -3216,13 +3437,20 @@
                 "However, there are limits to how small it can be, since @Program needs time to evaluate before they can respond to the next tick.",
                 "The smallest is probably around \\20ms\\."
             ],
-            "names": ["🕕", "Time"],
+            "names": [
+                "🕕",
+                "Time"
+            ],
             "frequency": {
-                "names": ["frequency"],
+                "names": [
+                    "frequency"
+                ],
                 "doc": "This is the frequency with which time should tick. It defaults to \\33ms\\, which is about 30 times per second."
             },
             "relative": {
-                "names": ["relative"],
+                "names": [
+                    "relative"
+                ],
                 "doc": "If \\⊤\\, time starts at 0, when the program is first evaluated. Otherwise, it starts at the number of milliseconds since the start of today, UTC (Coordinated Universal Time), allowing you to keep track of the time of day."
             }
         },
@@ -3234,9 +3462,14 @@
                 "\\Volume()\\",
                 "This is great for listening to how loud the audience is!"
             ],
-            "names": ["🎤", "Volume"],
+            "names": [
+                "🎤",
+                "Volume"
+            ],
             "frequency": {
-                "names": ["frequency"],
+                "names": [
+                    "frequency"
+                ],
                 "doc": "The time between samplings."
             }
         },
@@ -3248,9 +3481,14 @@
                 "\\Pitch()\\",
                 "This is great for listening the tone that someone is speaking or singing."
             ],
-            "names": ["🎵", "Pitch"],
+            "names": [
+                "🎵",
+                "Pitch"
+            ],
             "frequency": {
-                "names": ["frequency"],
+                "names": [
+                    "frequency"
+                ],
                 "doc": "The time between samplings."
             }
         },
@@ -3263,17 +3501,26 @@
                 "\\colors: Camera(32px 24px 33ms)\n\nStage(\ncolors.combine(\n[] \nƒ(phrases•[Phrase] row•[Color] y•#) \nphrases.append(\nrow.translate(\nƒ(color•Color x•#)\nPhrase('o' place: Place((x - 1) · 0.5m y · -0.5m) color: color duration: 0s\n)\n)\n)\n)\n)\\",
                 "But you could also analyze the colors to decide if a light was on or off, or if a particular color was common, letting the audience influence a performance with the colors they show."
             ],
-            "names": ["🎥", "Camera"],
+            "names": [
+                "🎥",
+                "Camera"
+            ],
             "width": {
-                "names": ["width"],
+                "names": [
+                    "width"
+                ],
                 "doc": "The number of @Color to sample in a row."
             },
             "height": {
-                "names": ["height"],
+                "names": [
+                    "height"
+                ],
                 "doc": "The number of @Color to sample in a column."
             },
             "frequency": {
-                "names": ["frequency"],
+                "names": [
+                    "frequency"
+                ],
                 "doc": "The time between @Color samples."
             }
         },
@@ -3293,7 +3540,10 @@
                 "\\click: ∆ Button()\nScene([\n\tPhrase('Hello')\n\tclick\n\tPhrase('How are you?' duration: 0.25s rotation: 5° entering: Pose(rotation: 0°))\n\tclick\n\tPhrase('I am fine')\n])\\",
                 "See how it pauses after each @Phrase, and waits for @Button to change before advancing?"
             ],
-            "names": ["🎬", "Scene"],
+            "names": [
+                "🎬",
+                "Scene"
+            ],
             "outputs": {
                 "names": "outputs",
                 "doc": "The list of outputs to show in sequence."
@@ -3309,7 +3559,10 @@
                 "See how the o bounces? On the first evaluation, we give it a place up high on @Stage, but then after, it gets @None, which allows @Motion to change it to whatever position gravity would place it.",
                 "Check out the many other ways to configure it below."
             ],
-            "names": ["⚽️", "Motion"],
+            "names": [
+                "⚽️",
+                "Motion"
+            ],
             "place": {
                 "doc": "The starting place.",
                 "names": "place"
@@ -3335,7 +3588,10 @@
                 "\\Chat().has('hello') ? 'hi!' 'huh?'\\",
                 "That's it! You can make all kinds of performances with this, like chat bots, text adventures, or text-based control schemes for other kinds of performances."
             ],
-            "names": ["🗣️", "Chat"]
+            "names": [
+                "🗣️",
+                "Chat"
+            ]
         },
         "Placement": {
             "doc": [
@@ -3348,7 +3604,10 @@
                 "Try copying this to your program and moving us arrowed with the pointer or keyboard.",
                 "You can customize the @Placement, enabling and disabling movement on certain dimensions, changing how far a @Place moves, and the initial @Place the stream starts with."
             ],
-            "names": ["✥", "Placement"],
+            "names": [
+                "✥",
+                "Placement"
+            ],
             "inputs": [
                 {
                     "doc": "The initial place to start with.",
@@ -3382,7 +3641,10 @@
                 "\\Webpage('https://wordplay.dev' 'h1')\\",
                 "Lots of things can go wrong with this one. If you lose your internet connection, or the URL doesn't resolve to anything, or the URL isn't public, or the URL isn't an HTML page… All of these can lead to exception. If if you find a page that works, you'll get some @Number indicating a percent commplete and then a @List of the words on the page."
             ],
-            "names": ["🔗", "Webpage"],
+            "names": [
+                "🔗",
+                "Webpage"
+            ],
             "url": {
                 "doc": "The HTML webpage URL to get.",
                 "names": "url"
@@ -3468,7 +3730,10 @@
                 "\\Group(Stack() [Phrase('first') Phrase('second')])\\",
                 "How exactly I arrange things depend on the @Arrangement you give me."
             ],
-            "names": ["🔳", "Group"],
+            "names": [
+                "🔳",
+                "Group"
+            ],
             "layout": {
                 "doc": "The arrangement to use to put @Output in their places.",
                 "names": "layout"
@@ -3487,14 +3752,19 @@
             },
             "face": {
                 "doc": "The name of the font face content inside me should have, unless they have their own face to use.",
-                "names": ["face", "font"]
+                "names": [
+                    "face",
+                    "font"
+                ]
             },
             "place": {
                 "doc": "The place on stage where I should be. The content inside me will be arranged relative to there.",
                 "names": "place"
             },
             "name": {
-                "doc": ["The same as @Phrase/name!"],
+                "doc": [
+                    "The same as @Phrase/name!"
+                ],
                 "names": "name"
             },
             "description": {
@@ -3525,7 +3795,10 @@
             },
             "rotation": {
                 "doc": "How tilted should I be around my center, my @Pose has a different one.",
-                "names": ["📐", "rotation"]
+                "names": [
+                    "📐",
+                    "rotation"
+                ]
             },
             "scale": {
                 "doc": "How big I should be relative to my original size.",
@@ -3557,7 +3830,10 @@
             },
             "duration": {
                 "doc": "Same as @Phrase/duration!",
-                "names": ["⏳", "duration"]
+                "names": [
+                    "⏳",
+                    "duration"
+                ]
             },
             "style": {
                 "doc": "Same as @Phrase/style!",
@@ -3574,7 +3850,10 @@
                 "You can also optionally give me everything an @Output can do, including changing my size, font, rotation, and do all of my incredible dances with @Pose and @Sequence.",
                 "You can also select me on @Stage and edit me on the palette next door."
             ],
-            "names": ["💬", "Phrase"],
+            "names": [
+                "💬",
+                "Phrase"
+            ],
             "text": {
                 "doc": "The characters to show on @Stage, a @TextLiteral or @FormattedLiteral.",
                 "names": "text"
@@ -3593,7 +3872,10 @@
             },
             "wrap": {
                 "doc": "The edge at which I should wrap symbols or \\ø\\ if I shouldn't wrap them.",
-                "names": ["↵", "wrap"]
+                "names": [
+                    "↵",
+                    "wrap"
+                ]
             },
             "alignment": {
                 "doc": "If there's a @Phrase/wrap boundary set, whether I should align symbols to the start, center, or end of edge.",
@@ -3681,7 +3963,10 @@
             },
             "duration": {
                 "doc": "The duration to apply when moving to a different place on stage.",
-                "names": ["⏳", "duration"]
+                "names": [
+                    "⏳",
+                    "duration"
+                ]
             },
             "style": {
                 "doc": "The animation style to use when moving to a different place on stage.",
@@ -3691,11 +3976,17 @@
         },
         "Arrangement": {
             "doc": "I am an inspiration to the many other kinds of arrangment in the Verse, including @Row, @Stack, @Grid, and @Free. I work closely with @Group to ",
-            "names": ["⠿", "Arrangement"]
+            "names": [
+                "⠿",
+                "Arrangement"
+            ]
         },
         "Row": {
             "doc": "I am @Row, a horizontal @Arrangement of @Output, with optional padding in between. Have you met my twin, @Stack?",
-            "names": ["➡", "Row"],
+            "names": [
+                "➡",
+                "Row"
+            ],
             "description": "row of $1 phrases and groups",
             "alignment": {
                 "doc": "Whether to align text at the start, center, or end on each column.",
@@ -3708,7 +3999,10 @@
         },
         "Stack": {
             "doc": "I am @Stack, a vertical @Arrangement of @Output, with optional padding in between. Have you met my twin, @Row? ",
-            "names": ["⬇", "Stack"],
+            "names": [
+                "⬇",
+                "Stack"
+            ],
             "description": "stack of $1 phrases and groups",
             "alignment": {
                 "doc": "Whether to align text at the start, center, or end on each row.",
@@ -3721,7 +4015,10 @@
         },
         "Grid": {
             "doc": "I am grid of @Output. Give me a row and column count and I'll make a tidy arrangement with optional padding and cell sizes.",
-            "names": ["▦", "Grid"],
+            "names": [
+                "▦",
+                "Grid"
+            ],
             "description": "$1 row $2 column grid",
             "rows": {
                 "doc": "How many rows in make in the grid.",
@@ -3749,12 +4046,17 @@
                 "I'm like, whatever. Sit wherever you want. Just sit somewhere! Make sure all the @Output you give me have a @Place, otherwise they won't know where to go.",
                 "Oh, and remember that the @Place you give each @Output is relative to the @Group's @Place! So if you're wondering why things aren't appearing where you expect, try giving the @Group a place too."
             ],
-            "names": ["Free"],
+            "names": [
+                "Free"
+            ],
             "description": "free-form $1 outputs"
         },
         "Shape": {
             "doc": "I'm an inspiration to all shapes. I'm useful for telling @Stage what shape to be.",
-            "names": ["⬟", "Shape"],
+            "names": [
+                "⬟",
+                "Shape"
+            ],
             "form": {
                 "doc": "I'm the kind of shape to show. Each shape requires different information to define its arrangement.",
                 "names": "form"
@@ -3832,11 +4134,15 @@
         },
         "Form": {
             "doc": "I am an abstract form, like a @Rectangle or @Circle.",
-            "names": ["Form"]
+            "names": [
+                "Form"
+            ]
         },
         "Rectangle": {
             "doc": "I am a rectangle, useful for making @Stage have a boundary the size of your choosing.",
-            "names": ["Rectangle"],
+            "names": [
+                "Rectangle"
+            ],
             "left": {
                 "doc": "The left edge of the stage on the x-axis",
                 "names": "left"
@@ -3860,7 +4166,9 @@
         },
         "Circle": {
             "doc": "I am a circle, useful for making shapes on @Stage.",
-            "names": ["Circle"],
+            "names": [
+                "Circle"
+            ],
             "radius": {
                 "doc": "The radius of the circle",
                 "names": "radius"
@@ -3880,7 +4188,9 @@
         },
         "Polygon": {
             "doc": "I am a 'regular' polygon with equal length sides and angles, useful for making shapes on @Stage.",
-            "names": ["Polygon"],
+            "names": [
+                "Polygon"
+            ],
             "radius": {
                 "doc": "The radius of the polygon",
                 "names": "radius"
@@ -3907,7 +4217,10 @@
                 "You know when someone strikes the most amazing way of standing, a pauses, and everyone looks? That's me. I capture a pose for @Output to be in, and am the building block of their movements.",
                 "So much goes into a pose. Check out my many inputs to see what kinds of poses you might make!"
             ],
-            "names": ["🤪", "Pose"],
+            "names": [
+                "🤪",
+                "Pose"
+            ],
             "style": {
                 "doc": "The style of animation to use when moving to this pose.",
                 "names": "style"
@@ -3959,18 +4272,30 @@
                 "\\Color(50% 100 300°)\\",
                 "\\Color(50% 100 330°)\\"
             ],
-            "names": ["🌈", "Color"],
+            "names": [
+                "🌈",
+                "Color"
+            ],
             "lightness": {
                 "doc": "How light I should be from \\0\\ to \\1\\, from black at \\0\\, to grey at \\0.5\\, to white at \\1\\.",
-                "names": ["lightness", "l"]
+                "names": [
+                    "lightness",
+                    "l"
+                ]
             },
             "chroma": {
                 "doc": "How much color I should have, from \\0\\ to \\∞\\. No color means grey, higher numbers mean the more color.",
-                "names": ["chroma", "c"]
+                "names": [
+                    "chroma",
+                    "c"
+                ]
             },
             "hue": {
                 "doc": "What color I should be, on a color wheel, from magenta \\0\\, red \\30\\, green \\120\\, to blue \\270\\.",
-                "names": ["hue", "h"]
+                "names": [
+                    "hue",
+                    "h"
+                ]
             }
         },
         "Sequence": {
@@ -3982,14 +4307,20 @@
                 "This says, /at the beginning (0%), start at tilt 360, and end at tilt 0/. That'll spin us around in circles forever, since I'm set as the @Phrase's rest pose!",
                 "Try your own creative dances by playing with other inputs."
             ],
-            "names": ["💃", "Sequence"],
+            "names": [
+                "💃",
+                "Sequence"
+            ],
             "poses": {
                 "doc": "A @Map of percentages between 0% and 100%, each paired with a @Pose. You don't have to provide all the percents; I will smoothly move a @Output between the ones you give me.",
                 "names": "poses"
             },
             "duration": {
                 "doc": "How long should I do this dance? If I'm to repeat it, I won't add any time to the duration, I'll just dance faster.",
-                "names": ["⏳", "duration"]
+                "names": [
+                    "⏳",
+                    "duration"
+                ]
             },
             "style": {
                 "doc": "The style should I use to for the dance.",
@@ -4006,7 +4337,10 @@
         },
         "Place": {
             "doc": "I'm a location on @Stage. All my inputs are optional, because I'm at the center by default.",
-            "names": ["📍", "Place"],
+            "names": [
+                "📍",
+                "Place"
+            ],
             "x": {
                 "doc": "A position on the x-axis.",
                 "names": "x"
@@ -4021,12 +4355,18 @@
             },
             "rotation": {
                 "doc": "Rotation at this position",
-                "names": ["📐", "rotation"]
+                "names": [
+                    "📐",
+                    "rotation"
+                ]
             }
         },
         "Velocity": {
             "doc": "I'm a location on @Stage. All my inputs are optional, because I'm at the center by default.",
-            "names": ["💨", "Velocity"],
+            "names": [
+                "💨",
+                "Velocity"
+            ],
             "x": {
                 "doc": "How many meters to move each second on the x-axis.",
                 "names": "x"
@@ -4037,12 +4377,18 @@
             },
             "angle": {
                 "doc": "How many degrees to rotate each second",
-                "names": ["angle", "°"]
+                "names": [
+                    "angle",
+                    "°"
+                ]
             }
         },
         "Matter": {
             "doc": "I'm physical properties of output, which influence how I interact with other output on stage.",
-            "names": ["⚛️", "Matter"],
+            "names": [
+                "⚛️",
+                "Matter"
+            ],
             "mass": {
                 "doc": "A weight, in kilograms",
                 "names": "mass"
@@ -4073,7 +4419,10 @@
                 "I am an AURA. I make @Phrase GLOW! Like this:",
                 "\\Phrase(\n\t'I am GLOWING!' \n\taura: Aura(Color(50% 100 118°) 0.1m 0m 0.1m\n)\\"
             ],
-            "names": ["🔮", "Aura"],
+            "names": [
+                "🔮",
+                "Aura"
+            ],
             "color": {
                 "doc": "The @Color the @Aura should be.",
                 "names": "color"
@@ -4100,7 +4449,10 @@
                 "YOU MAY ALSO GIVE ME A FRAME BORDER AND I WILL CROP.",
                 "\\Stage([Phrase('stufffffff')] background: Color(75% 50 100°) frame: Rectangle(-1m -1m 1m 1m))\\"
             ],
-            "names": ["🎭", "Stage"],
+            "names": [
+                "🎭",
+                "Stage"
+            ],
             "content": {
                 "doc": "The list of @Output to show on stage.",
                 "names": "content"
@@ -4122,7 +4474,9 @@
                 "names": "place"
             },
             "name": {
-                "doc": ["SAME AS @Phrase/name!"],
+                "doc": [
+                    "SAME AS @Phrase/name!"
+                ],
                 "names": "name"
             },
             "description": {
@@ -4153,7 +4507,10 @@
             },
             "rotation": {
                 "doc": "SAME AS @Group/rotation",
-                "names": ["📐", "rotation"]
+                "names": [
+                    "📐",
+                    "rotation"
+                ]
             },
             "scale": {
                 "doc": "SAME AS @Group/scale",
@@ -4185,7 +4542,10 @@
             },
             "duration": {
                 "doc": "SAME AS @Phrase/duration!",
-                "names": ["⏳", "duration"]
+                "names": [
+                    "⏳",
+                    "duration"
+                ]
             },
             "style": {
                 "doc": "SAME AS @Phrase/style!",
@@ -4206,39 +4566,57 @@
         "sequence": {
             "sway": {
                 "doc": "I create a @Sequence that sways back and forth around a @Output's center.",
-                "names": ["sway"],
+                "names": [
+                    "sway"
+                ],
                 "angle": {
                     "doc": "How much to tilt in the sway.",
-                    "names": ["angle"]
+                    "names": [
+                        "angle"
+                    ]
                 }
             },
             "bounce": {
                 "doc": "I create a @Sequence that bounces @Output a given height.",
-                "names": ["bounce"],
+                "names": [
+                    "bounce"
+                ],
                 "height": {
                     "doc": "How high to bounce.",
-                    "names": ["height"]
+                    "names": [
+                        "height"
+                    ]
                 }
             },
             "spin": {
                 "doc": "I create a @Sequence that rotates @Output around its center.",
-                "names": ["spin"]
+                "names": [
+                    "spin"
+                ]
             },
             "fadein": {
                 "doc": "I create a @Sequence that fades @Output in from invisible to visible.",
-                "names": ["fadein"]
+                "names": [
+                    "fadein"
+                ]
             },
             "fadeout": {
                 "doc": "I create a @Sequence that fades @Output from visible to invisible. Try me in an exiting @Sequence!",
-                "names": ["fadeout"]
+                "names": [
+                    "fadeout"
+                ]
             },
             "popup": {
                 "doc": "I create a @Sequence that makes @Output scale in quickly than shrink to its normal size.",
-                "names": ["popup"]
+                "names": [
+                    "popup"
+                ]
             },
             "shake": {
                 "doc": "I create a @Sequence that makes it look like a @Output is scared.",
-                "names": ["shake"]
+                "names": [
+                    "shake"
+                ]
             }
         },
         "Source": {
@@ -4469,7 +4847,7 @@
                 "header": "How-tos",
                 "subheader": "$1 how-tos, $2 new",
                 "subheaderEmpty": "create the first!",
-                "prompt": "How-tos are short explanations and example code for how to do something with Wordplay. When you figure how something you want to share, write one for the other creators in this gallery, so they can learn it to!"
+                "prompt": "How-tos are short explanations and example code for how to do something with Wordplay. When you figure how something you want to share, write one for the other creators in this gallery, so they can learn it too!"
             },
             "headerTooltip": "go back to gallery",
             "drafts": {
@@ -4518,7 +4896,10 @@
                 },
                 "notification": {
                     "label": "notify subscribers",
-                    "labels": ["notify", "do not notify"],
+                    "labels": [
+                        "notify",
+                        "do not notify"
+                    ],
                     "tips": [
                         "notify subscribers when you post this how-to",
                         "do not notify subscribers when you post this how-to"
@@ -4594,7 +4975,10 @@
                     },
                     "mode": {
                         "label": "default visibility",
-                        "labels": ["limited", "expanded"],
+                        "labels": [
+                            "limited",
+                            "expanded"
+                        ],
                         "tips": [
                             "only collaborators of this gallery can view",
                             "collaborators of any gallery any curator creates can view"
@@ -4895,7 +5279,10 @@
             "mode": {
                 "browse": {
                     "label": "section",
-                    "labels": ["code", "how-to"],
+                    "labels": [
+                        "code",
+                        "how-to"
+                    ],
                     "tips": [
                         "programming language concepts",
                         "reusable patterns for making projects"
@@ -5057,7 +5444,10 @@
                 "mode": {
                     "public": {
                         "label": "visibility",
-                        "labels": ["private", "public"],
+                        "labels": [
+                            "private",
+                            "public"
+                        ],
                         "tips": [
                             "only you and collaborators can see this project",
                             "anyone can see this project"
@@ -5131,7 +5521,11 @@
                     },
                     "dark": {
                         "label": "theme",
-                        "labels": ["light", "dark", "auto"],
+                        "labels": [
+                            "light",
+                            "dark",
+                            "auto"
+                        ],
                         "tips": [
                             "lighter colors",
                             "darker colors",
@@ -5140,12 +5534,21 @@
                     },
                     "blocks": {
                         "label": "editor",
-                        "labels": ["text", "blocks"],
-                        "tips": ["edit code as text", "edit code as blocks"]
+                        "labels": [
+                            "text",
+                            "blocks"
+                        ],
+                        "tips": [
+                            "edit code as text",
+                            "edit code as blocks"
+                        ]
                     },
                     "space": {
                         "label": "space indicator",
-                        "labels": ["hide", "show"],
+                        "labels": [
+                            "hide",
+                            "show"
+                        ],
                         "tips": [
                             "do not show space and tab indicators",
                             "show space and tab indicators explicitly"
@@ -5153,7 +5556,10 @@
                     },
                     "lines": {
                         "label": "line numbers",
-                        "labels": ["hide", "show"],
+                        "labels": [
+                            "hide",
+                            "show"
+                        ],
                         "tips": [
                             "do not show line numbers in text mode",
                             "show line numbers in text mode"
@@ -5186,7 +5592,10 @@
                 "open": "open notifications dialog",
                 "howToNotifications": {
                     "label": "notifications for new how-tos",
-                    "labels": ["off", "on"],
+                    "labels": [
+                        "off",
+                        "on"
+                    ],
                     "tips": [
                         "do not notify me of new how-tos",
                         "notify me of new how-tos"
@@ -5256,7 +5665,10 @@
                 },
                 "mode": {
                     "label": "feedback",
-                    "labels": ["defects", "ideas"],
+                    "labels": [
+                        "defects",
+                        "ideas"
+                    ],
                     "tips": [
                         "report something that seems broken",
                         "suggest new features or improvements"
@@ -5692,7 +6104,10 @@
                     },
                     "public": {
                         "label": "visibility",
-                        "labels": ["public", "private"],
+                        "labels": [
+                            "public",
+                            "private"
+                        ],
                         "tips": [
                             "anyone can see this character",
                             "only you and collaborators can see this character"
@@ -5732,7 +6147,11 @@
                     },
                     "fill": {
                         "label": "fill",
-                        "labels": ["none", "inerit", "choose"],
+                        "labels": [
+                            "none",
+                            "inerit",
+                            "choose"
+                        ],
                         "tips": [
                             "no fill",
                             "inherit fill color from surrounding text",
@@ -5741,7 +6160,11 @@
                     },
                     "stroke": {
                         "label": "stroke",
-                        "labels": ["none", "inerit", "choose"],
+                        "labels": [
+                            "none",
+                            "inerit",
+                            "choose"
+                        ],
                         "tips": [
                             "no stroke",
                             "inherit stroke color from surrounding text",

--- a/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
@@ -342,6 +342,16 @@
     }
 
     function updateCollaborators(toChangeID: string, add: boolean) {
+        // must be a gallery creator, curator, or how-to viewer to be added
+        if (
+            !(
+                howTo?.hasViewer(toChangeID) ||
+                gallery?.hasCurator(toChangeID) ||
+                gallery?.hasCreator(toChangeID)
+            )
+        )
+            return;
+
         if (add) {
             if (!allCollaborators.includes(toChangeID))
                 allCollaborators.push(toChangeID);
@@ -562,7 +572,7 @@
             </Labeled>
         </div>
         <div class="toolbar">
-            {#if howTo.isCreatorCollaborator($user.uid)}
+            {#if howTo.isCreatorCollaborator($user.uid) || gallery?.hasCurator($user.uid)}
                 <Button
                     tip={(l) => l.ui.howto.viewer.edit.tip}
                     label={(l) => l.ui.howto.viewer.edit.label}

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -3,6 +3,7 @@
     import AddProject from '@components/app/AddProject.svelte';
     import GalleryPreview from '@components/app/GalleryPreview.svelte';
     import Header from '@components/app/Header.svelte';
+    import Link from '@components/app/Link.svelte';
     import Notice from '@components/app/Notice.svelte';
     import ProjectPreviewSet from '@components/app/ProjectPreviewSet.svelte';
     import Spinning from '@components/app/Spinning.svelte';
@@ -19,7 +20,6 @@
         COPY_SYMBOL,
         EDIT_SYMBOL,
     } from '../../parser/Symbols';
-    import Link from '@components/app/Link.svelte';
 
     const user = getUser();
 


### PR DESCRIPTION
# Context

While enumerating tests for #907 , I encountered some bugs in the new how-to feature that need to be fixed. 

1. Allowing viewers to use social features but not move a how-to, but allows gallery curators and collaborators to move a how-to
2. Don't show draft how-tos in the guide
3. Fix typo (to --> too) in the explainer/description text for how-tos.
4. Allow curators to edit any how-to in their gallery (already possible via firestore rules, but adding the button from the frontend that permits it. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #825 #907 
-   Closes #

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

See #907 for list of manual tests

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
