### PR TITLE
How to loading bug

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -471,7 +471,7 @@ async function seedCreatorHowTos(): Promise<void> {
             guidingQuestions: HOWTO_GUIDING_QUESTIONS,
             text: HOWTO_GUIDING_QUESTIONS.map(
                 (_, qi) =>
-                    `¶Example answer ${qi + 1} for "${title}". (Seeded content — edit me!)¶/en-US`,
+                    `¶Example answer ${qi + 1} for "${title}". (Seeded content — edit me!) \n\n\\Phrase("hello world")\\¶/en-US`,
             ),
             creator: creator.uid,
             collaborators: [],

--- a/src/db/projects/previewQueue.ts
+++ b/src/db/projects/previewQueue.ts
@@ -72,9 +72,10 @@ export function enqueuePreviewCompute(
     project: Project,
     locales: Locales,
     db: Database,
+    howToId?: string,
 ): Promise<ExtractedPreview> {
-    const id = project.getID();
-    const existing = pending.get(id);
+    const cacheID = howToId ?? project.getID();
+    const existing = pending.get(cacheID);
     if (existing) return existing;
 
     const job = workerChain.then(async () => {
@@ -93,14 +94,14 @@ export function enqueuePreviewCompute(
         }
     });
 
-    pending.set(id, job);
+    pending.set(cacheID, job);
     // Chain the next job to wait for this one, but swallow this job's
     // errors here so a single failure doesn't poison the whole queue.
     workerChain = job.catch(() => undefined);
     // Clear the dedupe slot once the job is fully settled so a subsequent
     // call recomputes (the project's sources may have changed since).
     void job.finally(() => {
-        if (pending.get(id) === job) pending.delete(id);
+        if (pending.get(cacheID) === job) pending.delete(cacheID);
     });
     return job;
 }

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -99,6 +99,10 @@
     let canvasWidth: number = $state(0);
     let canvasHeight: number = $state(0);
 
+    // Tiles mount this many pixels before entering the visible viewport so
+    // the component-creation cost is paid off-screen, not on first visibility.
+    let PRELOAD_MARGIN = $derived(Math.max(canvasWidth, canvasHeight) / 2);
+
     // determine if the user can add a new how-to
     let canUserEdit = $derived(
         gallery
@@ -122,6 +126,7 @@
     let cameraX = $state(0);
     let cameraY = $state(0);
 
+
     function panTo(x: number, y: number) {
         cameraX = -x + 10;
         cameraY = -y + 10;
@@ -141,16 +146,47 @@
         whichMoving = 'canvas';
     }
 
+    // Accumulated pointer deltas waiting for the next animation frame.
+    // Batching multiple pointermove events into a single rAF update caps
+    // the Svelte reactive cascade (transform update + inCanvasArea checks)
+    // at the display's paint rate rather than the raw pointer event rate.
+    let pendingDX = 0;
+    let pendingDY = 0;
+    let panRafID: number | undefined;
+
+    function flushPan() {
+        if (panRafID !== undefined) {
+            cancelAnimationFrame(panRafID);
+            panRafID = undefined;
+        }
+        if (pendingDX !== 0 || pendingDY !== 0) {
+            cameraX += pendingDX;
+            cameraY += pendingDY;
+            pendingDX = 0;
+            pendingDY = 0;
+        }
+    }
+
     function onpointerup() {
         if (whichMoving !== 'canvas' || whichDialogOpen) return;
+        flushPan();
         whichMoving = undefined;
     }
 
     function onpointermove(e: PointerEvent) {
         if (whichMoving !== 'canvas' || whichDialogOpen) return;
 
-        cameraX += e.movementX;
-        cameraY += e.movementY;
+        pendingDX += e.movementX;
+        pendingDY += e.movementY;
+        if (panRafID === undefined) {
+            panRafID = requestAnimationFrame(() => {
+                panRafID = undefined;
+                cameraX += pendingDX;
+                cameraY += pendingDY;
+                pendingDX = 0;
+                pendingDY = 0;
+            });
+        }
     }
 
     let keyboardFocused: boolean = $state(false);
@@ -510,7 +546,7 @@
                         style:transform="translate({cameraX}px, {cameraY}px)"
                     >
                         {#each howTos as howTo, i (howTo.getHowToId())}
-                            {#if howTo.isPublished() && howTo.inCanvasArea(-cameraX, -cameraX + canvasWidth, -cameraY, -cameraY + canvasHeight)}
+                            {#if howTo.isPublished() && howTo.inCanvasArea(-cameraX - PRELOAD_MARGIN, -cameraX + canvasWidth + PRELOAD_MARGIN, -cameraY - PRELOAD_MARGIN, -cameraY + canvasHeight + PRELOAD_MARGIN)}
                                 <HowToPreview
                                     bind:howTo={howTos[i]}
                                     bind:this={howToComponents[i]}

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -505,26 +505,31 @@
                     {onblur}
                     {onkeydown}
                 >
-                    {#each howTos as howTo, i (howTo.getHowToId())}
-                        {#if howTo.isPublished() && howTo.inCanvasArea(-cameraX, -cameraX + canvasWidth, -cameraY, -cameraY + canvasHeight)}
-                            <HowToPreview
-                                bind:howTo={howTos[i]}
-                                bind:this={howToComponents[i]}
-                                bind:cameraX
-                                bind:cameraY
-                                {canvasWidth}
-                                {canvasHeight}
-                                bind:whichMoving
-                                bind:notPermittedAreas
-                                galleryCuratorCollaborators={gallery
-                                    ? gallery
-                                          .getCurators()
-                                          .concat(gallery.getCreators())
-                                    : []}
-                                bind:whichDialogOpen
-                            />
-                        {/if}
-                    {/each}
+                    <div
+                        class="world"
+                        style:transform="translate({cameraX}px, {cameraY}px)"
+                    >
+                        {#each howTos as howTo, i (howTo.getHowToId())}
+                            {#if howTo.isPublished() && howTo.inCanvasArea(-cameraX, -cameraX + canvasWidth, -cameraY, -cameraY + canvasHeight)}
+                                <HowToPreview
+                                    bind:howTo={howTos[i]}
+                                    bind:this={howToComponents[i]}
+                                    bind:cameraX
+                                    bind:cameraY
+                                    {canvasWidth}
+                                    {canvasHeight}
+                                    bind:whichMoving
+                                    bind:notPermittedAreas
+                                    galleryCuratorCollaborators={gallery
+                                        ? gallery
+                                              .getCurators()
+                                              .concat(gallery.getCreators())
+                                        : []}
+                                    bind:whichDialogOpen
+                                />
+                            {/if}
+                        {/each}
+                    </div>
                 </div>
             </div>
         </div>
@@ -586,5 +591,10 @@
         overflow: hidden;
         position: relative;
         touch-action: none;
+    }
+
+    .world {
+        position: absolute;
+        inset: 0;
     }
 </style>

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToPreview.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToPreview.svelte
@@ -1,30 +1,30 @@
 <script lang="ts">
     import Fonts from '@basis/Fonts';
-    import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import Spinning from '@components/app/Spinning.svelte';
+    import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import {
         getAnnouncer,
         getTip,
         getUser,
         isAuthenticated,
     } from '@components/project/Contexts';
+    import { pickPreviewExample } from '@concepts/pickPreviewExample';
     import { characterToSVG, type Character } from '@db/characters/Character';
     import { CharactersDB, DB, HowTos, locales } from '@db/Database';
     import HowTo from '@db/howtos/HowToDatabase.svelte';
-    import Project from '@db/projects/Project';
     import { enqueuePreviewCompute } from '@db/projects/previewQueue';
+    import Project from '@db/projects/Project';
     import Source from '@nodes/Source';
     import { toMarkup } from '@parser/toMarkup';
+    import UnicodeString from '@unicode/UnicodeString';
     import { untrack } from 'svelte';
     import type { SvelteMap } from 'svelte/reactivity';
-    import UnicodeString from '@unicode/UnicodeString';
     import HowToForm from './HowToForm.svelte';
     import {
         findHowToPlacement,
         movePermitted,
         snapToNearestEdge,
     } from './HowToMovement';
-    import { pickPreviewExample } from '@concepts/pickPreviewExample';
 
     interface Props {
         howTo: HowTo;
@@ -211,7 +211,6 @@
         isAuthenticated($user) && allWriters.includes($user.uid),
     );
 
-
     /** Anchor recorded at drag start: the viewport-space cursor position
      *  and the tile's world-space position. We compute new positions as
      *  origin.xcoord + (e.clientX - origin.clientX) instead of summing
@@ -262,6 +261,31 @@
         if (panY !== 0) cameraY += panY;
     }
 
+    // Latest pointer position waiting for the next animation frame.
+    // Storing absolute clientX/Y (not deltas) means we only need the
+    // most recent event — earlier ones in the same frame are redundant.
+    let pendingClientX: number | null = null;
+    let pendingClientY: number | null = null;
+    let dragRafID: number | undefined;
+
+    function flushDrag() {
+        if (dragRafID !== undefined) {
+            cancelAnimationFrame(dragRafID);
+            dragRafID = undefined;
+        }
+        if (
+            dragOrigin !== null &&
+            pendingClientX !== null &&
+            pendingClientY !== null
+        ) {
+            xcoord = dragOrigin.xcoord + (pendingClientX - dragOrigin.clientX);
+            ycoord = dragOrigin.ycoord + (pendingClientY - dragOrigin.clientY);
+            autoPanToShowTile();
+            pendingClientX = null;
+            pendingClientY = null;
+        }
+    }
+
     function onpointerdown(e: PointerEvent) {
         if (!canEdit || whichDialogOpen) return;
 
@@ -286,6 +310,7 @@
     function onpointerup() {
         if (whichMoving !== howToId || !canEdit || whichDialogOpen) return;
 
+        flushDrag();
         dragOrigin = null;
         whichMoving = undefined;
 
@@ -303,9 +328,14 @@
             dragOrigin === null
         )
             return;
-        xcoord = dragOrigin.xcoord + (e.clientX - dragOrigin.clientX);
-        ycoord = dragOrigin.ycoord + (e.clientY - dragOrigin.clientY);
-        autoPanToShowTile();
+        pendingClientX = e.clientX;
+        pendingClientY = e.clientY;
+        if (dragRafID === undefined) {
+            dragRafID = requestAnimationFrame(() => {
+                dragRafID = undefined;
+                flushDrag();
+            });
+        }
     }
 
     let keyboardFocused: boolean = $state(false);
@@ -323,7 +353,10 @@
         if (!canEdit || whichDialogOpen) return;
 
         keyboardFocused = false;
-        if (whichMoving === howToId) whichMoving = undefined;
+        if (whichMoving === howToId) {
+            flushDrag();
+            whichMoving = undefined;
+        }
 
         onDropHowTo();
     }

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToPreview.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToPreview.svelte
@@ -145,7 +145,7 @@
             [],
             $locales.getLocales(),
         );
-        enqueuePreviewCompute(project, $locales, DB)
+        enqueuePreviewCompute(project, $locales, DB, howTo.getHowToId())
             .then((extracted) => {
                 if (cancelled) return;
                 if (extracted.face) Fonts.loadFace(extracted.face);
@@ -211,8 +211,6 @@
         isAuthenticated($user) && allWriters.includes($user.uid),
     );
 
-    let renderX: number = $derived(xcoord + (isPublished ? cameraX : 0));
-    let renderY: number = $derived(ycoord + (isPublished ? cameraY : 0));
 
     /** Anchor recorded at drag start: the viewport-space cursor position
      *  and the tile's world-space position. We compute new positions as
@@ -243,6 +241,8 @@
         if (!isPublished) return;
         if (canvasWidth <= 0 || canvasHeight <= 0) return;
 
+        const renderX = xcoord + cameraX;
+        const renderY = ycoord + cameraY;
         let panX = 0;
         let panY = 0;
 
@@ -495,8 +495,8 @@
 <div
     class="howto"
     class:moving={whichMoving === howToId}
-    style:left={`${renderX}px`}
-    style:top={`${renderY}px`}
+    style:left={`${xcoord}px`}
+    style:top={`${ycoord}px`}
     id="howto-{howToId}"
     tabindex="0"
     bind:clientWidth={width}


### PR DESCRIPTION
# Context

<!-- Briefly describe what this issue is about -->

Adrienne reporting lagging when navigating the how-to space as well as previews taking a long time to load.

**Previews**
- Problem: although a preview cache is being maintained, it is cached on the project ID, which is ephemeral (new null project created to render the preview). 
- Solution: cache how-to previews on a "cache ID" instead, which is the how-to's ID

**Navigation lag**
- Problem: the entire canvas was re-rendering each time it was dragged
- Solution: use CSS transforms, which apparently is a lot faster?

- Problem: we updated the canvas camera position or the preview tile's position for every mouse move instead of every paint (which has a lower frequency)
- Solution: only update the how-to's or camera's position when painting is done

- Problem: the canvas lags the most when approaching a new how-to that has not been rendered yet
- Solution: pre-load how-tos that are within half a canvas of the current view

While I had the hypothesis that the issue was that the canvas was being re-rendered every time it was dragged, Claude identified the problems and suggested each fix when prompted. I verified the changes.

## Related issues

<!--
For pull requests that relate or close an issue, please include them below.  We follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). For example having the text: "closes #1234" would connect the current pull
request to issue 1234. And when we merge the pull request, Github will automatically close the issue.
-->

-   Related Issue #
-   Closes #

## Verification

<!-- Describe how you have verified your changes and how we can follow the same steps, including what browsers you've tested on, and what accessibility verification you've done. -->

I added code to each of the pre-generated how-tos so that examples would be computed. Panning and moving behavior is intact. I don't think I'm seeing the same slowdowns as Adrienne is, but I can confirm that panning is faster and there is no longer a long pause before a new how-to is rendered on the screen. 

## Checklist

<!-- If this is a draft pull request, what steps remain before you view it as complete? You can use GitHub's checklist to make a list for yourself (e.g., - [ ], - [x]) -->
