### PR TITLE
Add AgentPond tracing for Anthropic functions

### DIFF
--- a/.agents/skills/agentpond-instrumentation/SKILL.md
+++ b/.agents/skills/agentpond-instrumentation/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: agentpond-instrumentation
+description: Add OpenInference tracing to a Firebase server application and export spans directly to AgentPond through Firebase Storage. Use when instrumenting an untraced Firebase AI application, adding a missing OpenInference integration, or adapting an existing OpenTelemetry setup to use createFirebaseSpanExporter().
+---
+
+# AgentPond Instrumentation
+
+Instrument Firebase AI applications without changing business behavior. Analyze the target service first, reuse existing tracing infrastructure, and keep Firebase Admin and trace export strictly server-side.
+
+Read these references when relevant:
+
+- Firebase Admin, exporter, and Storage Rules: [references/firebase.md](references/firebase.md)
+- OpenInference routing, custom spans, sessions, and verification: [references/openinference.md](references/openinference.md)
+
+## Core principles
+
+- Inspect before editing. Confirm the service, runtime, package manager, AI SDK, framework, and existing telemetry.
+- Instrument only trusted server code. Never import `firebase-admin` or `@agentpond/firebase` into browser or client bundles.
+- Prefer framework or provider auto-instrumentation. Add manual spans only for application logic, chains, tools, or gaps.
+- Reuse the existing Firebase default app and global OpenTelemetry provider. Do not register a competing provider.
+- Initialize tracing before importing or constructing instrumented AI clients.
+- Keep tracing additive and follow the repository's conventions.
+- Never add credentials to source code or ask the user to paste secrets into chat.
+
+## Phase 0: preflight
+
+1. Confirm which Firebase service should be instrumented. In a monorepo, do not assume every Functions source or server package is in scope.
+2. Identify the build, typecheck, start, emulator, and real-request commands needed for verification.
+3. Confirm the target is a trusted Node.js server runtime. If only client code exists, stop and ask whether the user wants to add a server function or another trusted runtime.
+4. Read [references/firebase.md](references/firebase.md) before proposing Firebase changes.
+
+## Phase 1: read-only analysis
+
+Do not write files or install packages during this phase.
+
+1. Inspect `firebase.json`, `.firebaserc`, package manifests, lockfiles, and server entrypoints.
+2. Scan imports to identify:
+   - AI providers and clients
+   - agent or LLM frameworks
+   - existing OpenInference or OpenTelemetry setup
+   - Firebase Admin initialization
+   - request, conversation, and tool execution boundaries
+3. Find the Storage Rules file configured by `firebase.json` and review whether any matching client rule can access `agentpond/**`.
+4. Prefer a framework-native OpenInference integration when it captures model and tool spans. Add a provider instrumentor only for a documented gap.
+5. Return a concise proposal containing:
+   - target service and package manager
+   - detected AI SDKs and framework
+   - packages to install
+   - existing Firebase and telemetry initialization to reuse
+   - Storage Rules status
+   - files and verification commands expected to change
+
+Stop after presenting the proposal and ask for explicit confirmation before installing packages or editing files. The initial request to instrument the project does not replace confirmation of the analyzed target, package choices, files, and Storage Rules changes.
+
+## Phase 2: implementation
+
+1. Read current official integration documentation for the detected framework or AI client.
+2. Install packages with the project's package manager:
+   - `@agentpond/firebase`
+   - required OpenTelemetry SDK packages
+   - the matching `@arizeai/openinference-*` package
+   - `firebase-admin` only when the trusted server package does not already provide it
+3. Create or update one centralized server instrumentation module.
+4. Reuse an existing default Firebase Admin app. Add default initialization only when it is absent; follow [references/firebase.md](references/firebase.md).
+5. Create `createFirebaseSpanExporter()` after the default app exists.
+6. Add the exporter to the existing provider. When no provider exists, create one using APIs supported by the installed OpenTelemetry version and prefer NodeSDK's batched `traceExporter` configuration or an explicit `BatchSpanProcessor`.
+7. Register the selected OpenInference instrumentation before AI clients are created.
+8. Add manual CHAIN and TOOL spans only where auto-instrumentation leaves important application behavior invisible.
+9. Preserve one `session.id` across all turns in the same conversation.
+10. Fix unsafe Storage Rules before declaring instrumentation complete. Do not add a standalone false rule as a supposed override for a broader allow.
+
+## Verification
+
+Treat the work as complete only when:
+
+1. The project builds or typechecks.
+2. The server starts or its emulator loads the instrumentation without duplicate-provider or duplicate-app errors.
+3. One real AI request produces OpenInference spans.
+4. Storage Rules do not grant client SDK access to `agentpond/**`.
+5. The trace is visible after:
+
+```bash
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+Inspect the trace and confirm model, CHAIN, TOOL, input/output, parent-child, and session attributes that apply to the application. For short-lived processes, force-flush before exit. Do not shut down a reusable module-level provider after every Firebase request.
+
+## Attribution
+
+This workflow is adapted from Arize AI's MIT-licensed [arize-instrumentation skill](https://github.com/Arize-ai/arize-skills/tree/main/skills/arize-instrumentation). It replaces Arize-specific export and verification with AgentPond and Firebase Storage while retaining the analyze-then-implement workflow.

--- a/.agents/skills/agentpond-instrumentation/agents/openai.yaml
+++ b/.agents/skills/agentpond-instrumentation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AgentPond Instrumentation"
+  short_description: "Add OpenInference tracing to Firebase apps"
+  default_prompt: "Use $agentpond-instrumentation to add OpenInference tracing to this Firebase application."

--- a/.agents/skills/agentpond-instrumentation/references/firebase.md
+++ b/.agents/skills/agentpond-instrumentation/references/firebase.md
@@ -1,0 +1,90 @@
+# Firebase instrumentation and storage
+
+Use this reference for every Firebase instrumentation task.
+
+## Trusted runtime boundary
+
+`createFirebaseSpanExporter()` uses Firebase Admin and must run in trusted server code such as Cloud Functions for Firebase or another Node.js server with Firebase Admin credentials. Never add it to web, mobile, or other client bundles.
+
+If the repository has no trusted server runtime, stop and ask whether the user wants to add one. Do not work around the boundary with client credentials.
+
+## Default Firebase app
+
+The exporter derives the project ID and storage bucket from the default Firebase Admin app. Reuse the project's existing initialization whenever possible:
+
+```ts
+import { createFirebaseSpanExporter } from "@agentpond/firebase";
+
+const exporter = createFirebaseSpanExporter();
+```
+
+Add `initializeApp()` only when the server has no default app initialization. When a shared module genuinely needs defensive initialization, check the default app specifically:
+
+```ts
+import { getApp, initializeApp } from "firebase-admin/app";
+
+try {
+  getApp();
+} catch {
+  initializeApp();
+}
+```
+
+Do not use `getApps().length` for this decision. A named app can exist while the required default app is absent.
+
+## OpenTelemetry provider
+
+Inspect the installed OpenTelemetry version and existing provider before editing. Add the exporter to the existing provider rather than registering another global provider.
+
+When no provider exists, a typical Node SDK shape is:
+
+```ts
+import { createFirebaseSpanExporter } from "@agentpond/firebase";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const sdk = new NodeSDK({
+  traceExporter: createFirebaseSpanExporter(),
+  instrumentations: [
+    // Add the integration selected for the detected AI SDK or framework.
+  ],
+});
+
+sdk.start();
+```
+
+NodeSDK wraps `traceExporter` in a `BatchSpanProcessor`, so each exporter invocation can contain multiple spans and AgentPond writes one object per exported batch. When constructing a provider manually or tuning queue and batch settings, create a `BatchSpanProcessor` explicitly instead. Do not use `SimpleSpanProcessor` for normal production export because it invokes the exporter separately for every ended span.
+
+Adapt the construction to the installed SDK API and project lifecycle. Initialize the module before instrumented clients. Force-flush at a real lifecycle boundary when required so queued batches finish exporting; do not shut down a reusable Functions instance after every request.
+
+## Storage Rules review
+
+AgentPond writes trace objects below `agentpond/` in the Firebase Storage bucket. Firebase Admin access from the exporter and local CLI is trusted and bypasses Firebase client Storage Rules. Client SDKs must not be able to read, list, create, update, or delete those objects.
+
+1. Read `firebase.json` and locate every configured Storage Rules file.
+2. Review every `match` and `allow` expression that can overlap `agentpond/**`, including recursive wildcard rules.
+3. Remember that Firebase Rules are allow-only. If any overlapping allow condition evaluates to true, access is granted.
+4. A nested block such as this is not a deny override:
+
+```rules
+match /agentpond/{allPaths=**} {
+  allow read, write: if false;
+}
+```
+
+5. If no allow matches `agentpond/**`, leave the default-deny rules unchanged.
+6. If a broad allow matches the prefix, report a blocker. Narrow the broad match to application-owned prefixes or change its actual condition so AgentPond objects are excluded. Base the edit on the repository's rule structure; do not invent a universal exclusion snippet.
+7. When the emulator and Rules tests are configured, add or run tests proving representative authenticated and unauthenticated client requests cannot access `agentpond/**` while intended application paths still work.
+
+Do not declare setup complete while a broad client allow still exposes AgentPond trace data.
+
+## Firebase project selection and verification
+
+Select the project with Firebase, not AgentPond environments:
+
+```bash
+firebase use <alias-or-project-id>
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+Do not use `npx agentpond env init` or `npx agentpond env use` for Firebase projects.

--- a/.agents/skills/agentpond-instrumentation/references/openinference.md
+++ b/.agents/skills/agentpond-instrumentation/references/openinference.md
@@ -1,0 +1,40 @@
+# OpenInference integration
+
+Use current official OpenInference documentation to select packages and initialization for the detected AI SDK or framework.
+
+## Routing
+
+1. Prefer a framework-native integration when it captures model, chain, and tool activity.
+2. Otherwise select the provider-specific `@arizeai/openinference-*` instrumentor matching imports actually used by the server.
+3. Do not add both framework and provider instrumentation when that would duplicate spans.
+4. If no auto-instrumentor exists, retain normal OpenTelemetry tracing and add OpenInference semantic attributes to manual spans.
+
+Common JavaScript surfaces include OpenAI, Anthropic, LangChain, Bedrock, Vercel AI SDK, MCP, and GenAI semantic-convention adapters. Verify the current package name and version before installation rather than guessing from this list.
+
+## Initialization order
+
+Set up the Firebase exporter and tracer provider, register instrumentations, and only then import or construct AI clients. Respect any framework-specific preload or bootstrap mechanism.
+
+If the application already has a global provider, add the AgentPond exporter to it. Do not replace existing exporters unless the user explicitly asks.
+
+## Manual spans
+
+Use manual spans for custom application steps that auto-instrumentation cannot see:
+
+- `CHAIN`: orchestration or agent-loop boundaries
+- `TOOL`: each tool invocation, including input, output, and error status
+- `AGENT`: a meaningful agent execution boundary when the framework does not emit one
+
+Set `openinference.span.kind` and the applicable `input.value`, `output.value`, and MIME-type attributes. Avoid recording secrets or unnecessary personal data.
+
+## Sessions
+
+Set `session.id` on the outer CHAIN or AGENT span. Generate it once at the conversation boundary and reuse it for every turn in that conversation. Auto-instrumented model and tool spans should be children of that outer span.
+
+## Flush and verification
+
+- Long-running servers: keep the provider alive and flush at supported lifecycle boundaries.
+- Short-lived scripts and test commands: force-flush and shut down before process exit.
+- Firebase request handlers: do not shut down a module-level provider after every request.
+
+Run a real application request and verify the resulting trace rather than treating compilation alone as success. Confirm span kinds, inputs/outputs, parent-child relationships, tool results, and session grouping.

--- a/.agents/skills/agentpond/SKILL.md
+++ b/.agents/skills/agentpond/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: agentpond
+description: Inspect and analyze AgentPond traces, observations, sessions, and scores with focused CLI commands and DuckDB SQL. Use when investigating agent behavior, querying trace data, comparing sessions, reviewing annotations, or diagnosing failures after traces have already been collected.
+---
+
+# AgentPond trace analytics
+
+Use AgentPond to inspect collected trace data.
+
+Read these references when relevant:
+
+- Data-access commands and environment selection: [references/cli.md](references/cli.md)
+- DuckDB tables and SQL examples: [references/duckdb-schema.md](references/duckdb-schema.md)
+- Trace investigation workflow: [references/error-analysis.md](references/error-analysis.md)
+
+## Select the data source
+
+First determine whether the current directory is inside a Firebase project.
+
+For Firebase, select the project with Firebase:
+
+```bash
+firebase use <alias-or-project-id>
+npx agentpond sync
+```
+
+AgentPond follows the Firebase CLI's active project selection, including
+selections stored globally when the project has no `.firebaserc`.
+If skill installation is cancelled, `init` stops without printing the coding-agent prompt.
+
+For non-Firebase storage, inspect and select an existing AgentPond environment:
+
+```bash
+npx agentpond env current
+npx agentpond env list
+npx agentpond env use <name>
+npx agentpond sync
+```
+
+Select only an existing non-Firebase environment as part of an analysis request.
+
+## Inspect traces
+
+Start with focused commands:
+
+```bash
+npx agentpond traces list --limit 25
+npx agentpond traces get <trace-id>
+npx agentpond observations list --traceId <trace-id>
+npx agentpond scores list --traceId <trace-id>
+```
+
+Inspect a session when behavior spans multiple traces:
+
+```bash
+npx agentpond sessions list
+npx agentpond sessions get <session-id>
+```
+
+Use SQL for joins, aggregation, time windows, raw event inspection, or cost analysis:
+
+```bash
+npx agentpond sql "select id, name, session_id, total_cost from traces order by start_time desc limit 10"
+```
+
+## Report findings
+
+Separate confirmed observations from inference. Include the trace or session IDs inspected, commands or SQL used, the observed pattern, the likely cause, and the smallest useful code, prompt, or workflow change.

--- a/.agents/skills/agentpond/references/cli.md
+++ b/.agents/skills/agentpond/references/cli.md
@@ -1,0 +1,49 @@
+# AgentPond data-access CLI
+
+Run AgentPond through `npx` unless it is installed globally.
+
+## Select data
+
+Firebase project selection is owned by Firebase:
+
+```bash
+firebase use <alias-or-project-id>
+npx agentpond sync
+```
+
+AgentPond detects the Firebase root from `.firebaserc` or `firebase.json`, follows the active selection stored by the Firebase CLI even when `.firebaserc` is absent, uses that project ID for the local cache name, reads the Firebase project data, and ignores AgentPond environment selection.
+
+`npx agentpond init` verifies that both AgentPond skills exist after installation. Cancelling the Skills CLI stops setup without printing a success message or coding-agent prompt.
+
+For non-Firebase storage, select an existing environment:
+
+```bash
+npx agentpond env current
+npx agentpond env list
+npx agentpond env use production
+npx agentpond --env staging sync
+```
+
+Sync the selected environment before querying when recent data matters.
+
+## Query commands
+
+```bash
+npx agentpond sync
+npx agentpond sync --json
+
+npx agentpond traces list --limit 25
+npx agentpond traces get <trace-id>
+npx agentpond observations list --traceId <trace-id>
+
+npx agentpond sessions list
+npx agentpond sessions get <session-id>
+
+npx agentpond scores list --traceId <trace-id>
+npx agentpond scores list --observationId <observation-id>
+
+npx agentpond sql "select * from traces limit 10"
+npx agentpond sql "select * from scores where trace_id = '<trace-id>'" --json
+```
+
+Use JSON output when another tool needs to consume the result. Use focused commands for individual resources and SQL for aggregation, joins, time filtering, raw events, and cost analysis.

--- a/.agents/skills/agentpond/references/duckdb-schema.md
+++ b/.agents/skills/agentpond/references/duckdb-schema.md
@@ -1,0 +1,119 @@
+# DuckDB Schema
+
+AgentPond stores raw accepted events and projected analysis tables in the configured DuckDB cache. Use `npx agentpond sync` before querying when object storage may contain new events.
+
+## Queryable Structures
+
+`events_raw` keeps every accepted event payload:
+
+```text
+event_id TEXT PRIMARY KEY
+project_id TEXT
+manifest_key TEXT
+object_key TEXT
+event_type TEXT
+event_timestamp TIMESTAMP
+entity_id TEXT
+body_json TEXT
+event_json TEXT
+```
+
+`traces` contains projected trace rows:
+
+```text
+id TEXT PRIMARY KEY
+project_id TEXT
+name TEXT
+user_id TEXT
+session_id TEXT
+start_time TIMESTAMP
+end_time TIMESTAMP
+metadata_json TEXT
+input_json TEXT
+output_json TEXT
+total_cost DOUBLE
+updated_at TIMESTAMP
+```
+
+`observations` contains projected span, generation, and observation rows:
+
+```text
+id TEXT PRIMARY KEY
+project_id TEXT
+trace_id TEXT
+parent_observation_id TEXT
+type TEXT
+name TEXT
+start_time TIMESTAMP
+end_time TIMESTAMP
+metadata_json TEXT
+input_json TEXT
+output_json TEXT
+usage_details_json TEXT
+cost_details_json TEXT
+total_cost DOUBLE
+updated_at TIMESTAMP
+```
+
+`scores` contains projected trace, observation, and session scores:
+
+```text
+id TEXT PRIMARY KEY
+project_id TEXT
+trace_id TEXT
+observation_id TEXT
+session_id TEXT
+name TEXT
+value DOUBLE
+string_value TEXT
+data_type TEXT
+source TEXT
+comment TEXT
+metadata_json TEXT
+timestamp TIMESTAMP
+updated_at TIMESTAMP
+```
+
+`sessions` is a view derived from traces with session IDs:
+
+```text
+id TEXT
+project_id TEXT
+first_seen_at TIMESTAMP
+last_seen_at TIMESTAMP
+trace_count BIGINT
+```
+
+## SQL Patterns
+
+Recent high-cost traces:
+
+```bash
+npx agentpond sql "select id, name, session_id, total_cost from traces order by total_cost desc nulls last limit 20"
+```
+
+Observation timeline for one trace:
+
+```bash
+npx agentpond sql "select id, parent_observation_id, type, name, start_time, end_time, total_cost from observations where trace_id = '<trace-id>' order by start_time asc"
+```
+
+Scores attached to a trace:
+
+```bash
+npx agentpond sql "select name, value, string_value, data_type, source, comment, timestamp from scores where trace_id = '<trace-id>' order by timestamp desc"
+```
+
+Sessions with repeated trace activity:
+
+```bash
+npx agentpond sql "select id, trace_count, first_seen_at, last_seen_at from sessions order by trace_count desc, last_seen_at desc limit 20"
+```
+
+Raw event inspection:
+
+```bash
+npx agentpond sql "select event_type, event_timestamp, entity_id, body_json from events_raw where entity_id = '<entity-id>' order by event_timestamp asc"
+```
+
+JSON columns are stored as text. Use DuckDB JSON functions when a query needs fields inside `metadata_json`, `input_json`, `output_json`, `usage_details_json`, `cost_details_json`, `body_json`, or `event_json`.

--- a/.agents/skills/agentpond/references/error-analysis.md
+++ b/.agents/skills/agentpond/references/error-analysis.md
@@ -1,0 +1,72 @@
+# Error Analysis
+
+Use AgentPond to inspect real agent traces, build a failure picture, and identify concrete improvements. Start from the focused CLI commands, then use SQL when the question requires aggregation or cross-table context.
+
+## Basic Investigation Flow
+
+1. Sync fresh data:
+
+```bash
+npx agentpond sync
+```
+
+2. Find recent traces:
+
+```bash
+npx agentpond traces list --limit 25
+```
+
+3. Read the trace and its timeline:
+
+```bash
+npx agentpond traces get <trace-id>
+npx agentpond observations list --traceId <trace-id>
+```
+
+4. Check quality signals and annotations:
+
+```bash
+npx agentpond scores list --traceId <trace-id>
+```
+
+## SQL Investigation
+
+Find traces with low numeric scores:
+
+```bash
+npx agentpond sql "select t.id, t.name, t.session_id, s.name as score_name, s.value, s.comment from traces t join scores s on s.trace_id = t.id where s.value is not null and s.value < 0.5 order by s.timestamp desc limit 50"
+```
+
+Inspect observation trees for a trace:
+
+```bash
+npx agentpond sql "select id, parent_observation_id, type, name, start_time, end_time, total_cost from observations where trace_id = '<trace-id>' order by start_time asc"
+```
+
+Find expensive traces:
+
+```bash
+npx agentpond sql "select id, name, user_id, session_id, total_cost, start_time from traces order by total_cost desc nulls last limit 25"
+```
+
+Find repeated sessions:
+
+```bash
+npx agentpond sql "select id, trace_count, first_seen_at, last_seen_at from sessions where trace_count > 1 order by last_seen_at desc"
+```
+
+Inspect raw payloads when projected columns do not explain the behavior:
+
+```bash
+npx agentpond sql "select event_type, event_timestamp, body_json from events_raw where entity_id = '<trace-or-observation-id>' order by event_timestamp asc"
+```
+
+## Recording Findings
+
+When a user asks for analysis, report:
+
+- the trace or session IDs inspected
+- the commands or SQL used
+- the observed failure pattern
+- the likely root cause, stated separately from confirmed facts
+- the smallest code, prompt, or workflow change that would address the pattern

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,8 +9,11 @@
                 "shared-types"
             ],
             "dependencies": {
+                "@agentpond/firebase": "^0.4.2",
                 "@anthropic-ai/sdk": "^0",
+                "@arizeai/openinference-instrumentation-anthropic": "^0.1.15",
                 "@google-cloud/translate": "^9",
+                "@opentelemetry/sdk-node": "^0.220.0",
                 "@supercharge/promise-pool": "^3",
                 "firebase-admin": "^13",
                 "firebase-functions": "^7",
@@ -26,6 +29,71 @@
             },
             "engines": {
                 "node": "^22.0.0"
+            }
+        },
+        "node_modules/@agentpond/core": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@agentpond/core/-/core-0.4.2.tgz",
+            "integrity": "sha512-zzPN5RolUc9QL2PzZq9uNdtNgPzNJK2D2qpc1pDHMQHT53KfOb1kqmFxn1ZbAnLkuP+4FON5yfHv7MObUNe2yA==",
+            "license": "MIT",
+            "dependencies": {
+                "protobufjs": "^7.6.4",
+                "zod": "^4.3.6"
+            }
+        },
+        "node_modules/@agentpond/firebase": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@agentpond/firebase/-/firebase-0.4.2.tgz",
+            "integrity": "sha512-OyEsZYdlsxKQOjhAnYWzUMAk/B5Z4e8rVxItzNY0B4hJeb19OtxQyj+Z1CacP4Ev4DrTu0V0s4nAAyxTicBqSw==",
+            "license": "MIT",
+            "dependencies": {
+                "@agentpond/core": "0.4.2",
+                "@agentpond/google": "0.3.5",
+                "@agentpond/ingest": "0.3.5",
+                "@agentpond/otel": "0.1.1"
+            },
+            "peerDependencies": {
+                "firebase-admin": ">=13.6.0"
+            },
+            "peerDependenciesMeta": {
+                "firebase-admin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@agentpond/google": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@agentpond/google/-/google-0.3.5.tgz",
+            "integrity": "sha512-4ft91NKsXtGC/bvrOeGZ+dPwcwsDOHQLmJcSuK6ykI9NOJ9wztht9ZMsVB9EZ4+3Wk+yjSPZK/l4lShXyrHc8g==",
+            "license": "MIT",
+            "dependencies": {
+                "@agentpond/core": "0.4.2",
+                "@agentpond/ingest": "0.3.5",
+                "@google-cloud/storage": "^7.21.0"
+            }
+        },
+        "node_modules/@agentpond/ingest": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@agentpond/ingest/-/ingest-0.3.5.tgz",
+            "integrity": "sha512-MlyRgciw7cqqznI21eVESXiys/RbjBGPPZCV3THmiIQBJBJINp3J9yHbm2vm5fkooQtUF6fGiy/PjeHeF4EUpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@agentpond/core": "0.4.2"
+            }
+        },
+        "node_modules/@agentpond/otel": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@agentpond/otel/-/otel-0.1.1.tgz",
+            "integrity": "sha512-cgen6TxJ/rkPMlC/mxkbP/XmVC16LP1AIJRPP512P/GeM7J29+TEqBsqc9FxZ3OFkSxnzeSyRtdce5DF9E9fNA==",
+            "license": "MIT",
+            "dependencies": {
+                "@agentpond/core": "0.4.2",
+                "@opentelemetry/core": "^2.9.0",
+                "@opentelemetry/otlp-transformer": "^0.220.0",
+                "@opentelemetry/sdk-trace-base": "^2.9.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
             }
         },
         "node_modules/@anthropic-ai/sdk": {
@@ -48,6 +116,84 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@arizeai/openinference-core": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@arizeai/openinference-core/-/openinference-core-2.4.0.tgz",
+            "integrity": "sha512-F4FgdLj9dCp/f2C0GZ6w3qpd4rsNC8/Rr4ikOvQcIBsn0hjn1jyWA2/9x3TF4Xf8H53ckoGoQv4uhexgwbtCNw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@arizeai/openinference-semantic-conventions": "2.5.0",
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/core": "^1.25.1"
+            }
+        },
+        "node_modules/@arizeai/openinference-core/node_modules/@opentelemetry/core": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+            "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@arizeai/openinference-core/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@arizeai/openinference-instrumentation-anthropic": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/@arizeai/openinference-instrumentation-anthropic/-/openinference-instrumentation-anthropic-0.1.15.tgz",
+            "integrity": "sha512-YdTjEevjp3wtajdPWWUwmbRvcx3nrPYwZDDcXwPoZAtpnUeNR3uzjhYOESZGvpX69VVejtclVVrKI76gphqcrQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@arizeai/openinference-core": "2.4.0",
+                "@arizeai/openinference-semantic-conventions": "2.5.0",
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/core": "^1.25.1",
+                "@opentelemetry/instrumentation": "^0.46.0"
+            }
+        },
+        "node_modules/@arizeai/openinference-instrumentation-anthropic/node_modules/@opentelemetry/core": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+            "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@arizeai/openinference-instrumentation-anthropic/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@arizeai/openinference-semantic-conventions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@arizeai/openinference-semantic-conventions/-/openinference-semantic-conventions-2.5.0.tgz",
+            "integrity": "sha512-4ZeSwiFX3YxB0WSE6x568wM4PVHiYmz3yiOxic6WGKVrE/KIGggMFP/eqUNQhikBKP68IDV0qiILlZAIYnheAQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
@@ -1039,7 +1185,6 @@
             "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
             "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "arrify": "^2.0.0",
                 "extend": "^3.0.2"
@@ -1071,7 +1216,6 @@
             "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
             "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "@google-cloud/paginator": "^5.0.0",
                 "@google-cloud/projectify": "^4.0.0",
@@ -1097,7 +1241,6 @@
             "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
             "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
             "license": "Apache-2.0",
-            "optional": true,
             "engines": {
                 "node": ">=14"
             }
@@ -1107,7 +1250,6 @@
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -1120,7 +1262,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1138,7 +1279,6 @@
             "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
             "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "gaxios": "^6.1.1",
                 "google-logging-utils": "^0.0.2",
@@ -1153,7 +1293,6 @@
             "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
             "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
@@ -1171,7 +1310,6 @@
             "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
             "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
             "license": "Apache-2.0",
-            "optional": true,
             "engines": {
                 "node": ">=14"
             }
@@ -1181,7 +1319,6 @@
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -1196,7 +1333,6 @@
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -1209,15 +1345,13 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/@google-cloud/storage/node_modules/retry-request": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
             "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "@types/request": "^2.48.8",
                 "extend": "^3.0.2",
@@ -1232,7 +1366,6 @@
             "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
             "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "http-proxy-agent": "^5.0.0",
                 "https-proxy-agent": "^5.0.0",
@@ -1792,17 +1925,614 @@
                     "url": "https://github.com/sponsors/nodable"
                 }
             ],
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/@opentelemetry/api": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "license": "Apache-2.0",
-            "optional": true,
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-logs": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+            "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/configuration": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.220.0.tgz",
+            "integrity": "sha512-glfIVKnZevRin8fY/9uES/mhRtMT1lGINLHc9MIo5fTQZXswEEHamJtgjv4MTtzgnhHGC92mIS/0lzAUZMyE0w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "yaml": "^2.8.3"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0"
+            }
+        },
+        "node_modules/@opentelemetry/context-async-hooks": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
+            "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+            "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.220.0.tgz",
+            "integrity": "sha512-s0sRPCSlXYqlgObOpCftomJllp3LfUL9FobQ5csg2172ydVhSEnu1ptpsVBJadazs5nUNp7vDuLE03FAFWTLOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/sdk-logs": "0.220.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
+            "integrity": "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.220.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/sdk-logs": "0.220.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.220.0.tgz",
+            "integrity": "sha512-8LZAxdJ0ENDAFwr4j0oY35mHBltiSzvlhdQAPGiC7p9VnxtuSq4SW1gfBAdW6t6hiQG6OwUl8w7KHaOdJPKHWg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/sdk-logs": "0.220.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.220.0.tgz",
+            "integrity": "sha512-U128izvJfX/dW9jRGP0gIfadR1Hg7ft3UEGIeRxLFK70m2BWw6AtNCOnsUygpw2zCgR/ygdWbGpcL6TmhW0ZGw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-metrics": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.220.0.tgz",
+            "integrity": "sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-metrics": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.220.0.tgz",
+            "integrity": "sha512-lyO+IQBdSvqHN/ZOW/OzrSWemtfD+HgWngn+HBNLhjy0YrCQQTz0OE/kSekH2Pl340dn9DWzhqHdz5Eftr+HLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-metrics": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-prometheus": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.220.0.tgz",
+            "integrity": "sha512-JZD5DL/NBpVd2BHefvYosm3G40UZ/KzExLv5tc0eZe0CtrsHHtcOk3YPUxR2EINmUeBf8+w5UReTV8fFPn95lA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-metrics": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.220.0.tgz",
+            "integrity": "sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/sdk-trace": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
+            "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.220.0.tgz",
+            "integrity": "sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/exporter-zipkin": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.9.0.tgz",
+            "integrity": "sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.46.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.46.0.tgz",
+            "integrity": "sha512-a9TijXZZbk0vI5TGLZl+0kxyFfrXHhX6Svtz7Pp2/VBlCSKrazuULEyoJQrOknJyFWNMEmbbJgOciHCCpQcisw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/shimmer": "^1.0.2",
+                "import-in-the-middle": "1.7.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-exporter-base": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+            "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-transformer": "0.220.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.220.0.tgz",
+            "integrity": "sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.14.3",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-transformer": "0.220.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/otlp-transformer": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+            "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.220.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-logs": "0.220.0",
+                "@opentelemetry/sdk-metrics": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-b3": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.9.0.tgz",
+            "integrity": "sha512-WrOT1WsOUG+B7hstD2RYoMPIOK76G8E9AQHhMjUvrQaGx/oA7rPWQvvr1Rqv7+yy4R0ZMVwWLC4vW2xnkgWPAQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/propagator-jaeger": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.9.0.tgz",
+            "integrity": "sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+            "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-logs": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+            "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.220.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.4.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-metrics": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+            "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.9.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.220.0.tgz",
+            "integrity": "sha512-wHtGyHhSKHNH3fym33xRu4Ef/HXTFvX8eQ42xdQdEO9LYx9Y2qNyBDJytyqVlvmo6abWZlNYTUthuAGUMYqYnQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.220.0",
+                "@opentelemetry/configuration": "0.220.0",
+                "@opentelemetry/context-async-hooks": "2.9.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/exporter-logs-otlp-grpc": "0.220.0",
+                "@opentelemetry/exporter-logs-otlp-http": "0.220.0",
+                "@opentelemetry/exporter-logs-otlp-proto": "0.220.0",
+                "@opentelemetry/exporter-metrics-otlp-grpc": "0.220.0",
+                "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
+                "@opentelemetry/exporter-metrics-otlp-proto": "0.220.0",
+                "@opentelemetry/exporter-prometheus": "0.220.0",
+                "@opentelemetry/exporter-trace-otlp-grpc": "0.220.0",
+                "@opentelemetry/exporter-trace-otlp-http": "0.220.0",
+                "@opentelemetry/exporter-trace-otlp-proto": "0.220.0",
+                "@opentelemetry/exporter-zipkin": "2.9.0",
+                "@opentelemetry/instrumentation": "0.220.0",
+                "@opentelemetry/otlp-exporter-base": "0.220.0",
+                "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
+                "@opentelemetry/propagator-b3": "2.9.0",
+                "@opentelemetry/propagator-jaeger": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-logs": "0.220.0",
+                "@opentelemetry/sdk-metrics": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0",
+                "@opentelemetry/sdk-trace-base": "2.9.0",
+                "@opentelemetry/sdk-trace-node": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.220.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+            "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.220.0",
+                "import-in-the-middle": "^3.0.0",
+                "require-in-the-middle": "^8.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/import-in-the-middle": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+            "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "cjs-module-lexer": "^2.2.0",
+                "es-module-lexer": "^2.2.0",
+                "module-details-from-path": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/@opentelemetry/sdk-node/node_modules/require-in-the-middle": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+            "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+            "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+            "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/resources": "2.9.0",
+                "@opentelemetry/sdk-trace": "2.9.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-node": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
+            "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-async-hooks": "2.9.0",
+                "@opentelemetry/core": "2.9.0",
+                "@opentelemetry/sdk-trace-base": "2.9.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+            "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@pkgjs/parseargs": {
@@ -1936,7 +2666,6 @@
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
             "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -2016,8 +2745,7 @@
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
             "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/@types/connect": {
             "version": "3.4.38",
@@ -2169,7 +2897,6 @@
             "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
             "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "@types/caseless": "*",
                 "@types/node": "*",
@@ -2207,6 +2934,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/shimmer": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+            "license": "MIT"
+        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -2219,8 +2952,7 @@
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
             "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/@types/yargs": {
             "version": "17.0.35",
@@ -2362,9 +3094,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2380,9 +3109,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2398,9 +3124,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2416,9 +3139,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2434,9 +3154,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2452,9 +3169,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2470,9 +3184,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2488,9 +3199,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2506,9 +3214,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2524,9 +3229,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2619,7 +3321,6 @@
             "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -2638,6 +3339,28 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-assertions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+            "deprecated": "package has been renamed to acorn-import-attributes",
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/agent-base": {
@@ -2732,8 +3455,7 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -2766,7 +3488,6 @@
             "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
             "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "retry": "0.13.1"
             }
@@ -2775,8 +3496,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/babel-jest": {
             "version": "30.4.1",
@@ -3156,9 +3876,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
             "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -3275,7 +3993,6 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -3416,7 +4133,6 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3573,6 +4289,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -3590,7 +4312,6 @@
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -3656,7 +4377,6 @@
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3816,7 +4536,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "path-expression-matcher": "^1.5.0",
                 "xml-naming": "^0.1.0"
@@ -3833,7 +4552,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "@nodable/entities": "^2.2.0",
                 "fast-xml-builder": "^1.2.0",
@@ -4025,7 +4743,6 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
             "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -4113,7 +4830,6 @@
             "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
             "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
             "license": "Apache-2.0",
-            "optional": true,
             "dependencies": {
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^7.0.1",
@@ -4442,7 +5158,6 @@
             "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
             "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "gaxios": "^6.0.0",
                 "jws": "^4.0.0"
@@ -4479,7 +5194,6 @@
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -4659,6 +5373,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/import-in-the-middle": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+            "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.8.2",
+                "acorn-import-assertions": "^1.9.0",
+                "cjs-module-lexer": "^1.2.2",
+                "module-details-from-path": "^1.0.3"
+            }
+        },
+        "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "license": "MIT"
+        },
         "node_modules/import-local": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4727,6 +5459,21 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/is-core-module": {
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4763,7 +5510,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4782,8 +5528,7 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -6000,7 +6745,6 @@
             "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
             "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
             "license": "MIT",
-            "optional": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -6063,6 +6807,12 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.0.0",
@@ -6129,7 +6879,6 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -6270,7 +7019,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
@@ -6381,7 +7129,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -6405,6 +7152,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
         },
         "node_modules/path-scurry": {
             "version": "1.11.1",
@@ -6674,6 +7427,64 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-in-the-middle": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/require-in-the-middle/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/require-in-the-middle/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -6704,7 +7515,6 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6861,6 +7671,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/side-channel": {
             "version": "1.1.1",
@@ -7228,7 +8044,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "anynum": "^1.0.1"
             }
@@ -7251,6 +8066,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/synckit": {
@@ -7389,8 +8216,7 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/ts-algebra": {
             "version": "2.0.0",
@@ -7574,7 +8400,6 @@
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
-            "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -7628,8 +8453,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause",
-            "optional": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/websocket-driver": {
             "version": "0.7.5",
@@ -7659,7 +8483,6 @@
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -7800,7 +8623,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=16.0.0"
             }
@@ -7821,6 +8643,21 @@
             "dev": true,
             "license": "ISC",
             "peer": true
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
         },
         "node_modules/yargs": {
             "version": "17.7.3",
@@ -7911,13 +8748,21 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "src/shared": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,8 +17,11 @@
     },
     "main": "lib/index.js",
     "dependencies": {
+        "@agentpond/firebase": "^0.4.2",
         "@anthropic-ai/sdk": "^0",
+        "@arizeai/openinference-instrumentation-anthropic": "^0.1.15",
         "@google-cloud/translate": "^9",
+        "@opentelemetry/sdk-node": "^0.220.0",
         "@supercharge/promise-pool": "^3",
         "firebase-admin": "^13",
         "firebase-functions": "^7",

--- a/functions/src/firebase.ts
+++ b/functions/src/firebase.ts
@@ -1,0 +1,3 @@
+import { initializeApp } from 'firebase-admin/app';
+
+initializeApp();

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,4 @@
 import type { UserIdentifier } from 'firebase-admin/auth';
-import { initializeApp } from 'firebase-admin/app';
 import {
     onDocumentCreated,
     onDocumentWritten,
@@ -15,6 +14,8 @@ import type {
     EmailExistsOutput,
     GetLLMTranslationsInputs,
 } from 'shared-types';
+
+import './instrumentation.js';
 
 import compactProjectUpdatesHandler from './compactProjectUpdates.js';
 import createClassHandler from './createClass.js';
@@ -36,8 +37,6 @@ import tidyStaleAssignmentsHandler, {
 
 export { submitLocalizationBundle } from './submitLocalization.js';
 export { submitLocaleRequest } from './submitLocaleRequest.js';
-
-initializeApp();
 
 // Permit local testing and calls from our two domains.
 const cors = {

--- a/functions/src/instrumentation.ts
+++ b/functions/src/instrumentation.ts
@@ -1,0 +1,17 @@
+import { createFirebaseSpanExporter } from '@agentpond/firebase';
+import Anthropic from '@anthropic-ai/sdk';
+import { AnthropicInstrumentation } from '@arizeai/openinference-instrumentation-anthropic';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import './firebase.js';
+
+const anthropicInstrumentation = new AnthropicInstrumentation();
+
+// The Functions package uses ESM, so Anthropic must be patched explicitly.
+anthropicInstrumentation.manuallyInstrument(Anthropic);
+
+const telemetry = new NodeSDK({
+    traceExporter: createFirebaseSpanExporter(),
+    instrumentations: [anthropicInstrumentation],
+});
+
+telemetry.start();

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "agentpond": {
+      "source": "marcusschiesser/agentpond",
+      "sourceType": "github",
+      "skillPath": "skills/agentpond/SKILL.md",
+      "computedHash": "702f2f5e3ba4decc4e77147e9583a14d4910a29d3b5b73964a3ccd74e081b1c8"
+    },
+    "agentpond-instrumentation": {
+      "source": "marcusschiesser/agentpond",
+      "sourceType": "github",
+      "skillPath": "skills/agentpond-instrumentation/SKILL.md",
+      "computedHash": "4f31bb5d92817278a8273e76e042c4120f59dcc768bad10b82dc1d303f7b8a1e"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- initialize OpenTelemetry once for the Firebase Functions runtime
- capture Anthropic `messages.create` calls as OpenInference LLM spans and export them to [AgentPond](https://github.com/marcusschiesser/agentpond) through Firebase Storage
- install the AgentPond analysis and instrumentation skills generated by `npx agentpond@0.5.2 init`

Firebase Admin initialization now lives in a small bootstrap module so the default app exists before the AgentPond exporter is constructed. The ESM Anthropic SDK is patched before any function handlers load.

## Why AgentPond

AgentPond stores traces in Wordplay’s own Firebase Storage bucket and lets maintainers sync and analyze them locally. For the Claude-backed translation functions, this makes it easier to:

- diagnose failed, refused, truncated, or unexpectedly slow model requests
- inspect model inputs, outputs, token usage, latency, and errors in one trace
- compare behavior across requests with focused CLI commands or local DuckDB queries
- retain portable OpenInference/OpenTelemetry data without adding a separate hosted observability backend

The repository does not configure a Firebase Storage Rules file in `firebase.json`, so there was no repository-owned ruleset to update. Client access to `agentpond/**` should be confirmed against the deployed project rules before merge.

## Verification

- `npm run build` in `functions/`
- `npm run sync && npm run check:now`
- `npm run test:run` — 3,243 passed, 4 skipped
- loaded the compiled Functions entrypoint with Firebase project and bucket configuration
- exercised a real Anthropic request and confirmed an OpenInference `LLM` span was emitted

A production Firebase Storage export was not exercised because the contributor account cannot list or access the project bucket.