### PR TITLE
Make Speech eyes opt-in; remove from concept input/property listings

### DIFF
--- a/src/components/annotations/Annotation.svelte
+++ b/src/components/annotations/Annotation.svelte
@@ -177,7 +177,7 @@
         class={`annotation ${annotation.kind}`}
         transition:fade|local={{ duration: $animationDuration }}
     >
-        <Speech character={annotation.node.getCharacter($locales)} below>
+        <Speech character={annotation.node.getCharacter($locales)} below eyes>
             {#snippet content()}{@render messageBody()}{/snippet}
         </Speech>
     </div>
@@ -212,6 +212,7 @@
         <Speech
             character={annotation.node.getCharacter($locales)}
             below
+            eyes
             bubble={expanded}
         >
             {#snippet aside()}{@render nameLabel()}{/snippet}

--- a/src/components/annotations/Annotations.svelte
+++ b/src/components/annotations/Annotations.svelte
@@ -353,6 +353,7 @@
         <div class="annotations">
             {#if source.isEmpty()}
                 <Speech
+                    eyes
                     character={Characters.FunctionDefinition}
                     scroll={false}
                     below
@@ -370,6 +371,7 @@
                 <!-- Hide the caret description while conflicts are showing so the
                      list stays scannable. -->
                 <Speech
+                    eyes
                     character={Characters.FunctionDefinition}
                     scroll={false}
                     below

--- a/src/components/app/Background.svelte
+++ b/src/components/app/Background.svelte
@@ -132,6 +132,7 @@
                 >{withColorEmoji(character.symbol)}<Eyes
                     invert={false}
                     emotion={Emotion.neutral}
+                    active={false}
                 /></div
             >
         {/each}

--- a/src/components/app/TutorialView.svelte
+++ b/src/components/app/TutorialView.svelte
@@ -833,6 +833,7 @@
                                     projectContext?.getConceptByName(character)}
                                 <!-- First speaker is always function, alternating speakers are the concept we're learning about. -->
                                 <Speech
+                                    eyes
                                     character={concept ??
                                         BasisCharacters[
                                             character as keyof typeof BasisCharacters

--- a/src/components/concepts/ConceptView.svelte
+++ b/src/components/concepts/ConceptView.svelte
@@ -95,7 +95,11 @@
 
     <div class="body" class:sidebar={useSidebar}>
         <div class="bubble">
-            <Speech character={concept.getCharacter($locales)} below={header}>
+            <Speech
+                character={concept.getCharacter($locales)}
+                below={header}
+                eyes={header}
+            >
                 {#snippet content()}
                     {#if concept.getDocs($locales)[0]}
                         <MarkupHTMLView

--- a/src/components/lore/Speech.svelte
+++ b/src/components/lore/Speech.svelte
@@ -28,6 +28,11 @@
         emote?: boolean;
         /** Optionally double size of text */
         big?: boolean;
+        /** Whether to render the character's animated blinking eyes. Off by default: eyes are
+         *  reserved for prominent, one-at-a-time characters (tutorial, annotations, palette),
+         *  not the many small bubbles in a concept's input/property listing, where dozens of
+         *  blink loops would drop frames. */
+        eyes?: boolean;
         /** Whether to render the speech bubble. When false, only the character
          *  (and optional aside) show — useful for a collapsed view whose
          *  character must be identical to the expanded one. Toggling this
@@ -47,6 +52,7 @@
         emotion = undefined,
         emote = true,
         big = false,
+        eyes = false,
         bubble = true,
         aside,
         content,
@@ -116,7 +122,11 @@
             {:else}
                 {symbols}
             {/if}
-            <Eyes {invert} active={animate} emotion={emotion ?? Emotion.neutral} />
+            {#if eyes}<Eyes
+                    {invert}
+                    active={animate}
+                    emotion={emotion ?? Emotion.neutral}
+                />{/if}
         </div>{@render aside?.()}
     </div>
     {#if bubble && content}

--- a/src/components/output/OutputView.svelte
+++ b/src/components/output/OutputView.svelte
@@ -1422,6 +1422,7 @@
         {:else if exception !== undefined}
             <div class="message exception" class:mini data-uiid="exception"
                 >{#if mini}!{:else}<Speech
+                        eyes
                         character={index?.getNodeConcept(exception.creator) ??
                             exception.creator.getCharacter($locales)}
                         invert

--- a/src/components/palette/Palette.svelte
+++ b/src/components/palette/Palette.svelte
@@ -217,6 +217,7 @@
 >
     {#if propertyValues.size > 0}
         <Speech
+            eyes
             character={(outputs.length > 1 || definition === undefined
                 ? undefined
                 : index?.getStructureConcept(definition)) ?? {
@@ -253,7 +254,7 @@
         {/each}
     {:else if editable}
         {#if selection === undefined || selection.isEmpty()}
-            <Speech character={{ symbols: PALETTE_SYMBOL }}
+            <Speech eyes character={{ symbols: PALETTE_SYMBOL }}
                 >{#snippet content()}
                     <MarkupHtmlView
                         markup={(l) => l.ui.palette.prompt.select}


### PR DESCRIPTION
Follow-up to #1206. That PR paused Speech animations off-screen and during scroll, which helped but didn't fully fix the jank on a structure/function concept page (e.g. Phrase): even paused, ~27 `Eyes` components (one per input/property bubble) added enough DOM and blink-loop churn to keep dropping frames on iOS.

## Change

Make blinking eyes **opt-in** via a new `Speech` `eyes` prop (default off), and enable them only where a prominent, one-at-a-time character speaks:

- **Eyes on:** tutorial dialogue (`TutorialView`), annotations (`Annotations`, `Annotation`), palette (`Palette`), the `OutputView` exception bubble, and the **top/header** concept bubble (`ConceptView`, via `eyes={header}`).
- **Eyes off:** the per-input/property bubbles in concept listings (`BindConceptView`), how-to concept views, etc.
- **Background** characters keep their eyes but render them **static** (`active={false}`) for performance.
- **PeekingBackground** (TutorialChooser's peek background) keeps its animated eyes (unchanged).

Net result: a structure/function concept page renders **zero** Eyes in its input/property listing, removing the bulk of the per-bubble DOM and JS churn.

## Verification

- `npm run check:now` — 0 errors
- `npm test` — 2907 passed

## Open questions (deferred)

- TutorialChooser's own speech bubble currently has no eyes (only its peek background does). Add them?
- ProjectView's function-definition glyph currently has no eyes. Keep eyeless?

🤖 Generated with [Claude Code](https://claude.com/claude-code)