### PR TITLE
Fix ∆/← over a stream binding throwing TypeException after unrelated stream changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 - 🧲 We replaced the physics engine that powers `@Motion` and `@Collision` with a faster one, so projects with lots of moving and colliding things run more smoothly, especially on slower computers. Falling, bouncing, and rolling should feel mostly the same as before, though projects that use these might need a bit of tuning.
 - 🧶 We changed the Pounce example so the ball bounces away from wherever it lands on the kitty, instead of always flying the way the kitty faces.
 
+### Fixed
+
+- 🐛 We fixed a bug where checking a named stream for changes with `∆` (or its history with `←`) could suddenly stop a program with an error after another input changed — which made projects quietly stop responding to clicks and choices.
+
 ## 0.26.1 - 2026-07-09
 
 ### Added

--- a/src/nodes/Reaction.test.ts
+++ b/src/nodes/Reaction.test.ts
@@ -6,11 +6,14 @@ import ExpectedStream from '@conflicts/ExpectedStream';
 import { testConflict } from '@conflicts/TestUtilities';
 import { DB } from '@db/Database';
 import Project from '@db/projects/Project';
+import Button from '@input/Button';
+import Choice from '@input/Choice';
 import Time from '@input/Time';
 import DefaultLocale from '@locale/DefaultLocale';
 import type Expression from '@nodes/Expression';
 import Reaction from '@nodes/Reaction';
 import Source from '@nodes/Source';
+import ExceptionValue from '@values/ExceptionValue';
 
 const makeOne = (creator: Expression) => Time.make(creator, 1);
 
@@ -103,3 +106,104 @@ test.each([
 );
 
 testConflict('1 … ∆ Time() … 1 + ⬚', '1 … ⊤ … 1 + ⬚', Reaction, ExpectedStream);
+
+/** Build a reactive evaluator around the given code and return it with its source. */
+function startReactive(code: string) {
+    const source = new Source('test', code);
+    const project = Project.make(null, 'test', source, [], DefaultLocale);
+    const evaluator = new Evaluator(
+        project,
+        DB,
+        [DefaultLocale],
+        true,
+        undefined,
+        1,
+    );
+    evaluator.start();
+    return { evaluator, source };
+}
+
+// Regression: ∆ over a REFERENCE to a stream-holding binding must keep resolving
+// after an unrelated stream triggers a reevaluation. The evaluator's value→stream
+// map was evicted per expression history, so a Button reevaluation could orphan
+// the memoized Choice value that ∆ picked resolves through, producing a
+// TypeException that silently stopped all streams.
+test('∆ over a stream binding survives unrelated stream changes', () => {
+    // The crucial shape: \`clicks\` references BOTH Button and picked, so it is
+    // Button-dependent; a Button reevaluation evicts its expression history,
+    // which used to delete the shared Choice value's stream mapping that
+    // \`mode\`'s memoized ∆ picked still resolves through.
+    const { evaluator, source } = startReactive(
+        `picked: Choice()
+t: Time()
+mode: 'none' … ∆ picked … picked
+clicks: 0 … (∆ Button()) & ~(∆ picked) … clicks + 1
+mode`,
+    );
+
+    /** Simulate animation-frame time passing, as in a real project. */
+    function tickTime(times: number) {
+        for (let i = 0; i < times; i++) {
+            evaluator
+                .getBasisStreamsOfType(Time)[0]
+                .add(Time.make(source, i + 1), i + 1);
+            evaluator.flush();
+        }
+    }
+
+    /** Simulate a pointer down on a selectable output, which fires both a
+     *  Button event and a Choice event, as OutputView does. */
+    function click(name: string) {
+        evaluator.singletonReact(Button, (stream) => stream.react(true));
+        evaluator.singletonReact(Choice, (stream) => stream.react(name));
+    }
+
+    expect(evaluator.getLatestSourceValue(source)?.toString()).toBe('"none"');
+    expect(evaluator.exception).toBeUndefined();
+
+    // A click selection updates the mode.
+    click('hum');
+    expect(evaluator.exception).toBeUndefined();
+    expect(evaluator.getLatestSourceValue(source)?.toString()).toBe('"hum"');
+
+    // Time passes, as it does between user inputs in a real project.
+    tickTime(3);
+
+    // A second click must not corrupt ∆ picked's stream resolution: its Button
+    // event reevaluates expressions that reference both streams, which used to
+    // evict the shared Choice value's stream mapping and throw a TypeException.
+    click('tap');
+    expect(evaluator.exception).toBeUndefined();
+    const afterClick = evaluator.getLatestSourceValue(source);
+    expect(afterClick).not.toBeInstanceOf(ExceptionValue);
+    expect(afterClick?.toString()).toBe('"tap"');
+
+    // And the Choice stream must still be alive (the exception used to stop it).
+    tickTime(2);
+    click('hum');
+    expect(evaluator.exception).toBeUndefined();
+    expect(evaluator.getLatestSourceValue(source)?.toString()).toBe('"hum"');
+
+    evaluator.stop();
+});
+
+// Same regression for ← (Previous), which resolves streams the same way.
+test('← over a stream binding survives unrelated stream changes', () => {
+    const { evaluator, source } = startReactive(
+        `picked: Choice()
+clicks: 0 … ∆ Button() … clicks + 1
+← 1 picked`,
+    );
+
+    expect(evaluator.exception).toBeUndefined();
+
+    evaluator.singletonReact(Choice, (stream) => stream.react('hum'));
+
+    evaluator.singletonReact(Button, (stream) => stream.react(true));
+    expect(evaluator.exception).toBeUndefined();
+    expect(evaluator.getLatestSourceValue(source)).not.toBeInstanceOf(
+        ExceptionValue,
+    );
+
+    evaluator.stop();
+});

--- a/src/runtime/Evaluator.ts
+++ b/src/runtime/Evaluator.ts
@@ -258,9 +258,19 @@ export default class Evaluator {
 
     /**
      * Remember streams that were converted to values so we can convert them back to streams
-     * when needed in stream operations.
+     * when needed in stream operations (∆/Changed and ←/Previous resolve their operand
+     * values through this).
+     *
+     * This must be keyed by value identity but live as long as ANY expression history
+     * retains the value: the same value object appears in several expression histories
+     * (the stream's Evaluate, a Bind, each Reference), and evicting one history must not
+     * orphan the value for the others, which still resolve through it — that produced
+     * spurious TypeExceptions from ∆/← over a binding reference whenever an unrelated
+     * stream's reevaluation evicted a history sharing the value. A WeakMap ties each
+     * entry's lifetime to the value's reachability, which is exactly that invariant,
+     * and needs no manual eviction for memory management.
      */
-    readonly streamsResolved: Map<Value, StreamValue> = new Map();
+    #streamsResolved: WeakMap<Value, StreamValue> = new WeakMap();
 
     /** Remember streams accessed during reactions conditions so we can decide whether to reevaluate */
     readonly reactionDependencies: {
@@ -743,23 +753,23 @@ export default class Evaluator {
         broadcast = true,
     ) {
         // Reset the non-constant expression values and any values dependent on reaction.
+        // Note: we deliberately do NOT touch #streamsResolved here — a value evicted from
+        // one expression's history may still be memoized in another's, and must keep
+        // resolving to its stream there. The WeakMap reclaims entries when values become
+        // unreachable.
         if (keepConstants) {
-            for (const [expression, values] of this.values)
+            for (const [expression] of this.values)
                 if (
                     !this.project.isConstant(expression) &&
                     (this.#currentStreamDependencies === null ||
                         this.#currentStreamDependencies.has(expression))
-                ) {
+                )
                     this.values.delete(expression);
-                    for (const value of values)
-                        if (value.value)
-                            this.streamsResolved.delete(value.value);
-                }
         }
         // Not keeping constants? Reset histories entirely to avoid memory leaks.
         else {
             this.values.clear();
-            this.streamsResolved.clear();
+            this.#streamsResolved = new WeakMap();
         }
 
         // Reset the evluation stack.
@@ -1427,7 +1437,7 @@ export default class Evaluator {
     }
 
     getStreamResolved(value: Value): StreamValue | undefined {
-        const stream = this.streamsResolved.get(value);
+        const stream = this.#streamsResolved.get(value);
 
         // If we're tracking a reaction's dependencies, remember this was obtained.
         if (stream && this.reactionDependencies.length > 0)
@@ -1437,7 +1447,7 @@ export default class Evaluator {
     }
 
     setStreamResolved(value: Value, stream: StreamValue) {
-        this.streamsResolved.set(value, stream);
+        this.#streamsResolved.set(value, stream);
 
         // If we're tracking a reaction's dependencies, remember this was converted into a value.
         if (this.reactionDependencies.length > 0)


### PR DESCRIPTION
## Summary

Fixes a runtime crash reachable from ordinary learner code: a program that checks a **named** stream for changes (`picked: Choice()` … `∆ picked`) — or reads its history with `←` — throws a `TypeException` at the `∆`/`←` node as soon as an **unrelated** stream (e.g. `Button()`) triggers a reevaluation after the named stream has emitted. Worse, the exception calls `stopStreams()`, which silently kills input streams that honor `stop()` (Choice goes dead) while temporal streams keep running — the program *looks* alive but stops responding, with only the notification badge as evidence.

Discovered while building the Flappy example's Choice-based mode switcher, which died after its first selection. Existing examples (Maze, Calculator) only survive because `Choice` is essentially their sole stream.

## Root cause

`Evaluator.streamsResolved` maps **value objects → the stream that produced them**; `Changed.evaluate` and `Previous.evaluate` resolve their operand through it and throw on a miss. The map was keyed by value identity but evicted **per expression history**: `resetForEvaluation` deleted the entries of every value in every evicted history. The same value object is shared across several histories (the stream's `Evaluate`, a `Bind`, each `Reference`), so a reevaluation for an unrelated stream could evict *one* history sharing the value and orphan it for the *other, still-memoized* histories that resolve through it.

## Fix

Replace the manual eviction with a **`WeakMap`**, tying each entry's lifetime to the value's reachability — exactly the needed invariant (the mapping must survive as long as *any* history retains the value). A value→stream fact never becomes wrong, so longer retention can only turn spurious exceptions into correct answers; memory management improves (entries reclaimed exactly when values become unreachable, no bookkeeping). The full-reset path replaces the map wholesale, as before.

One file of production change ([src/runtime/Evaluator.ts](../blob/main/src/runtime/Evaluator.ts)); `Changed`/`Previous` untouched.

## Testing

- New tests in `Reaction.test.ts` covering `∆` and `←` over stream-holding bindings mixed with unrelated `Button`/`Choice`/`Time` events — paths that previously had zero coverage. **Honest caveat:** these tests pass both pre- and post-fix; the exact eviction preconditions (which involve the browser's full stream mix and dependency-set expansion) could not be reproduced in the vitest harness despite substantial effort, including replaying the full original program with mirrored evaluators and simulated clicks.
- **The real reproduction was verified fixed end-to-end**: restoring the crashing `∆ picked` variant of the Flappy mode switcher in the browser, the pre-fix probe (first selection works, every later selection dead, `!TypeException ∆picked` in the evaluator) now runs the full click sequence flawlessly with no exception.
- `npm run check:now` clean; full `npm test` passes (3275 tests, including all 227 example programs); Catch's Choice-driven toggle spot-checked in the browser.

## Changelog

Adds a Fixed entry (and regenerated `updates.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)