### PR TITLE
Fix defect with how-tos moving when dialog is open

### DIFF
--- a/src/routes/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/gallery/[galleryid]/howto/+page.svelte
@@ -98,17 +98,22 @@
     // if how-to id, then that how-to is moving
     let whichMoving: string | undefined = $state(undefined);
 
+    // doesn't allow how-tos to move while a dialog is open
+    let whichDialogOpen: string | undefined = $state(undefined);
+
     function onpointerdown() {
+        if (whichDialogOpen) return;
+
         whichMoving = 'canvas';
     }
 
     function onpointerup() {
-        if (whichMoving !== 'canvas') return;
+        if (whichMoving !== 'canvas' || whichDialogOpen) return;
         whichMoving = undefined;
     }
 
     function onpointermove(e: PointerEvent) {
-        if (whichMoving !== 'canvas') return;
+        if (whichMoving !== 'canvas' || whichDialogOpen) return;
 
         cameraX += e.movementX;
         cameraY += e.movementY;
@@ -116,10 +121,14 @@
 
     let keyboardFocused: boolean = $state(false);
     function onfocus() {
+        if (whichDialogOpen) return;
+
         keyboardFocused = true;
     }
 
     function onblur() {
+        if (whichDialogOpen) return;
+
         keyboardFocused = false;
 
         if (whichMoving === 'canvas') whichMoving = undefined;
@@ -129,7 +138,8 @@
     function onkeydown(event: KeyboardEvent) {
         if (
             keyboardFocused &&
-            (whichMoving === undefined || whichMoving === 'canvas')
+            (whichMoving === undefined || whichMoving === 'canvas') &&
+            !whichDialogOpen
         ) {
             switch (event.key) {
                 case 'ArrowUp':
@@ -303,6 +313,7 @@
                             bind:cameraX
                             bind:cameraY
                             {notPermittedAreas}
+                            bind:whichDialogOpen
                         />
                     {/if}
 
@@ -358,6 +369,7 @@
                                                     {notPermittedAreas}
                                                     {cameraX}
                                                     {cameraY}
+                                                    bind:whichDialogOpen
                                                 />
                                             </li>
                                         {/if}
@@ -439,6 +451,7 @@
                                 galleryCuratorCollaborators={gallery
                                     .getCurators()
                                     .concat(gallery.getCreators())}
+                                bind:whichDialogOpen
                             />
                         {/if}
                     {/each}

--- a/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
@@ -36,6 +36,7 @@
         cameraX: number;
         cameraY: number;
         preview?: Snippet;
+        whichDialogOpen: string | undefined;
     }
 
     let {
@@ -45,6 +46,7 @@
         cameraX = $bindable(),
         cameraY = $bindable(),
         preview = undefined,
+        whichDialogOpen = $bindable(),
     }: Props = $props();
 
     // utility variables
@@ -72,6 +74,11 @@
 
     // whether to show the preview form or not.
     let show: boolean = $state(false);
+    $effect(() => {
+        if (show) whichDialogOpen = howToId;
+        else if (!show && whichDialogOpen === howToId)
+            whichDialogOpen = undefined;
+    });
 
     // data from the how-to
     let isPublished: boolean = $derived(howTo ? howTo.isPublished() : false);

--- a/src/routes/gallery/[galleryid]/howto/HowToPreview.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToPreview.svelte
@@ -34,6 +34,7 @@
         whichMoving: string | undefined;
         notPermittedAreas: SvelteMap<string, [number, number, number, number]>;
         galleryCuratorCollaborators: string[];
+        whichDialogOpen: string | undefined;
     }
 
     let {
@@ -43,6 +44,7 @@
         whichMoving = $bindable(),
         notPermittedAreas = $bindable(),
         galleryCuratorCollaborators,
+        whichDialogOpen = $bindable(),
     }: Props = $props();
 
     let title: string = $derived(howTo?.getTitle() ?? '');
@@ -212,7 +214,7 @@
     let renderY: number = $derived(ycoord + (isPublished ? cameraY : 0));
 
     function onpointerdown(e: PointerEvent) {
-        if (!canEdit) return;
+        if (!canEdit || whichDialogOpen) return;
 
         e.stopPropagation();
 
@@ -220,7 +222,7 @@
     }
 
     function onpointerup() {
-        if (whichMoving !== howToId || !canEdit) return;
+        if (whichMoving !== howToId || !canEdit || whichDialogOpen) return;
 
         whichMoving = undefined;
 
@@ -229,7 +231,7 @@
 
     // // Drag and drop function referenced from: https://svelte.dev/playground/7d674cc78a3a44beb2c5a9381c7eb1a9?version=5.46.0
     function onpointermove(e: PointerEvent) {
-        if (!canEdit || whichMoving !== howToId) return;
+        if (!canEdit || whichMoving !== howToId || whichDialogOpen) return;
         let intendX = xcoord + e.movementX;
         let intendY = ycoord + e.movementY;
 
@@ -250,13 +252,13 @@
 
     let keyboardFocused: boolean = $state(false);
     function onfocus() {
-        if (!canEdit) return;
+        if (!canEdit || whichDialogOpen) return;
 
         keyboardFocused = true;
     }
 
     function onblur() {
-        if (!canEdit) return;
+        if (!canEdit || whichDialogOpen) return;
 
         keyboardFocused = false;
         if (whichMoving === howToId) whichMoving = undefined;
@@ -266,7 +268,7 @@
 
     // if navigating using a keyboard, the how-to is put "move mode" when arrow keys are used
     function onkeydown(event: KeyboardEvent) {
-        if (!canEdit || !keyboardFocused) return;
+        if (!canEdit || !keyboardFocused || whichDialogOpen) return;
 
         let intendX: number;
         let intendY: number;
@@ -450,6 +452,7 @@
         {cameraX}
         {cameraY}
         {preview}
+        bind:whichDialogOpen
     />
 </div>
 <svelte:window onblur={onpointerup} {onpointerup} {onpointermove} />


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

Defect: Using a mouse to drag within the how-to form dialog moves the how-to in the canvas or moves the canvas itself. I think this is because the dialog is a child of the how-to preview and the preview is a child of the canvas, both of which are movable using a mouse. I added a variable that tracks which dialog is open, and doesn't allow the canvas or the how-to to move if a dialog is open.

https://github.com/user-attachments/assets/b5403d3c-c4d8-4f3a-98a9-d7f0ecf68e31


## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create a how-to, make sure that it is short so that the dialog doesn't block the view of the whole how-to space
2. Move that how-to to the bottom right corner of the canvas so that it is visible when the dialog opens. 
3. Open the dialog. Drag and click within the dialog. Check that the how-to preview nor canvas move as a result of these actions. 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
