### PR TITLE
Sorting reactions prior to rendering

### DIFF
--- a/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
@@ -217,10 +217,12 @@
                 : gallery
                   ? gallery.getHowToReactions()
                   : {},
-        ).map(([emoji, description]) => ({
-            label: emoji,
-            tip: description,
-        })),
+        )
+            .map(([emoji, description]) => ({
+                label: emoji,
+                tip: description,
+            }))
+            .sort((a, b) => a.label.localeCompare(b.label)),
     );
 
     function findPlaceToWrite() {


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

The reaction buttons swap around when new reactions are added, which can make it difficult to click the right one. This PR adds a line of code to sort the reaction buttons by their emoji label prior to rendering, so that there is a consistent order.

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #974 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

Checked the buttons appear in a consistent order, but I'm not sure we can replicate the exact conditions observed in class without two people trying to react to a how-to simultaneously.

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
