### PR TITLE
Changing error vs. loading logic for how-to space

### DIFF
--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -336,11 +336,13 @@
     $effect(() => {
         indexContext.index = placeholderIndex;
     });
+
+    $inspect(gallery).with(console.log);
 </script>
 
 {#if gallery === null}
     <Loading />
-{:else if (!galleryID && gallery === undefined) || (galleryID && gallery === undefined && howTos.length === 0)}
+{:else if (galleryID === undefined && gallery === undefined) || (gallery === undefined && urlID === null)}
     <Writing>
         <Notice text={(l) => l.ui.howto.error.unknown} />
     </Writing>

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -72,6 +72,9 @@
     // get the how-tos in the gallery
     let howTos: HowTo[] = $state([]);
 
+    // true if queried how-to exists and user has access, false if query failed, null if query in progress
+    let urlHowToStatus = $state<null | boolean>(null);
+
     // get all of the how-tos for the gallery if the user has gallery access
     // otherwise, see if there was a specific how-to id in the url and if so just get that one
     $effect(() => {
@@ -80,8 +83,14 @@
                 if (data) howTos = data;
             });
         } else if (urlID) {
+            urlHowToStatus = null;
             HowTos.getHowTo(urlID).then((data) => {
-                if (data) howTos = [data];
+                if (data) {
+                    howTos = [data];
+                    urlHowToStatus = true;
+                } else {
+                    urlHowToStatus = false;
+                }
             });
         }
     });
@@ -336,13 +345,11 @@
     $effect(() => {
         indexContext.index = placeholderIndex;
     });
-
-    $inspect(gallery).with(console.log);
 </script>
 
-{#if gallery === null}
+{#if gallery === null || (gallery === undefined && urlID !== null && urlHowToStatus === null)}
     <Loading />
-{:else if (galleryID === undefined && gallery === undefined) || (gallery === undefined && urlID === null)}
+{:else if gallery === undefined && (galleryID === undefined || urlID === null || urlHowToStatus === false)}
     <Writing>
         <Notice text={(l) => l.ui.howto.error.unknown} />
     </Writing>

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -73,7 +73,7 @@
     let howTos: HowTo[] = $state([]);
 
     // true if queried how-to exists and user has access, false if query failed, null if query in progress
-    let urlHowToStatus = $state<null | boolean>(null);
+    let urlLoaded = $state<null | boolean>(null);
 
     // get all of the how-tos for the gallery if the user has gallery access
     // otherwise, see if there was a specific how-to id in the url and if so just get that one
@@ -83,13 +83,13 @@
                 if (data) howTos = data;
             });
         } else if (urlID) {
-            urlHowToStatus = null;
+            urlLoaded = null;
             HowTos.getHowTo(urlID).then((data) => {
                 if (data) {
                     howTos = [data];
-                    urlHowToStatus = true;
+                    urlLoaded = true;
                 } else {
-                    urlHowToStatus = false;
+                    urlLoaded = false;
                 }
             });
         }
@@ -347,9 +347,9 @@
     });
 </script>
 
-{#if gallery === null || (gallery === undefined && urlID !== null && urlHowToStatus === null)}
+{#if gallery === null || (gallery === undefined && urlID !== null && urlLoaded === null)}
     <Loading />
-{:else if gallery === undefined && (galleryID === undefined || urlID === null || urlHowToStatus === false)}
+{:else if gallery === undefined && (galleryID === undefined || urlID === null || urlLoaded === false)}
     <Writing>
         <Notice text={(l) => l.ui.howto.error.unknown} />
     </Writing>


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

When the user pulls up a public how-to from a gallery they do not have access to, the page briefly shows the "This how-to space doesn't exist or isn't public" error message before loading the how-to space. This is because if the user doesn't have access to the gallery, the gallery variable for the page is set to `undefined`, which renders the error until the how-to is queried. This PR changes the logic for loading vs. error vs. show how-to space slightly so that the page never goes to the "error" state if a valid how-to is queried for. 

New logic:

- If the gallery is null, then the gallery is still loading. Show the loading screen.
- If the gallery is undefined, then the user does not have access to it. Check if there was a specific how-to being queried via the URL. 
    - If so, and the URL loading status variable (`urlLoaded`) is null, then a how-to was specifically queried and it is still loading. Show the loading screen.
    - If so, and the URL loading status variable is false, then the how-to was specifically queried but it was not successfully fetched. Show the error screen. 
    - If not, then the `urlID` variable is null. Show the error screen.
- Otherwise, render the how-to space (with any how-tos that the user has access to in it).

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #1140 

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create an account. Using that account, create a gallery Gallery1. In Gallery1, create two how-tos. HowToA should be public, HowToB should be private.
2. Open an incognito window, do not log in to Wordplay (or use an account that doesn't have access to Gallery1). Try accessing Gallery1's how-to space directly via the URL, with no parameters querying for a how-to by ID. Check that the loading screen is showed, followed by the error message. 
3. In the incognito window, open HowToA using its URL. Check that the loading screen is shown, followed by the how-to space rendering. No error message is shown in this rendering process.
4. In the incognito window, open HowToB using its URL. Check that the loading screen is shown, followed by the error message being rendered. The how-to space is never shown to the user during this rendering process. 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
