### PR TITLE
Show full how-to title as tooltip for preview

### DIFF
--- a/src/routes/gallery/[galleryid]/howto/HowToPreview.svelte
+++ b/src/routes/gallery/[galleryid]/howto/HowToPreview.svelte
@@ -3,6 +3,7 @@
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import {
         getAnnouncer,
+        getTip,
         getUser,
         isAuthenticated,
     } from '@components/project/Contexts';
@@ -255,12 +256,16 @@
 
     let keyboardFocused: boolean = $state(false);
     function onfocus() {
+        showTip();
+
         if (!canEdit || whichDialogOpen) return;
 
         keyboardFocused = true;
     }
 
     function onblur() {
+        hideTip();
+
         if (!canEdit || whichDialogOpen) return;
 
         keyboardFocused = false;
@@ -404,6 +409,17 @@
             }
         });
     });
+
+    let hint = getTip();
+    let previewNode: HTMLDivElement;
+
+    function showTip() {
+        if (previewNode) hint.show(title, previewNode);
+    }
+
+    function hideTip() {
+        hint.hide();
+    }
 </script>
 
 {#snippet preview()}
@@ -444,6 +460,12 @@
     {onfocus}
     {onblur}
     {onkeydown}
+    onpointerenter={showTip}
+    onpointerleave={hideTip}
+    ontouchstart={showTip}
+    ontouchend={hideTip}
+    ontouchcancel={hideTip}
+    bind:this={previewNode}
 >
     <div class="howtotitle"> <MarkupHTMLView markup={title} /></div>
 


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

Only a small segment of the how-to title is shown in the how-to preview, which makes it hard to know what that how-to is actually about. This will get particularly challenging if there are a lot of how-tos that start with the same few words in the title (e.g., "How to <do something>"). This PR adds a tooltip to the how-to preview that shows the full title of the how-to when the user hovers over the how-to preview in the canvas.

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #988 
-   Closes #988 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create a new how-to, preferably with a long title
2. Check that the full title is shown in a tooltip when hovering over any part of the preview that is not the button

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
