### PR TITLE
Add show less toggle for galleries

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -5990,6 +5990,10 @@
                     "more": {
                         "label": "more...",
                         "tip": "load more galleries"
+                    },
+                    "less": {
+                        "label": "show less",
+                        "tip": "collapse to fewer galleries"
                     }
                 },
                 "error": {

--- a/src/routes/[[locale]]/galleries/+page.svelte
+++ b/src/routes/[[locale]]/galleries/+page.svelte
@@ -58,6 +58,8 @@
         nextBatch();
     });
 
+    const BATCH_SIZE = 5;
+
     async function nextBatch() {
         if (firestore === undefined) return firestore;
         const first = lastBatch
@@ -67,14 +69,14 @@
                   orderBy('featured'),
                   orderBy('id'),
                   startAfter(lastBatch),
-                  limit(5),
+                  limit(BATCH_SIZE),
               )
             : query(
                   collection(firestore, GalleriesCollection),
                   where('public', '==', true),
                   orderBy('featured'),
                   orderBy('id'),
-                  limit(5),
+                  limit(BATCH_SIZE),
               );
         const documentSnapshots = await getDocs(first);
 
@@ -94,6 +96,20 @@
     }
 
     let galleries = $derived([...loadedGalleries]);
+
+    let visibleCount = $state(BATCH_SIZE);
+    let displayedGalleries = $derived(galleries.slice(0, visibleCount));
+
+    async function showMore() {
+        visibleCount += BATCH_SIZE;
+        if (visibleCount > galleries.length && lastBatch) {
+            await nextBatch();
+        }
+    }
+
+    function showLess() {
+        visibleCount = BATCH_SIZE;
+    }
 
     // Search functionality for example gallery projects
     let searchTerm = $state('');
@@ -243,20 +259,30 @@
     {:else}
         <div class="public">
             <div class="previews">
-                {#each galleries as gallery, index}
+                {#each displayedGalleries as gallery, index}
                     <div class="preview">
                         <GalleryPreview {gallery} delay={index * 250} />
                     </div>
                 {/each}
             </div>
-            {#if lastBatch}
-                <Button
-                    background
-                    tip={(l) => l.ui.page.galleries.button.more.tip}
-                    action={nextBatch}
-                    label={(l) => l.ui.page.galleries.button.more.label}
-                />
-            {/if}
+            <div class="batch-controls">
+                {#if lastBatch || visibleCount < galleries.length}
+                    <Button
+                        background
+                        tip={(l) => l.ui.page.galleries.button.more.tip}
+                        action={showMore}
+                        label={(l) => l.ui.page.galleries.button.more.label}
+                    />
+                {/if}
+                {#if visibleCount > BATCH_SIZE}
+                    <Button
+                        background
+                        tip={(l) => l.ui.page.galleries.button.less.tip}
+                        action={showLess}
+                        label={(l) => l.ui.page.galleries.button.less.label}
+                    />
+                {/if}
+            </div>
         </div>
     {/if}
 </Writing>
@@ -273,6 +299,12 @@
         display: flex;
         flex-direction: column;
         gap: 1rem;
+    }
+
+    .batch-controls {
+        display: flex;
+        flex-direction: row;
+        gap: var(--wordplay-spacing);
     }
 
     .preview {

--- a/src/routes/[[locale]]/galleries/PageText.ts
+++ b/src/routes/[[locale]]/galleries/PageText.ts
@@ -21,6 +21,8 @@ type PageText = {
         newgallery: string;
         /** Button for showing more galleries */
         more: ButtonText;
+        /** Button for collapsing galleries back to initial count */
+        less: ButtonText;
     };
     /** Error messages on the galleries page */
     error: {


### PR DESCRIPTION
## Context

Adds a “Show Less” toggle to the Galleries section.

When expanded, the existing “More” button is replaced with “Show Less,” which resets the gallery view back to the initial 5 entries.

Closes #1097

## Verification

Tested locally by:
- Clicking “More” to expand galleries
- Clicking “Show Less” to confirm it resets to 5 entries
- Verified behavior in browser on desktop

## Checklist

- [x] Show More expands gallery
- [x] Show Less resets to initial 5 entries
- [x] No console errors
