### PR TITLE
Add unit tests for SetLiteral node

### DIFF
--- a/src/nodes/SetLiteral.test.ts
+++ b/src/nodes/SetLiteral.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+import evaluateCode from '@runtime/evaluate';
+
+test('set literal with one element', () => {
+    expect(evaluateCode('{1}')?.toString()).toBe('{1}');
+});
+
+test('set literal with multiple elements', () => {
+    expect(evaluateCode('{1 2 3}')?.toString()).toBe('{1 2 3}');
+});
+
+test('set literal with string elements', () => {
+    expect(evaluateCode("{'a' 'b' 'c'}")?.toString()).toBe('{"a" "b" "c"}');
+});
+
+test('set literal removes duplicate elements', () => {
+    expect(evaluateCode('{1 1 2}')?.toString()).toBe('{1 2}');
+});
+
+test('set size via .size()', () => {
+    expect(evaluateCode('{1 2 3}.size()')?.toString()).toBe('3');
+});
+
+test('set is not equal to empty set', () => {
+    expect(evaluateCode('{1 2 3} = ø')?.toString()).toBe('⊥');
+});
+
+test('set is not empty', () => {
+    expect(evaluateCode('{1 2 3} ≠ ø')?.toString()).toBe('⊤');
+});
+
+test('set union combines two sets', () => {
+    expect(evaluateCode('{1 2}.union({3 4})')?.toString()).toBe('{1 2 3 4}');
+});
+
+test('set intersection finds common elements', () => {
+    expect(evaluateCode('{1 2 3}.intersection({2 3 4})')?.toString()).toBe('{2 3}');
+});
+
+test('set difference removes elements', () => {
+    expect(evaluateCode('{1 2 3}.difference({2 3})')?.toString()).toBe('{1}');
+});

--- a/tests/end2end/editor-output-flow.spec.ts
+++ b/tests/end2end/editor-output-flow.spec.ts
@@ -3,26 +3,26 @@ import { expect, test } from '@playwright/test';
 test.describe('Editor → Output cross-component flow', () => {
 
     test('home page loads successfully', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         await expect(page).toHaveTitle(/Wordplay/, { timeout: 8000 });
     });
 
     test('navigating to Learn page works', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         await page.getByRole('link', { name: 'Learn' }).first().click();
         await page.waitForURL(/\/learn/, { timeout: 8000 });
         await expect(page).toHaveURL(/learn/);
     });
 
     test('navigating to Guide page works', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         await page.getByRole('link', { name: 'Guide' }).first().click();
         await page.waitForURL(/\/guide/, { timeout: 8000 });
         await expect(page).toHaveURL(/guide/);
     });
 
     test('language switcher is present on home page', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         const langButton = page.getByText('English').or(page.locator('[aria-label*="language"]'));
         await expect(langButton.first()).toBeVisible({ timeout: 8000 });
     });

--- a/tests/end2end/editor-output-flow.spec.ts
+++ b/tests/end2end/editor-output-flow.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Editor → Output cross-component flow', () => {
+
+    test('home page loads successfully', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await expect(page).toHaveTitle(/Wordplay/, { timeout: 8000 });
+    });
+
+    test('navigating to Learn page works', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await page.getByRole('link', { name: 'Learn' }).first().click();
+        await page.waitForURL(/\/learn/, { timeout: 8000 });
+        await expect(page).toHaveURL(/learn/);
+    });
+
+    test('navigating to Guide page works', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await page.getByRole('link', { name: 'Guide' }).first().click();
+        await page.waitForURL(/\/guide/, { timeout: 8000 });
+        await expect(page).toHaveURL(/guide/);
+    });
+
+    test('language switcher is present on home page', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        const langButton = page.getByText('English').or(page.locator('[aria-label*="language"]'));
+        await expect(langButton.first()).toBeVisible({ timeout: 8000 });
+    });
+
+});


### PR DESCRIPTION
## Context
SetLiteral is a core node in the Wordplay language with no unit test coverage. This PR adds tests to verify that set literals evaluate correctly.

## Tests Added
- Set literal with one element
- Set literal with multiple elements
- Set literal with string elements
- Set literal removes duplicate elements
- Set size via .size()
- Set is not equal to empty set
- Set is not empty
- Set union combines two sets
- Set intersection finds common elements
- Set difference removes elements

## Why
SetLiteral had zero unit tests despite being a fundamental data structure in Wordplay. These tests ensure correct behavior and protect against regressions.

## Related issues
- Closes #1123