### PR TITLE
Increment view count from guide

### DIFF
--- a/src/components/concepts/HowToConceptView.svelte
+++ b/src/components/concepts/HowToConceptView.svelte
@@ -2,9 +2,12 @@
     import { goto } from '$app/navigation';
     import Subheader from '@components/app/Subheader.svelte';
     import Speech from '@components/lore/Speech.svelte';
+    import { getUser } from '@components/project/Contexts';
     import Button from '@components/widgets/Button.svelte';
     import type GalleryHowConcept from '@concepts/GalleryHowConcept';
-    import { locales } from '@db/Database';
+    import { HowTos, locales } from '@db/Database';
+    import HowTo from '@db/howtos/HowToDatabase.svelte';
+    import { onMount } from 'svelte';
     import MarkupHTMLView from './MarkupHTMLView.svelte';
 
     interface Props {
@@ -14,6 +17,29 @@
     let { concept }: Props = $props();
 
     let preferredLocale: string = $derived($locales.getLocaleString());
+
+    // add the user to the list of those who have viewed this how-to
+    const user = getUser();
+
+    onMount(() => {
+        let seenByUsers = concept.howTo.getSeenByUsers();
+
+        if ($user && !seenByUsers.includes($user.uid)) {
+            seenByUsers.push($user.uid);
+        }
+
+        HowTos.updateHowTo(
+            new HowTo({
+                ...concept.howTo.getData(),
+                social: {
+                    ...concept.howTo.getSocial(),
+                    seenByUsers: seenByUsers,
+                    viewCount: concept.howTo.getViewCount() + 1,
+                },
+            }),
+            true,
+        );
+    });
 </script>
 
 <Subheader>{concept.howTo.getTitleInLocale(preferredLocale)}</Subheader>


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

Over the past few weeks, we have made it possible for users to view user-created how-tos in the Guide via the Guide panel as well as through `/guide`. However, we did track viewership when how-tos were accessed via the Guide. This PR copies over the logic from the how-to space to (1) add the user to the list of viewers for the how-to and (2) increment the number of times that a how-to has been viewed. 

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

1. Create two users, UserA and UserB. 
2. From the UserA account, create GalleryA. Add UserB as a creator in the gallery.
3. From the UserA account, add HowToA and HowToB to GalleryA.
4. From the UserB account, create a project ProjectA in GalleryA. Access HowToA from the Guide pane in ProjectA. Using the Firebase emulator UI, check that UserB's UID is in the list of viewers and the number of viewers increments by 1 each time that HowToA is opened from the Guide pane (do this a few times). 
5. From the UserB account, access the Guide via `/guide`. Access HowToB from here. Verify the same things as in step 4. 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
