### PR TITLE
Fix duplicate contributor update PRs from stale deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,5 +56,11 @@ jobs:
             # freshly deployed client could call not-yet-updated functions. This
             # is acceptable as long as function changes are backward-compatible;
             # if that stops holding, split functions into its own prior step.
-            - run: npx firebase deploy --project wordplay-prod
+            #
+            # --force prunes functions that no longer exist in source. Without
+            # it, a renamed/removed function lingers in the project (CI can't
+            # answer the interactive deletion prompt) and keeps running its last
+            # deployed code on its own schedule — the cause of the duplicate
+            # contributor-update PRs.
+            - run: npx firebase deploy --project wordplay-prod --force
               name: Deploy to Firebase

--- a/functions/src/contributors.ts
+++ b/functions/src/contributors.ts
@@ -3,7 +3,6 @@ import {
     isBot,
     paginate,
     REPO_BASE,
-    REPO_OWNER,
     type GitHubUser,
 } from './github.js';
 
@@ -199,6 +198,10 @@ export async function fetchContributorsData(
     return { created: new Date().toISOString(), contributors };
 }
 
+/** Title shared by detection and creation so the duplicate check can match an
+ * existing PR by title regardless of its branch name. */
+const PR_TITLE = 'Update contributors data';
+
 /** GitHub returns 422 when a ref/PR already exists; tolerate that so duplicate
  * scheduled invocations converge instead of erroring (and triggering retries). */
 function alreadyExists(e: unknown): boolean {
@@ -220,12 +223,16 @@ export async function createContributorsPR(
         'base64',
     );
 
-    // If a PR for this branch is already open, this invocation is a duplicate.
-    const open = await githubFetch(
+    // Bail if any auto-generated contributors PR is already open. Matching by
+    // title (not just this branch's head) catches a duplicate opened by a
+    // separate invocation whose branch is named differently — e.g. a stale
+    // function deployment still minting timestamped branches — which a
+    // head-only check would miss.
+    const open = (await githubFetch(
         token,
-        `${base}/pulls?head=${REPO_OWNER}:${branch}&state=open`,
-    );
-    if (Array.isArray(open) && open.length > 0) return;
+        `${base}/pulls?base=main&state=open&per_page=100`,
+    )) as Array<{ title: string }> | undefined;
+    if (Array.isArray(open) && open.some((pr) => pr.title === PR_TITLE)) return;
 
     const ref = (await githubFetch(token, `${base}/git/ref/heads/main`)) as {
         object: { sha: string };
@@ -272,7 +279,7 @@ export async function createContributorsPR(
         await githubFetch(token, `${base}/pulls`, {
             method: 'POST',
             body: JSON.stringify({
-                title: 'Update contributors data',
+                title: PR_TITLE,
                 head: branch,
                 base: 'main',
                 body: `Automated refresh of \`static/contributors.json\` generated on ${data.created}.`,

--- a/functions/src/refreshContributors.ts
+++ b/functions/src/refreshContributors.ts
@@ -1,6 +1,17 @@
 import { createContributorsPR, fetchContributorsData } from './contributors.js';
 
+/** The contributor refresh opens PRs against the public repo, so it must run
+ * from exactly one place. Guard against a non-prod deployment (e.g.
+ * wordplay-dev) that fires the same weekly schedule and opens a duplicate PR.
+ * Only bail when we positively identify a non-prod project, so a missing
+ * project env var can never silently disable the prod job. */
+const PROD_PROJECT = 'wordplay-prod';
+
 export default async function refreshContributors(): Promise<void> {
+    const project =
+        process.env.GCLOUD_PROJECT ?? process.env.GOOGLE_CLOUD_PROJECT;
+    if (project !== undefined && project !== PROD_PROJECT) return;
+
     const token = process.env.GITHUB_TOKEN ?? '';
     const data = await fetchContributorsData(token);
     await createContributorsPR(token, data);


### PR DESCRIPTION
# Context

The contributor update function was opening duplicate PRs when multiple deployments of the same function were active (e.g., a stale deployment still running on its own schedule). This happened because:

1. The duplicate detection only checked if a PR existed for the current branch name, missing PRs opened by other deployments with differently-named branches
2. Firebase deployments weren't being pruned, so renamed/removed functions lingered and continued executing their old scheduled code
3. Non-prod deployments (e.g., `wordplay-dev`) were also firing the same weekly schedule and opening PRs against the public repo

## Changes

- **Duplicate detection by title**: Changed from checking `head={branch}` to checking all open PRs against `main` and matching by the shared `PR_TITLE` constant. This catches duplicates regardless of branch name.
- **Removed unused import**: Removed `REPO_OWNER` which is no longer needed after the duplicate detection refactor.
- **Environment-based gating**: Added a check in `refreshContributors` to only run on the `wordplay-prod` project, preventing non-prod deployments from opening PRs.
- **Force function pruning**: Added `--force` flag to Firebase deploy to remove stale functions that no longer exist in source, preventing them from continuing to run on their schedules.

## Verification

The changes are defensive and backward-compatible:
- The title-based duplicate check is more robust than the branch-based check
- The project environment check only bails on non-prod projects, so a missing env var won't silently disable the prod job
- The `--force` flag is a standard Firebase deployment practice for CI environments

Existing tests should continue to pass. The changes prevent the duplicate PR issue without altering the core contributor data fetching or PR creation logic.

https://claude.ai/code/session_01A7m1S7g5krLqmES4rKHUP1