### PR TITLE
Add Study Mode Meter Example

### DIFF
--- a/src/examples/examples.ts
+++ b/src/examples/examples.ts
@@ -1,26 +1,50 @@
 import Gallery, { GallerySchemaLatestVersion } from '@db/galleries/Gallery';
-import type Locales from '@locale/Locales';
-import { moderatedFlags } from '../db/projects/Moderation';
+import { moderatedFlags } from '@db/projects/Moderation';
 import {
     ProjectSchemaLatestVersion,
+    type SerializedPreview,
     type SerializedProject,
-} from '../db/projects/ProjectSchemas';
-import type { GalleryText } from '../locale/GalleryTexts';
-import { localeToString } from '../locale/Locale';
-import { parseNames } from '../parser/parseBind';
-import { toTokens } from '../parser/toTokens';
+} from '@db/projects/ProjectSchemas';
+import type { GalleryText } from '@locale/GalleryTexts';
+import { localeToString } from '@locale/Locale';
+import type Locales from '@locale/Locales';
+import { parseNames } from '@parser/parseBind';
+import { toTokens } from '@parser/toTokens';
+import UnicodeString from '@unicode/UnicodeString';
 
 /** This mirrors the static path to examples, but also helps distinguish project IDs from example project names. */
 export const ExamplePrefix = 'example-';
+
+/**
+ * `.wp` example files may optionally begin with a single-grapheme preview
+ * glyph on its own line, before the project title. If present, it ships as
+ * the project's persisted preview (mode: 'auto', value precomputed at build
+ * time by scripts/precompute-previews.ts). Legacy files without a preview
+ * line fall through to the on-demand preview queue.
+ */
+function parsePreviewLine(line: string): string | undefined {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return undefined;
+    const us = new UnicodeString(trimmed);
+    return us.getLength() === 1 ? trimmed : undefined;
+}
 
 export function parseSerializedProject(
     project: string,
     id: string,
 ): SerializedProject {
-    const lines = project.split('\n');
-    const rest = project.substring(lines.slice(0, 1).join().length + 1);
+    let lines = project.split('\n');
 
-    // The first line is the project name
+    // Optional preview-glyph first line. If present, peel it off so the
+    // second line is the project name as in the legacy format.
+    const previewGlyph = parsePreviewLine(lines[0] ?? '');
+    if (previewGlyph !== undefined) lines = lines.slice(1);
+
+    // Reconstruct the remainder for downstream `===`-splitting.
+    const body = lines.join('\n');
+    const rest = body.substring(lines.slice(0, 1).join().length + 1);
+
+    // The first line of the (possibly peeled) body is the project name.
     const name = lines[0].trim();
 
     // Split the file by "===" lines
@@ -40,6 +64,18 @@ export function parseSerializedProject(
         }
         return { names, code, caret: 0 };
     });
+
+    const preview: SerializedPreview | undefined =
+        previewGlyph !== undefined
+            ? {
+                  mode: 'auto',
+                  text: previewGlyph,
+                  foreground: null,
+                  background: null,
+                  face: null,
+                  characterName: null,
+              }
+            : undefined;
 
     // Return stuff for display
     return {
@@ -63,6 +99,9 @@ export function parseSerializedProject(
         restrictedGallery: false,
         viewers: [],
         commenters: [],
+        preview,
+        stamps: { lamport: 0, fields: {} },
+        crdt: null,
     };
 }
 
@@ -158,6 +197,7 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
                 'Pumpkin',
                 'Size',
                 'FloatingFoods',
+                'AditiAnimatedName',
             ],
             locales,
         ),
@@ -189,6 +229,7 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
                 'RainingLetters',
                 'Video',
                 'ASCII',
+                'Hand',
             ],
             locales,
         ),
@@ -197,7 +238,7 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
             Object.fromEntries(
                 locale.map((l) => [localeToString(l), l.gallery.stories]),
             ),
-            ['Pears', 'JapaneseClass'],
+            ['Pears', 'JapaneseClass', 'AditiPersonalMap'],
             locales,
         ),
         createGallery(

--- a/src/examples/examples.ts
+++ b/src/examples/examples.ts
@@ -1,50 +1,26 @@
 import Gallery, { GallerySchemaLatestVersion } from '@db/galleries/Gallery';
-import { moderatedFlags } from '@db/projects/Moderation';
+import type Locales from '@locale/Locales';
+import { moderatedFlags } from '../db/projects/Moderation';
 import {
     ProjectSchemaLatestVersion,
-    type SerializedPreview,
     type SerializedProject,
-} from '@db/projects/ProjectSchemas';
-import type { GalleryText } from '@locale/GalleryTexts';
-import { localeToString } from '@locale/Locale';
-import type Locales from '@locale/Locales';
-import { parseNames } from '@parser/parseBind';
-import { toTokens } from '@parser/toTokens';
-import UnicodeString from '@unicode/UnicodeString';
+} from '../db/projects/ProjectSchemas';
+import type { GalleryText } from '../locale/GalleryTexts';
+import { localeToString } from '../locale/Locale';
+import { parseNames } from '../parser/parseBind';
+import { toTokens } from '../parser/toTokens';
 
 /** This mirrors the static path to examples, but also helps distinguish project IDs from example project names. */
 export const ExamplePrefix = 'example-';
-
-/**
- * `.wp` example files may optionally begin with a single-grapheme preview
- * glyph on its own line, before the project title. If present, it ships as
- * the project's persisted preview (mode: 'auto', value precomputed at build
- * time by scripts/precompute-previews.ts). Legacy files without a preview
- * line fall through to the on-demand preview queue.
- */
-function parsePreviewLine(line: string): string | undefined {
-    const trimmed = line.trim();
-    if (trimmed.length === 0) return undefined;
-    const us = new UnicodeString(trimmed);
-    return us.getLength() === 1 ? trimmed : undefined;
-}
 
 export function parseSerializedProject(
     project: string,
     id: string,
 ): SerializedProject {
-    let lines = project.split('\n');
+    const lines = project.split('\n');
+    const rest = project.substring(lines.slice(0, 1).join().length + 1);
 
-    // Optional preview-glyph first line. If present, peel it off so the
-    // second line is the project name as in the legacy format.
-    const previewGlyph = parsePreviewLine(lines[0] ?? '');
-    if (previewGlyph !== undefined) lines = lines.slice(1);
-
-    // Reconstruct the remainder for downstream `===`-splitting.
-    const body = lines.join('\n');
-    const rest = body.substring(lines.slice(0, 1).join().length + 1);
-
-    // The first line of the (possibly peeled) body is the project name.
+    // The first line is the project name
     const name = lines[0].trim();
 
     // Split the file by "===" lines
@@ -64,18 +40,6 @@ export function parseSerializedProject(
         }
         return { names, code, caret: 0 };
     });
-
-    const preview: SerializedPreview | undefined =
-        previewGlyph !== undefined
-            ? {
-                  mode: 'auto',
-                  text: previewGlyph,
-                  foreground: null,
-                  background: null,
-                  face: null,
-                  characterName: null,
-              }
-            : undefined;
 
     // Return stuff for display
     return {
@@ -99,9 +63,6 @@ export function parseSerializedProject(
         restrictedGallery: false,
         viewers: [],
         commenters: [],
-        preview,
-        stamps: { lamport: 0, fields: {} },
-        crdt: null,
     };
 }
 
@@ -197,7 +158,6 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
                 'Pumpkin',
                 'Size',
                 'FloatingFoods',
-                'AditiAnimatedName',
             ],
             locales,
         ),
@@ -229,7 +189,6 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
                 'RainingLetters',
                 'Video',
                 'ASCII',
-                'Hand',
             ],
             locales,
         ),
@@ -238,7 +197,7 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
             Object.fromEntries(
                 locale.map((l) => [localeToString(l), l.gallery.stories]),
             ),
-            ['Pears', 'JapaneseClass', 'AditiPersonalMap'],
+            ['Pears', 'JapaneseClass'],
             locales,
         ),
         createGallery(
@@ -246,7 +205,7 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
             Object.fromEntries(
                 locale.map((l) => [localeToString(l), l.gallery.tools]),
             ),
-            ['Calculator', 'Literacy', 'Timer', 'Headlines', 'SentenceLength'],
+            ['Calculator', 'Literacy', 'Timer', 'Headlines', 'SentenceLength', 'StudyModeMeter'],
             locales,
         ),
     ];

--- a/src/examples/examples.ts
+++ b/src/examples/examples.ts
@@ -246,7 +246,14 @@ export function getExampleGalleries(locales: Locales): Gallery[] {
             Object.fromEntries(
                 locale.map((l) => [localeToString(l), l.gallery.tools]),
             ),
-            ['Calculator', 'Literacy', 'Timer', 'Headlines', 'SentenceLength', 'StudyModeMeter'],
+            [
+                'Calculator',
+                'Literacy',
+                'Timer',
+                'Headlines',
+                'SentenceLength',
+                'StudyModeMeter',
+            ],
             locales,
         ),
     ];

--- a/static/examples/StudyModeMeter.wp
+++ b/static/examples/StudyModeMeter.wp
@@ -1,0 +1,48 @@
+Study Mode Meter
+
+study-mode-meter
+
+¶The action stores the choice the user clicks, such as add or reset.¶/en
+action: Choice()
+
+¶Study hours remembers the current number of study hours.
+It starts at 0, then updates whenever the user selects an action.¶/en
+studyHours:
+	0 …
+	∆ action …
+		¶If the selected action is reset, study hours becomes 0.
+		Otherwise, it adds 1 study hour.¶/en
+		action = 'reset' ?
+			0
+			studyHours + 1
+
+¶Mood chooses the message shown on the screen.
+It uses conditional expressions to show Calm, Focus, or Overload mode.¶/en
+mood:
+	studyHours < 3 ?
+		'🌿 CALM MODE — click to add study time'
+		studyHours < 6 ?
+			'📚 FOCUS MODE — you are in the productive zone!'
+			'🔥 OVERLOAD MODE — take a break and "reset"'
+
+¶Stage creates the visible scene.
+The Stack places the title, message, and selectable text controls vertically.¶/en
+Stage([
+		Group(
+			Stack()
+			[
+				Phrase('Study Mode Meter' size: 0.5m)
+				Phrase(mood)
+
+				¶This selectable Phrase lets the user add one study hour.
+				Its name is add, so selecting it updates the action choice.¶/en
+				Phrase('Add Study Hour +1' selectable: ⊤ name: 'add' color: 🌈(80% 45 0°))
+
+				¶This selectable Phrase lets the user reset the tracker.
+				Its name is reset, so selecting it sets study hours back to 0.¶/en
+				Phrase('Reset' selectable: ⊤ name: 'reset' color: 🌈(69% 47 271°))
+			]
+		)
+	]
+	face: "Aclonica"
+)

--- a/static/examples/StudyModeMeter.wp
+++ b/static/examples/StudyModeMeter.wp
@@ -5,15 +5,21 @@ Study Mode Meter
 action: Choice()
 
 ¶Study hours remembers the current number of study hours.
-It starts at 0, then updates whenever the user selects an action.¶/en
+It starts at 0, then updates depends on the action the user selects.¶/en
 studyHours:
 	0 …
 	∆ action …
-		¶If the selected action is reset, study hours becomes 0.
-		Otherwise, it adds 1 study hour.¶/en
 		action = 'reset' ?
 			0
 			studyHours + 1
+
+¶Explanation shows a visible instruction for the user.¶/en
+explanation:
+	'Click “Add Study Hour +1” to increase your study time. Click “Reset” to start over.'
+
+¶Hours text shows how many hours the user has studied.¶/en
+hoursText:
+	'You have studied ' + studyHours → '' + ' hour(s).'
 
 ¶Mood chooses the message shown on the screen.
 It uses conditional expressions to show Calm, Focus, or Overload mode.¶/en
@@ -25,23 +31,32 @@ mood:
 			'🔥 OVERLOAD MODE — take a break and "reset"'
 
 ¶Stage creates the visible scene.
-The Stack places the title, message, and selectable text controls vertically.¶/en
+The Stack places the title, explanation, number display, message, and selectable text controls vertically.¶/en
 Stage([
 		Group(
 			Stack()
 			[
 				Phrase('Study Mode Meter' size: 0.5m)
-				Phrase(mood)
 
-				¶This selectable Phrase lets the user add one study hour.
-				Its name is add, so selecting it updates the action choice.¶/en
-				Phrase('Add Study Hour +1' selectable: ⊤ name: 'add' color: 🌈(80% 45 0°))
+				¶This Phrase shows the explanation on the screen.¶/en
+				Phrase(explanation size: 0.4m)
 
-				¶This selectable Phrase lets the user reset the tracker.
-				Its name is reset, so selecting it sets study hours back to 0.¶/en
-				Phrase('Reset' selectable: ⊤ name: 'reset' color: 🌈(69% 47 271°))
+				¶This Phrase shows the current number of study hours.¶/en
+				Phrase(hoursText size: 0.4m)
+
+				Phrase(mood size: 0.75m)
+
+				Group(➡(padding: 3m) [
+						¶This selectable Phrase lets the user add one study hour.
+						Its name is add, so selecting it updates the action choice.¶/en
+						Phrase('Add Study Hour +1' selectable: ⊤ name: 'add' color: 🌈(80% 45 0°))
+
+						¶This selectable Phrase lets the user reset the tracker.
+						Its name is reset, so selecting it sets study hours back to 0.¶/en
+						Phrase('Reset' selectable: ⊤ name: 'reset' color: 🌈(69% 47 271°))
+					]
+				)
 			]
+			face: "Aclonica"
 		)
-	]
-	face: "Aclonica"
-)
+	])

--- a/static/examples/StudyModeMeter.wp
+++ b/static/examples/StudyModeMeter.wp
@@ -1,7 +1,6 @@
+⏳
 Study Mode Meter
-
-study-mode-meter
-
+=== start/en
 ¶The action stores the choice the user clicks, such as add or reset.¶/en
 action: Choice()
 


### PR DESCRIPTION
# Context

This pull request adds a new example project called **Study Mode Meter** to `static/examples`.

The example is a small interactive study tracker. Users can add one study hour or reset the tracker, and the displayed message changes based on the current number of study hours.

It is intended to help beginners learn:
- selectable phrases
- choices
- state changes
- conditional expressions
- beginner-facing comments

## Related issues

Closes #1078