### PR TITLE
Set maximum height for how-to social features

### DIFF
--- a/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToForm.svelte
@@ -952,12 +952,7 @@
         height: 100%;
     }
 
-    .how-to-text {
-        height: 100%;
-        width: 100%;
-        padding: var(--wordplay-spacing);
-    }
-
+    .how-to-text,
     .how-to-social {
         height: 100%;
         width: 100%;


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

If a how-to is very long, then the chat window stretches vertically so that the message box (where the user types in their message) is at the very bottom, at the same vertical location as the end of the how-to. This is really unusable if the how-to is long. It also makes the scroll behavior confusing. 

This PR sets a max height of the social features of the how-to form, so that the social features are neither too tall nor too short. Instead of the entire right side being scrollable, only the chat is scrollable. This better matches the behavior of the chat in projects. But, the max height is a hardcoded value, and I'm not attached to the particular constant I set. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #975 
-   Closes #975 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create a new how-to that is really long (e.g., a few blocks of code) and post it
2. Start a chat. Verify that the message entry box is not at the very bottom of the dialog
3. Add a bunch of messages. Verify that when the chat has a lot of messages, the scroll bar appears
4. Create a new how-to that is really short (e.g., only one line of text) and post it
5. Start a chat. Verify that the message entry box exists. 
6. Repeat step 3. 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
