### PR TITLE
Don't offer to wrap a Music in a Phrase

### DIFF
--- a/src/components/palette/Palette.svelte
+++ b/src/components/palette/Palette.svelte
@@ -84,9 +84,10 @@
 
     // The kind of the program's rendered output, and whether a Stage already exists anywhere — used
     // to offer only type-correct output-creation actions when nothing is selected.
-    let outputKind = $derived(classifyOutput(project).kind);
+    let output = $derived(classifyOutput(project));
+    let outputKind = $derived(output.kind);
     let stageExists = $derived(getStage(project) !== undefined);
-    let offers = $derived(offersFor(outputKind, stageExists));
+    let offers = $derived(offersFor(outputKind, stageExists, output.isList));
 
     // Keep a reference to the text, since we need to pass that to the text style.
     let phraseTextValues: OutputPropertyValueSet | undefined =

--- a/src/components/palette/editOutput.test.ts
+++ b/src/components/palette/editOutput.test.ts
@@ -170,6 +170,44 @@ test('classifyOutput: an optional (Group|ø) output is a group, never a text-con
     expect(offersFor(kindOf(code), false)).not.toContain('phrase');
 });
 
+test('classifyOutput: a Music is output, not a value to convert to text', () => {
+    // Music is heard rather than seen, so nothing about it looked like output
+    // to the classifier and it fell through to `value` — which is the kind that
+    // offers "make a Phrase by converting this to text". A @Phrase wrapped
+    // around a song is not a thing.
+    expect(kindOf(`Music(Track([1 2 3]))`)).toBe('music');
+    expect(offersFor(kindOf(`Music(Track([1 2 3]))`), false)).not.toContain(
+        'phrase',
+    );
+});
+
+test('classifyOutput: a Music reached through a name is still output', () => {
+    // The same invariant the Group|ø case protects: a reference that evaluates
+    // to output must classify as that output, not as a text-convertible value.
+    const code = `song: Music(Track([1 2 3]))\nsong`;
+    expect(kindOf(code)).toBe('music');
+    expect(offersFor(kindOf(code), false)).not.toContain('phrase');
+});
+
+test('offersFor: a Phrase is offered for one statement, not for several', () => {
+    // The rule: wrap and convert a *single* statement that isn't output.
+    // `addSoloPhrase` already refuses more than one result statement, so
+    // offering it there was a button that did nothing.
+    expect(offersFor('value', false, false)).toContain('phrase');
+    expect(offersFor('value', false, true)).not.toContain('phrase');
+    expect(offersFor('text', false, true)).not.toContain('phrase');
+});
+
+test('offersFor: what several plain statements actually offer', () => {
+    // Two numbers are two result statements, so the program's value is a list
+    // of them — and there is no single value to make a Phrase from.
+    const several = classifyOutput(make(`1\n2`));
+    expect(several.isList).toBe(true);
+    expect(offersFor(several.kind, false, several.isList)).not.toContain(
+        'phrase',
+    );
+});
+
 // --- offersFor: the type-correct transformation matrix ----------------------
 
 test('offersFor: matrix (no stage yet)', () => {
@@ -184,6 +222,9 @@ test('offersFor: matrix (no stage yet)', () => {
     expect(offersFor('shape', false)).toEqual(['stage', 'music']);
     expect(offersFor('say', false)).toEqual(['group', 'stage', 'music']);
     expect(offersFor('stage', false)).toEqual(['music']);
+    // Music takes no room on stage and holds nothing, so it wraps nothing and
+    // is wrapped by nothing — but another song can always be added.
+    expect(offersFor('music', false)).toEqual(['music']);
 });
 
 test('offersFor: an existing Stage suppresses Group/Stage wraps', () => {

--- a/src/components/palette/editOutput.ts
+++ b/src/components/palette/editOutput.ts
@@ -344,7 +344,10 @@ export type OutputKind =
     | 'group'
     | 'shape'
     | 'stage'
-    | 'say';
+    | 'say'
+    /** Heard rather than seen, like `say` — but output all the same, so it is
+     *  never something to wrap in a @Phrase or convert to text. */
+    | 'music';
 
 /** The program's root block and its result statements — the statements whose values make up the
  *  rendered output (1 → that value, 2+ → a list of them). */
@@ -379,6 +382,7 @@ function outputKindOfType(
             if (def === output.Phrase) return 'phrase';
             if (def === output.Shape) return 'shape';
             if (def === output.Say) return 'say';
+        if (def === output.Music) return 'music';
             if (
                 def === output.Rectangle ||
                 def === output.Circle ||
@@ -473,6 +477,8 @@ export function classifyOutput(project: Project): {
             return { kind: 'shape', expression: last, isList: false };
         if (last.is(output.Say, context))
             return { kind: 'say', expression: last, isList: false };
+        if (last.is(output.Music, context))
+            return { kind: 'music', expression: last, isList: false };
         if (
             last.is(output.Rectangle, context) ||
             last.is(output.Circle, context) ||
@@ -546,14 +552,26 @@ export type OutputOffer =
 export function offersFor(
     kind: OutputKind,
     stageExists: boolean,
+    /**
+     * True when the output is a LIST rather than one value — either several
+     * result statements, or one expression that evaluates to a list.
+     *
+     * A @Phrase is made from a single value, so there is nothing to offer
+     * otherwise: `addSoloPhrase` refuses a program with more than one result
+     * statement, and an offer whose action does nothing is worse than no offer.
+     */
+    isList = false,
 ): OutputOffer[] {
     // No output at all: there's nothing to wrap, so offer to start with a placeholder Phrase — or
     // with music, which needs nothing to wrap and is a whole program on its own.
     if (kind === 'none') return ['placeholder', 'music'];
 
     const offers: OutputOffer[] = [];
-    // Make a Phrase from existing text, or a (text-convertible) value — never from an output/Form.
-    if (kind === 'text' || kind === 'value') offers.push('phrase');
+    // Make a Phrase out of a single statement that isn't already output: text,
+    // or a value that can be shown as text. Never out of output — a @Phrase
+    // around a @Stage is not a thing, and neither is one around a @Music, which
+    // is output you hear.
+    if (!isList && (kind === 'text' || kind === 'value')) offers.push('phrase');
     // Wrap a bare Form in a Shape.
     if (kind === 'form') offers.push('shape');
     // Wrap a Phrase/Say in a Group (Group excludes Shape and Stage); not if a Stage already exists.


### PR DESCRIPTION
# Context

The palette offered to wrap a `Music` in a `Phrase`, which isn't a thing — a
song is output you hear, not a value to show as text.

`classifyOutput`'s fast path knows Stage, Group, Phrase, Shape, Say, and the
Forms, but not Music, so a `Music(…)` fell through to `value` — the kind that
means "a plain value that can be text-converted" — and got the Phrase offer
that goes with it.

Music now has its own `OutputKind`, in the type-based classifier as well as the
fast path, so a Music reached through a name (`song: Music(…)` then `song`) is
caught too. That is the same invariant that already stops a `Group|ø` from
being offered as text. `addSoloPhrase` then refuses a Music without a case of
its own, since it already declines anything that isn't `none`, `text`, or
`value`.

**The rule caught a second mismatch.** `addSoloPhrase` refuses a program with
more than one result statement — *"only the empty or single-value cases make a
sensible single Phrase"* — but `offersFor` never knew, so with two statements
the palette showed a button whose action did nothing. The offer is now gated on
the output not being a list, which covers both several result statements and
one list-valued expression.

The rule the offer now follows: **wrap and convert a single statement that is
not already output.**

## Related issues

-   Related Issue #390

## Verification

`npm run check:now`, `npm test` (4,626 passing), and `npm run locales` all
clean.

Both halves are sabotage-verified: dropping the Music classification fails the
two Music tests, and dropping the list gate fails the two single-statement
tests. I checked that before trusting them, since a test that passes either way
is not evidence.

New tests cover a Music written directly, a Music reached through a name, the
single-versus-several rule, and what several plain statements actually offer.
The existing offer matrix gains a row for `music`.

Not verified by hand in a browser — the change is to a pure function with unit
tests, and its call site in `Palette.svelte` only threads `isList` through.

## Checklist

-   [ ] Confirm in the palette that a `Music` no longer offers a Phrase, and
        that a plain value still does
