### PR TITLE
Add E2E tests for cross-component navigation flow

### DIFF
--- a/tests/end2end/editor-output-flow.spec.ts
+++ b/tests/end2end/editor-output-flow.spec.ts
@@ -3,26 +3,26 @@ import { expect, test } from '@playwright/test';
 test.describe('Editor → Output cross-component flow', () => {
 
     test('home page loads successfully', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         await expect(page).toHaveTitle(/Wordplay/, { timeout: 8000 });
     });
 
     test('navigating to Learn page works', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         await page.getByRole('link', { name: 'Learn' }).first().click();
         await page.waitForURL(/\/learn/, { timeout: 8000 });
         await expect(page).toHaveURL(/learn/);
     });
 
     test('navigating to Guide page works', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         await page.getByRole('link', { name: 'Guide' }).first().click();
         await page.waitForURL(/\/guide/, { timeout: 8000 });
         await expect(page).toHaveURL(/guide/);
     });
 
     test('language switcher is present on home page', async ({ page }) => {
-        await page.goto('http://localhost:5173/en-US');
+        await page.goto('/en-US');
         const langButton = page.getByText('English').or(page.locator('[aria-label*="language"]'));
         await expect(langButton.first()).toBeVisible({ timeout: 8000 });
     });

--- a/tests/end2end/editor-output-flow.spec.ts
+++ b/tests/end2end/editor-output-flow.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Editor → Output cross-component flow', () => {
+
+    test('home page loads successfully', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await expect(page).toHaveTitle(/Wordplay/, { timeout: 8000 });
+    });
+
+    test('navigating to Learn page works', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await page.getByRole('link', { name: 'Learn' }).first().click();
+        await page.waitForURL(/\/learn/, { timeout: 8000 });
+        await expect(page).toHaveURL(/learn/);
+    });
+
+    test('navigating to Guide page works', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        await page.getByRole('link', { name: 'Guide' }).first().click();
+        await page.waitForURL(/\/guide/, { timeout: 8000 });
+        await expect(page).toHaveURL(/guide/);
+    });
+
+    test('language switcher is present on home page', async ({ page }) => {
+        await page.goto('http://localhost:5173/en-US');
+        const langButton = page.getByText('English').or(page.locator('[aria-label*="language"]'));
+        await expect(langButton.first()).toBeVisible({ timeout: 8000 });
+    });
+
+});


### PR DESCRIPTION
# Context
Adds a new end-to-end test suite covering cross-component navigation interactions — an area with no prior test coverage.

## What this tests
- Home page loads successfully
- Navigating from home to the Learn page works
- Navigating from home to the Guide page works
- Language switcher is visible on the home page

## Why this matters
Navigation between the home page and major sections (Learn, Guide) spans multiple Svelte components and had zero E2E test coverage. A regression here would affect all users on first visit.

## Related issues
- Closes #1120