### PR TITLE
Adding gallery access check for moderation notifications

### DIFF
--- a/src/components/settings/Notifications.svelte
+++ b/src/components/settings/Notifications.svelte
@@ -94,7 +94,11 @@
                 if (howTo) galleryID = howTo.getHowToGalleryId();
             }
 
-            if (!galleryID || !Galleries.accessibleGalleries.has(galleryID))
+            // No gallery, or creator doesn't have access to gallery? No need for notifications.
+            if (
+                galleryID === null ||
+                !Galleries.accessibleGalleries.has(galleryID)
+            )
                 return;
 
             const gallery = await Galleries.get(galleryID);
@@ -115,7 +119,7 @@
                                 : howTo
                                   ? howTo.getTitle()
                                   : '',
-                        galleryID: galleryID ? galleryID : undefined,
+                        galleryID,
                         itemID: itemID,
                         type: type,
                     } as NotificationData);


### PR DESCRIPTION
# Context

See #945 for full details. 

The notifications system for moderation goes through all of the chats that a user has access to, then checks if there are any messages that require moderation action from the current user. This function requires the gallery as a parameter to check if the user is the curator, which throws an error if the user does not have permission to view the gallery. 

This PR adds a condition that checks if the user has access to the gallery before trying to load it. Checking if the key is in `accessibleGalleries` should be enough, since this is populated when the user logs in, and any gallery that the user curates is in that list. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #945 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

Replicating the steps taken in #945 :

1. Create test accounts A and B.
2. Create a gallery using B. Create a project in that gallery. Add A as a collaborator on the project.
3. Send a chat from account B. Account A should receive a notification with no console errors output. 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
