### PR TITLE
Fix inappropriate Chinese localization in table column names

### DIFF
--- a/static/locales/zh-CN/zh-CN.json
+++ b/static/locales/zh-CN/zh-CN.json
@@ -5992,13 +5992,13 @@
                 "col": {
                     "component": "$~成分",
                     "preview": "$~预览",
-                    "variable": "$~值",
+                    "variable": "值",
                     "color": "$~颜色",
                     "hex": "$~十六进制",
                     "description": "$~描述",
                     "cssvalue": "$~CSS值",
                     "computed": "$~计算",
-                    "primaryface": "$~主要使用"
+                    "primaryface": "主要使用"
                 },
                 "demo": {
                     "button": "$~例子",

--- a/static/locales/zh-CN/zh-CN.json
+++ b/static/locales/zh-CN/zh-CN.json
@@ -5992,13 +5992,13 @@
                 "col": {
                     "component": "$~成分",
                     "preview": "$~预览",
-                    "variable": "$~多变的",
+                    "variable": "$~值",
                     "color": "$~颜色",
                     "hex": "$~十六进制",
                     "description": "$~描述",
                     "cssvalue": "$~CSS值",
                     "computed": "$~计算",
-                    "primaryface": "$~主要面部"
+                    "primaryface": "$~主要使用"
                 },
                 "demo": {
                     "button": "$~例子",


### PR DESCRIPTION
Fixes #1074
Fixes #1075

- variable: "多变的" → "值" (#1074)
- primaryface: "主要面部" → "主要使用" (#1075)

This is a resubmission of #1076 which was closed due to the fork being deleted.