### PR TITLE
Fix how-tos not rendering if two how-tos are posted without refreshing the how-to space

### DIFF
--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -536,16 +536,8 @@ export class HowToDatabase {
     }
 
     async getHowTos(howToIds: string[]): Promise<HowTo[]> {
-        let howTos: HowTo[] = [];
-
-        howToIds.forEach(async (howToId) => {
-            const howTo = await this.getHowTo(howToId);
-            if (howTo) {
-                howTos.push(howTo);
-            }
-        });
-
-        return Promise.resolve(howTos);
+        const results = await Promise.all(howToIds.map((id) => this.getHowTo(id)));
+        return results.filter((ht): ht is HowTo => ht !== undefined && ht !== false);
     }
 
     ignore() {

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToForm.svelte
@@ -72,13 +72,14 @@
     // Load the gallery if it exists.
     let gallery = $state<Gallery | undefined>(undefined);
     let galleryQuestions: string[] = $state([]);
-    onMount(async () => {
+    $effect(() => {
         if (galleryID) {
-            gallery = await Galleries.get(galleryID);
-
-            if (gallery) {
-                galleryQuestions = gallery.getHowToGuidingQuestions();
-            }
+            Galleries.get(galleryID).then((g) => {
+                if (g) {
+                    gallery = g;
+                    galleryQuestions = gallery.getHowToGuidingQuestions();
+                }
+            });
         } else {
             gallery = undefined;
         }


### PR DESCRIPTION
# Context

If a user posts two how-tos in a row without moving the camera or refreshing the page, only the second how-to is rendered and the first is not. It turns out that this is because the locally cached version of the gallery and the cloud version fall out of sync; the how-to ID for the first how-to is added, but then overwritten by the second how-to's ID in the local copy, so even though both how-tos exist in the cloud database, the first how-to doesn't exist in the cached local copy. This PR fixes this by reloading the gallery each time the HowToForm component is rendered, not just when the component is mounted. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #1083 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create a new how-to space
2. Create a how-to (titled: test1)
3. Without moving the camera or refreshing the page, create a how-to (titled: test2)
4. Pan the camera to verify that both test1 and test2 exist in the how-to space

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
