### PR TITLE
Stop Feedback's styles leaking onto every page

### DIFF
--- a/src/components/app/Feedback.svelte
+++ b/src/components/app/Feedback.svelte
@@ -389,57 +389,6 @@
             {/if}
         {/if}
     </div>
-
-    <style>
-        .feedback {
-            padding: var(--wordplay-spacing);
-            border: var(--wordplay-border-color) solid
-                var(--wordplay-border-width);
-            background-color: var(--color-background);
-            border-radius: var(--wordplay-border-radius);
-            transition: max-height calc(var(--animation-factor) * 100ms);
-            max-height: 5em;
-            overflow: hidden;
-        }
-
-        .feedback.expanded {
-            max-height: 100dvh;
-            overflow: auto;
-        }
-
-        .comment {
-            width: 100%;
-            padding: var(--wordplay-spacing);
-            border-inline-start: var(--wordplay-border-color) solid
-                var(--wordplay-focus-width);
-            background-color: var(--color-background);
-            padding-inline-start: 1em;
-            margin-inline-start: 1em;
-            margin-block-start: 1em;
-            display: flex;
-            flex-direction: row;
-            align-items: baseline;
-            gap: var(--wordplay-spacing);
-        }
-
-        .comment.moderator {
-            background-color: var(--wordplay-alternating-color);
-        }
-
-        .header {
-            display: flex;
-            align-items: baseline;
-            gap: var(--wordplay-spacing);
-            cursor: pointer;
-            border-radius: var(--wordplay-border-radius);
-        }
-        .tools {
-            display: flex;
-            flex-direction: row;
-            gap: var(--wordplay-spacing);
-            margin-inline-start: auto;
-        }
-    </style>
 {/snippet}
 
 <Dialog
@@ -545,6 +494,54 @@
 </Dialog>
 
 <style>
+    .feedback {
+        padding: var(--wordplay-spacing);
+        border: var(--wordplay-border-color) solid var(--wordplay-border-width);
+        background-color: var(--color-background);
+        border-radius: var(--wordplay-border-radius);
+        transition: max-height calc(var(--animation-factor) * 100ms);
+        max-height: 5em;
+        overflow: hidden;
+    }
+
+    .feedback.expanded {
+        max-height: 100dvh;
+        overflow: auto;
+    }
+
+    .comment {
+        width: 100%;
+        padding: var(--wordplay-spacing);
+        border-inline-start: var(--wordplay-border-color) solid
+            var(--wordplay-focus-width);
+        background-color: var(--color-background);
+        padding-inline-start: 1em;
+        margin-inline-start: 1em;
+        margin-block-start: 1em;
+        display: flex;
+        flex-direction: row;
+        align-items: baseline;
+        gap: var(--wordplay-spacing);
+    }
+
+    .comment.moderator {
+        background-color: var(--wordplay-alternating-color);
+    }
+
+    .header {
+        display: flex;
+        align-items: baseline;
+        gap: var(--wordplay-spacing);
+        cursor: pointer;
+        border-radius: var(--wordplay-border-radius);
+    }
+    .tools {
+        display: flex;
+        flex-direction: row;
+        gap: var(--wordplay-spacing);
+        margin-inline-start: auto;
+    }
+
     .feedback-list {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
The example toolbar in the [Guide](https://wordplay.dev/guide?concept=Music) sits halfway across the panel instead of at the inline start. It reproduces in production and not in `npm run dev`, which is the interesting part.

## Cause

`Feedback.svelte` kept a `<style>` block **inside a `{#snippet}`**. Svelte only scopes the component's top-level `<style>`; one nested in markup is ordinary HTML, so its selectors were emitted unscoped:

```
.feedback   .feedback.expanded   .comment   .comment.moderator   .header   .tools
```

Feedback's `.tools` carries `margin-inline-start: auto` to push its buttons to the inline end. An auto margin on the cross axis also cancels flex stretch, so `ExampleUI`'s unrelated `.tools` both shrank to its content **and** slid right.

`.header` and `.comment` were leaking on the same terms — `.tools` is just where it happened to show.

**Why production only:** dev serves each component's CSS as it mounts, and Feedback never mounts on the Guide. A production build folds CSS into shared chunks, so the rule loads everywhere.

## Fix

Move the rules into the component's own `<style>` so Svelte scopes them. `svelte-check` reports no unused selectors, so all six still match the markup they were written for.

## Verification

Measured on a local production build (`npm run build` + `vite preview`), since dev can't reproduce it:

| | `.tools` offset from panel | width (panel 582px) | `margin-inline-start` |
| --- | --- | --- | --- |
| production today | 251px | 330px | 249.8px |
| this branch, built | 1px | 580px | 0px |

Stable across play state — offset and first-button position are identical before and after pressing play, which was the actual report. Confirmed via CDP `CSS.getMatchedStylesForNode` that the unscoped `.tools` rule is gone from the built CSS; both remaining rules carry a scope hash.

`npm run check:now` clean, `npm test` 4354 passing, `npm run rtl` reports no direction-unaware CSS.