### PR TITLE
Remove social features from public how-tos

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -186,8 +186,9 @@ service cloud.firestore {
               (
                 request.resource.data.diff(resource.data).affectedKeys().hasOnly(["social"]) && 
                 (
-                  isGalleryPublic(resource.data.galleryId) || isRequestorViewer(request.auth.uid) || 
-                  isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || isRequestorOwnerCollaborator(request.auth.uid)
+                  isRequestorViewer(request.auth.uid) || 
+                  isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || 
+                  isRequestorOwnerCollaborator(request.auth.uid)
                 )
               )  
             )

--- a/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
@@ -341,16 +341,17 @@
         HowTos.updateHowTo(howTo, true);
     }
 
+    function isCreatorCollaboratorViewer(uid: string) {
+        return (
+            howTo?.hasViewer(uid) ||
+            gallery?.hasCurator(uid) ||
+            gallery?.hasCreator(uid)
+        );
+    }
+
     function updateCollaborators(toChangeID: string, add: boolean) {
         // must be a gallery creator, curator, or how-to viewer to be added
-        if (
-            !(
-                howTo?.hasViewer(toChangeID) ||
-                gallery?.hasCurator(toChangeID) ||
-                gallery?.hasCreator(toChangeID)
-            )
-        )
-            return;
+        if (!isCreatorCollaboratorViewer(toChangeID)) return;
 
         if (add) {
             if (!allCollaborators.includes(toChangeID))
@@ -558,7 +559,7 @@
                 />
             </div>
         </div>
-    {:else if howTo && howTo.isPublished() && $user}
+    {:else if howTo && howTo.isPublished() && $user && isCreatorCollaboratorViewer($user.uid)}
         <Header>
             {title}
         </Header>
@@ -674,7 +675,7 @@
                 />
             </div>
         </div>
-    {:else if !$user}
+    {:else if !$user || !isCreatorCollaboratorViewer($user.uid)}
         <Header>
             {title}
         </Header>


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

This PR removes the social interactions on how-tos for anyone who isn't explicitly granted access to a how-to by being:
- A creator or collaborator on the how-to
- A curator or creator on the gallery
- A curator or creator on another gallery which grants them expanded scope access

This means that if a gallery is public, its how-tos are visible, but a person who doesn't have access in one of the ways defined above cannot interact with any of the how-tos. 

I've also updated #907, which enumerates manual tests, to reflect this permissions change. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

See #907 for manual tests.

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
