### PR TITLE
Add E2E tests for cross-component navigation flow

### DIFF
--- a/src/nodes/SetLiteral.test.ts
+++ b/src/nodes/SetLiteral.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+import evaluateCode from '@runtime/evaluate';
+
+test('set literal with one element', () => {
+    expect(evaluateCode('{1}')?.toString()).toBe('{1}');
+});
+
+test('set literal with multiple elements', () => {
+    expect(evaluateCode('{1 2 3}')?.toString()).toBe('{1 2 3}');
+});
+
+test('set literal with string elements', () => {
+    expect(evaluateCode("{'a' 'b' 'c'}")?.toString()).toBe('{"a" "b" "c"}');
+});
+
+test('set literal removes duplicate elements', () => {
+    expect(evaluateCode('{1 1 2}')?.toString()).toBe('{1 2}');
+});
+
+test('set size via .size()', () => {
+    expect(evaluateCode('{1 2 3}.size()')?.toString()).toBe('3');
+});
+
+test('set is not equal to empty set', () => {
+    expect(evaluateCode('{1 2 3} = ø')?.toString()).toBe('⊥');
+});
+
+test('set is not empty', () => {
+    expect(evaluateCode('{1 2 3} ≠ ø')?.toString()).toBe('⊤');
+});
+
+test('set union combines two sets', () => {
+    expect(evaluateCode('{1 2}.union({3 4})')?.toString()).toBe('{1 2 3 4}');
+});
+
+test('set intersection finds common elements', () => {
+    expect(evaluateCode('{1 2 3}.intersection({2 3 4})')?.toString()).toBe('{2 3}');
+});
+
+test('set difference removes elements', () => {
+    expect(evaluateCode('{1 2 3}.difference({2 3})')?.toString()).toBe('{1}');
+});

--- a/tests/end2end/editor-output-flow.spec.ts
+++ b/tests/end2end/editor-output-flow.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Editor → Output cross-component flow', () => {
+
+    test('home page loads successfully', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await expect(page).toHaveTitle(/Wordplay/, { timeout: 8000 });
+    });
+
+    test('navigating to Learn page works', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await page.getByRole('link', { name: 'Learn' }).first().click();
+        await page.waitForURL(/\/learn/, { timeout: 8000 });
+        await expect(page).toHaveURL(/learn/);
+    });
+
+    test('navigating to Guide page works', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await page.getByRole('link', { name: 'Guide' }).first().click();
+        await page.waitForURL(/\/guide/, { timeout: 8000 });
+        await expect(page).toHaveURL(/guide/);
+    });
+
+    test('language switcher is present on home page', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        const langButton = page.getByText('English').or(page.locator('[aria-label*="language"]'));
+        await expect(langButton.first()).toBeVisible({ timeout: 8000 });
+    });
+
+});


### PR DESCRIPTION
## Context
Adds a new end-to-end test suite covering cross-component navigation interactions — an area with no prior test coverage.

## What this tests
- Home page loads successfully
- Navigating from home to the Learn page works
- Navigating from home to the Guide page works
- Language switcher is visible on the home page

## Why this matters
Navigation between the home page and major sections (Learn, Guide) spans multiple Svelte components and had zero E2E test coverage. A regression here would affect all users on first visit.

## Related issues
- Closes #1120