### PR TITLE
Pause Speech bubble animations off-screen and while scrolling

### DIFF
--- a/src/components/lore/Eyes.svelte
+++ b/src/components/lore/Eyes.svelte
@@ -33,9 +33,11 @@
     interface Props {
         invert: boolean;
         emotion: Emotion;
+        /** When false, the blink loop is paused (e.g. the bubble is off-screen or scrolling). */
+        active?: boolean;
     }
 
-    let { invert, emotion }: Props = $props();
+    let { invert, emotion, active = true }: Props = $props();
 
     let left: HTMLElement | null = $state(null);
     let right: HTMLElement | null = $state(null);
@@ -63,7 +65,7 @@
     }
 
     function animateEyes() {
-        if (left && right && $animationFactor > 0) {
+        if (active && left && right && $animationFactor > 0) {
             offset = Math.round(Math.random() * 4 - 2);
             gaze = Math.round(Math.random() * 50);
             const delay = getRandomDelay();
@@ -92,7 +94,8 @@
     let offset = $state(0);
     let gaze = $state(25);
     $effect(() => {
-        if (left && right && $animationFactor > 0) animateEyes();
+        if (active && left && right && $animationFactor > 0) animateEyes();
+        else cancelAnimations();
     });
 
     let eyes = $derived(

--- a/src/components/lore/Speech.svelte
+++ b/src/components/lore/Speech.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import { locales, animationDuration } from '@db/Database';
+    import { locales, animationDuration, animationFactor } from '@db/Database';
+    import { scrolling } from '@db/settings/scrolling';
     import { type Snippet } from 'svelte';
     import { slide } from 'svelte/transition';
     import Concept from '@concepts/Concept';
@@ -65,6 +66,29 @@
     );
 
     let symbols = $derived(withColorEmoji(characters));
+
+    // Decorative emotion/eye animations are paused when the bubble is off-screen or while the
+    // page is actively scrolling, so a page with many bubbles (e.g. a structure concept's
+    // ~27 properties) doesn't contend with the compositor and drop frames on mobile.
+    let dialog = $state<HTMLElement>();
+    let onscreen = $state(true);
+    $effect(() => {
+        const el = dialog;
+        if (!(el instanceof HTMLElement)) return;
+        if (typeof IntersectionObserver === 'undefined') {
+            onscreen = true;
+            return;
+        }
+        const observer = new IntersectionObserver(
+            (entries) => {
+                onscreen = entries.some((entry) => entry.isIntersecting);
+            },
+            { rootMargin: '200px' },
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    });
+    let animate = $derived(emote && onscreen && !$scrolling && $animationFactor > 0);
 </script>
 
 <div
@@ -77,12 +101,13 @@
           : 'row'} {!below && baseline ? 'baseline' : ''}"
     class:big
     class:scroll
+    bind:this={dialog}
 >
     <div class="speaker">
         <div
             class="characters {symbols.length >= 3
                 ? 'small'
-                : ''} {renderedEmotion && emote
+                : ''} {renderedEmotion && animate
                 ? `emotion-${renderedEmotion}`
                 : ''}"
         >
@@ -91,7 +116,7 @@
             {:else}
                 {symbols}
             {/if}
-            <Eyes {invert} emotion={emotion ?? Emotion.neutral} />
+            <Eyes {invert} active={animate} emotion={emotion ?? Emotion.neutral} />
         </div>{@render aside?.()}
     </div>
     {#if bubble && content}

--- a/src/db/settings/scrolling.ts
+++ b/src/db/settings/scrolling.ts
@@ -1,0 +1,25 @@
+import { browser } from '$app/environment';
+import { readable } from 'svelte/store';
+
+/** ms after the last scroll event before we consider scrolling to have stopped. */
+const IDLE_DELAY = 150;
+
+/** True while the user is actively scrolling anywhere in the app; flips false ~IDLE_DELAY ms
+ *  after scrolling stops. Used to suspend decorative animations (e.g. Speech bubbles) during
+ *  scroll so they don't contend with the compositor and drop frames on mobile. */
+export const scrolling = readable<boolean>(false, (set) => {
+    if (!browser) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const handler = () => {
+        set(true);
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => set(false), IDLE_DELAY);
+    };
+    // Capture + passive lets one cheap document-level listener catch scrolls from any nested
+    // scroller (scroll doesn't bubble) without blocking the scroll itself.
+    document.addEventListener('scroll', handler, { capture: true, passive: true });
+    return () => {
+        document.removeEventListener('scroll', handler, { capture: true });
+        if (timer) clearTimeout(timer);
+    };
+});


### PR DESCRIPTION
## Problem

Scrolling a structure concept page in the guide (e.g. **Phrase**) drops many frames on iOS Safari. The how-to listing is smooth — the difference is the **Speech bubbles**: a structure concept renders one bubble per input/property (~27 for Phrase), and each bubble runs an *infinite* `emotion-*` CSS animation **plus** a perpetual self-rescheduling eye-blink loop. Desktop's multi-threaded compositor hides the cost; iOS Safari's single main thread can't tick ~54 animations *and* composite a smooth scroll.

## Fix

Gate each bubble's decorative animations on **(on-screen) AND (not actively scrolling)**:

- New `scrolling` store ([src/db/settings/scrolling.ts](src/db/settings/scrolling.ts)) — `true` while the user scrolls anywhere (one capture-phase passive listener), flips `false` ~150ms after scrolling stops. Mirrors the existing `prefersReducedMotion` store.
- `Speech.svelte` derives `animate = emote && onscreen && !scrolling && animationFactor > 0` (IntersectionObserver tracks `onscreen`, guarded for tests/SSR), applies the `emotion-*` class only when `animate`, and passes `active={animate}` to Eyes.
- `Eyes.svelte` gains an `active` prop (default `true`) that pauses its blink loop.

Only the few visible bubbles animate at rest, and all freeze during an active scroll. On-screen idle appearance and reduced-motion behavior are unchanged.

## Verification

- `npm run check:now` — 0 errors
- `npm test` — 2907 passed
- Manual: on the Phrase guide page, bubbles freeze while scrolling and resume ~150ms after stopping; visible bubbles animate as before at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)