### PR TITLE
Fix how-to in Guide panel resetting scroll position when typing in Project editor

### DIFF
--- a/src/components/editor/caret/CaretView.svelte
+++ b/src/components/editor/caret/CaretView.svelte
@@ -89,17 +89,17 @@
 </script>
 
 <script lang="ts">
-    import { measureTokenSegment } from '@components/editor/highlights/measureTokenSegment';
-    import MenuTrigger from '@components/editor/menu/MenuTrigger.svelte';
-    import { getEditor, getEvaluation } from '@components/project/Contexts';
-    import { animationDuration, locales } from '@db/Database';
     import Caret from '@edit/caret/Caret';
     import type { LocaleTextAccessor } from '@locale/Locales';
     import Node from '@nodes/Node';
     import Token from '@nodes/Token';
     import { TAB_TEXT } from '@parser/Spaces';
-    import UnicodeString from '@unicode/UnicodeString';
     import { tick, untrack } from 'svelte';
+    import { animationDuration, locales } from '@db/Database';
+    import UnicodeString from '@unicode/UnicodeString';
+    import { getEditor, getEvaluation } from '@components/project/Contexts';
+    import { measureTokenSegment } from '@components/editor/highlights/measureTokenSegment';
+    import MenuTrigger from '@components/editor/menu/MenuTrigger.svelte';
 
     interface Props {
         /** The current caret state to render */

--- a/src/components/editor/caret/CaretView.svelte
+++ b/src/components/editor/caret/CaretView.svelte
@@ -89,17 +89,17 @@
 </script>
 
 <script lang="ts">
+    import { measureTokenSegment } from '@components/editor/highlights/measureTokenSegment';
+    import MenuTrigger from '@components/editor/menu/MenuTrigger.svelte';
+    import { getEditor, getEvaluation } from '@components/project/Contexts';
+    import { animationDuration, locales } from '@db/Database';
     import Caret from '@edit/caret/Caret';
     import type { LocaleTextAccessor } from '@locale/Locales';
     import Node from '@nodes/Node';
     import Token from '@nodes/Token';
     import { TAB_TEXT } from '@parser/Spaces';
-    import { tick, untrack } from 'svelte';
-    import { animationDuration, locales } from '@db/Database';
     import UnicodeString from '@unicode/UnicodeString';
-    import { getEditor, getEvaluation } from '@components/project/Contexts';
-    import { measureTokenSegment } from '@components/editor/highlights/measureTokenSegment';
-    import MenuTrigger from '@components/editor/menu/MenuTrigger.svelte';
+    import { tick, untrack } from 'svelte';
 
     interface Props {
         /** The current caret state to render */
@@ -146,6 +146,9 @@
 
     /** The HTMLElement rendering this view. */
     let element = $state<HTMLElement | null>(null);
+    let isElementInEditor: boolean = $derived(
+        element ? element.closest('.editor-viewport') !== null : false,
+    );
 
     /** Derive the current token we're on. */
     let token = $derived(caret?.getToken());
@@ -246,7 +249,12 @@
                 !caret.isNode()
             ) {
                 tick().then(() => {
-                    if (element) element.scrollIntoView({ block: 'nearest' });
+                    // Only scroll when inside an editor tile (class set by TileView for source tiles).
+                    // Skipping this in embedded-example contexts (e.g. guide panel how-tos) prevents
+                    // the caret scroll from overriding the panel's own scroll-to-top and causing the
+                    // how-to to appear to open mid-page.
+                    if (element && isElementInEditor)
+                        element.scrollIntoView({ block: 'nearest' });
                     lastScroll = performance.now();
                 });
             }


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

Students reported that the guide panel in the project viewer would scroll back up to the top of a long how-to whenever they typed. When I tried to replicate the issue, my experience was:

1. When I opened the how-to, the how-to would automatically scroll so that the caret positioned at the start of the last Example in the how-to would be just offscreen below the visible range of the how-to. 

<img width="472" height="784" alt="image" src="https://github.com/user-attachments/assets/a29cfc34-2057-47bf-8554-41ed60a8aa79" />

2. I would scroll to a different part of the how-to, then type something into the editor, and the how-to would scroll back to the original view from when I first opened the how-to

It appears that the issue is that Wordplay will always scroll to where the Caret is positioned, which might be explaining why it was scrolling to the position of the last Caret in the guide. Disclosure: I used Claude Code to get help with identifying the cause of the bug. The solution it offered was unnecessarily complicated so I re-wrote it myself -- it checks whether the Caret is in an editor, and if so, scrolls; otherwise, it does not scroll. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #1091 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create a long how-to with multiple examples (I used Adrienne's map how-to for debugging) in a gallery
2. Create a project in the gallery. Open the project editor for that project
3. Open the Guide pane in the project viewer. Verify that the how-to exists.
4. Open that how-to in the Guide pane. Verify that when the how-to is opened, the beginning of the how-to is seen.
5. Scroll to an arbitrary point within the Guide, and take note of where it scrolled to.
6. Type some Wordplay code into the project. Wait until the project re-compiles. Verify that the how-to did not scroll away from the point noted in step 5.
7. Type a lot more code into the project editor, until the source code is longer than can fit in the editor window. Verify that the editor will scroll down to show the last line of code in the source (that is, this change does not impact scrolling in the editor). 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->

- [ ] Editing is still laggy when I am testing locally, in a way that the production version of Wordplay does not lag. However, it is laggy both with and without the changes I made in this PR. This suggests to me that the lag is not due to this PR, but I wanted to note this in case it is introducing lag again. 
- [ ] I am worried that this may break something else in Wordplay