### PR TITLE
Show every track on the palette's staff, and fix four editing bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 - 🚦 When you use a name Wordplay doesn't know, we now look for it inside things like @Sequence, @Color, and @Instrument, and offer to fix it for you — `sway` becomes `Sequence.sway`, `red` becomes `Color.red`, and `piano` becomes `Instrument.piano`.
 - 🎵 Notes can now be numbers in between: `1.5` plays both the notes on either side of it, the closer one louder, like mashing two piano keys — and on a drum kit, both sounds at once. Set a @Track's `mash` to `⊥` to hear one note bent off pitch instead.
 - 🎼 We added a music editor to the palette. Put your cursor on a song and you get a staff you can read, where you can click to add a note, drag one to move it, or change it with the arrow keys. (#390)
-- 🎶 The editor shows one @Track at a time, with buttons for moving between tracks, adding and removing them, turning a note into a chord, and choosing how long a note lasts. (#390)
+- 🎶 The editor changes one @Track at a time, with buttons for moving between tracks, adding and removing them, turning a note into a chord, and choosing how long a note lasts. (#390)
+- 🎼 The staff shows every @Track at once, not just the one you're changing. The others sit behind it in grey so you can line a drum beat up against a tune, and they all go dark when you play the whole song. (#390)
+- 🔁 A @Track that loops shows its repeats on the staff in grey, so you can see it come back around — and see that stop when you turn `loop` off. (#390)
 - 🔊 You can hear a song while you write it, either the whole thing or one track on its own, and a line shows where the music has reached. (#390)
 - 🎹 You can now bring in a MIDI file and Wordplay writes it out as @Track's of notes. It also tells you what it had to change on the way in, like a drum sound our kit doesn't have. (#390)
 - 🎤 You can now hum or sing a tune and have Wordplay write down the notes. They appear while you sing, and we work out the key and the speed from what we hear. (#390)
@@ -45,6 +47,7 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 - 🐛 A function marked with ↑, so it belongs to a structure instead of to one of its things, can now use names from outside that structure. Before it could only see the structure's own parts, and using anything else stopped your project when it ran.
 - 🌐 We fixed two words that meant two different things at once: gray and brown were both "खैरो" in Nepali, and two of the fade-out animations shared one name in Swedish. We now check for this everywhere a name lives inside something else, so it can't happen again.
 - 🔊 A note that wasn't a whole number, like `1.5`, used to stop a song from playing at all. Now it plays.
+- 🔊 The little speaker in the corner of the stage no longer spins forever. It now goes away once a song's sounds have finished downloading, instead of waiting until you press play.
 - ✍️ We fixed typing into a @Phrase on the stage. Letters came out backwards and quote marks piled up after every key you pressed; now it works like a normal text box, and Escape or Enter gets you back out.
 - 📝 You can now type an apostrophe in your text, like in `don't`, without breaking your project. Wordplay picks a different pair of quote marks to hold the text when it needs to.
 - 📐 An empty @Phrase used to leave the stage blank, with nothing to click on and no way back in. Now it shows an empty box where the text will go, in the same spot the words would sit.

--- a/src/components/palette/EditableSheet.svelte
+++ b/src/components/palette/EditableSheet.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
     /**
-     * One track's notes on a staff, editable by pointer and keyboard.
+     * A music's notes on a staff, one track of them editable by pointer and
+     * keyboard.
+     *
+     * **Every track is drawn, but only one is edited.** Writing a part against
+     * another one — a drum beat under a melody — is impossible when the staff
+     * shows only the part being written, so the others are drawn behind it in
+     * the inactive color: not focusable, not clickable, there to line up
+     * against. The edited track's own loop repeats are drawn the same way, so
+     * that a track loops is something the staff shows rather than something
+     * only the `loop` toggle says.
      *
      * Built on `sheet.ts`'s geometry, which the read-only stage rendering uses
      * too, so a note sits in the same place in both. The stage's `Sheet.svelte`
@@ -28,15 +37,17 @@
     import { degreeText } from '@edit/output/editNotes';
     import {
         firstSoundingBeat,
-        indexAtBeat,
+        insertionAtBeat,
         trackLength,
     } from '@output/Music/musicData';
     import {
         beatAtX,
         degreeForStep,
         glyphFor,
+        lengthOf,
         marksOf,
         placeStep,
+        referenceMarks,
         staffCenterOf,
         staffLines,
         stepAtPlace,
@@ -50,6 +61,12 @@
 
     interface Props {
         track: EditableTrack;
+        /** Which track of the music is being edited. The one thing about the
+         * shown track that survives an edit, since every edit replaces the
+         * track's nodes and the value that wraps them. */
+        trackIndex: number;
+        /** Every other track of the music, drawn for reference only. */
+        others: readonly EditableTrack[];
         editable: boolean;
         /** Add a note of `degree` before entry `index`. */
         add: (index: number, degree: number) => void;
@@ -71,6 +88,9 @@
         cursor?: number;
         /** Where playing has reached, drawn as a moving playhead. */
         playhead?: number | undefined;
+        /** What the preview is sounding, so a reference note can say whether
+         * it is being heard as well as seen. */
+        playing?: 'music' | 'track' | undefined;
         /** Set the beat playing would start from. */
         onCursor?: (beat: number) => void;
         /** Told which note holds focus, so the toolbar can act on it. */
@@ -79,6 +99,8 @@
 
     let {
         track,
+        trackIndex,
+        others,
         editable,
         add,
         remove,
@@ -86,6 +108,7 @@
         reorder,
         cursor = 0,
         playhead = undefined,
+        playing = undefined,
         onCursor = undefined,
         onFocus = undefined,
     }: Props = $props();
@@ -172,7 +195,9 @@
           }
         | undefined = $state(undefined);
 
-    let data = $derived({
+    /** Everything the music has to say, drawn as it sounds — loops included —
+     * with the edited track first so it is track 0. */
+    let all = $derived({
         name: '',
         tempo: 120,
         volume: 1,
@@ -181,12 +206,39 @@
         replay: false,
         pause: false,
         description: undefined,
-        // Drawn as a one-shot however the track loops: the editor shows the
-        // notes that were written, not the repetitions they play as.
-        tracks: [{ ...track.data, loop: false }],
+        tracks: [track.data, ...others.map((other) => other.data)],
     });
 
-    let beats = $derived(Math.max(trackLength(track.data), 1));
+    /** Just the edited track, and just its first pass. Drawn as a one-shot
+     * however the track loops, because these are the noteheads that stand for
+     * the notes that were written: a repetition has no entry to edit. */
+    let self = $derived({ ...all, tracks: [{ ...track.data, loop: false }] });
+
+    /** One pass of the edited track, which is where its echoes begin. */
+    let pass = $derived(trackLength(track.data));
+
+    /** How much music there is to play: the longest written track, which is as
+     * far as the cursor can be put. Past it there is nothing to start from. */
+    let written = $derived(Math.max(lengthOf([all]), 1));
+
+    /**
+     * How wide the staff is drawn, in beats.
+     *
+     * The longest track, and a second pass of anything that loops. Without the
+     * second pass the *longest* track's own repeats have nowhere to go — the
+     * staff ends exactly where its first pass does — so toggling `loop` on the
+     * part being edited would change nothing on the staff, which is half of
+     * what drawing repeats is for. A shorter loop needs no help: it already
+     * repeats across whatever the longest track spans.
+     */
+    let beats = $derived(
+        Math.max(
+            written,
+            ...all.tracks.map(
+                (each) => trackLength(each) * (each.loop ? 2 : 1),
+            ),
+        ),
+    );
     let width = $derived((beats + 1) * PerBeat);
 
     /**
@@ -213,15 +265,22 @@
         ),
     );
 
-    let marks = $derived(marksOf([data], from, to));
+    /** The noteheads that can be edited. */
+    let mine = $derived(marksOf([self], from, to));
+
+    /** The noteheads that are only there to line up against. */
+    let reference = $derived(referenceMarks(marksOf([all], from, to), 0, pass));
 
     /**
-     * The staff's centre, measured once over the whole track rather than over
+     * The staff's centre, measured once over the whole music rather than over
      * the window: centring on what happens to be in view would slide every
-     * note vertically as the creator scrolled.
+     * note vertically as the creator scrolled. Over the music rather than over
+     * the edited track for the same reason in the other direction — a centre
+     * fitted to one part would move every reference note on each change of
+     * track, so a pitch wouldn't mean the same height from one to the next.
      */
     let center = $derived(
-        staffCenterOf(marksOf([data], 0, Math.min(beats, 64))),
+        staffCenterOf(marksOf([all], 0, Math.min(beats, 64))),
     );
 
     function slot(at: At): string {
@@ -329,17 +388,20 @@
         );
     }
 
-    /** Claim focus for a note. Held until the creator moves it somewhere real. */
+    /**
+     * Claim focus for a note. Held until the creator moves it somewhere real.
+     *
+     * The slot is taken as asked for rather than clamped to the notes that
+     * exist, because this runs *before* the revise it follows has landed: a
+     * caller that just edited is naming a slot in the list its edit makes, and
+     * the list still on hand is the one from before. Clamping against that put
+     * focus on the second-to-last note after adding one to the end, and
+     * refused it outright for the first note added to an empty track.
+     * A caller that removes a note has to say where focus goes itself, since
+     * only it knows what the list is about to lose.
+     */
     function focusNote(at: At) {
-        const last = track.data.notes.length - 1;
-        if (last < 0) {
-            owned = false;
-            onFocus?.(undefined);
-            return;
-        }
-        const index = Math.max(0, Math.min(at.index, last));
-        const voice = Math.max(0, Math.min(at.voice, voicesIn(index) - 1));
-        focused = { index, voice };
+        focused = at;
         owned = true;
         // Report immediately as well as on the element's own focus event: the
         // toolbar acts on which note is being edited and shouldn't have to wait
@@ -352,17 +414,23 @@
     });
 
     /**
-     * Show the track's first note when the track changes.
+     * Show the track's first note when the carousel moves to another track.
      *
      * An imported track that enters late opens with a long rest, so the staff
      * would otherwise start on empty space with the music somewhere off to the
      * right. Only on a change of track, so it never fights a creator who has
      * scrolled somewhere deliberately.
+     *
+     * Keyed on which track is shown rather than on the track itself, because
+     * every edit revises the project and mints a fresh `EditableTrack` — so an
+     * identity check reads every note placed, moved, or deleted as a change of
+     * track and scrolls the staff back to the beginning under the creator's
+     * hand.
      */
-    let shown: EditableTrack | undefined = undefined;
+    let shown: number | undefined = undefined;
     $effect(() => {
-        if (track === shown) return;
-        shown = track;
+        if (trackIndex === shown) return;
+        shown = trackIndex;
         const first = firstSoundingBeat(track.data);
         if (first === undefined || region === undefined) return;
         // A little before it, so the first note isn't jammed against the clef.
@@ -373,7 +441,7 @@
     $effect(() => {
         // Read the marks so this re-runs after every edit rebuilds them, which
         // is when the element holding focus has just been replaced.
-        void marks;
+        void mine;
         if (!owned) return;
         const view = viewAt(focused);
         if (view === null || view === undefined) return;
@@ -448,9 +516,19 @@
                     })
                     .toText(),
             );
-            // The note that followed has taken this place; if there wasn't one,
-            // the effect's clamp lands on the note before instead.
-            focusNote({ index: at.index, voice: 0 });
+            // The note that followed has taken this place; if there wasn't
+            // one, the note before it; and if there was nothing else at all,
+            // there is nothing left to focus. Worked out here because only
+            // this branch knows the list is about to be one shorter.
+            const remaining = track.data.notes.length - 1;
+            if (remaining <= 0) {
+                owned = false;
+                onFocus?.(undefined);
+            } else
+                focusNote({
+                    index: Math.min(at.index, remaining - 1),
+                    voice: 0,
+                });
         } else if (event.key === 'Enter') {
             // Repeat this note's pitch after it, which is a starting point to
             // move rather than an arbitrary one to find.
@@ -602,9 +680,10 @@
             clientX - box.left - ClefInset + region.scrollLeft,
             PerBeat,
         );
-        // Bounded by the music: there is nothing to start playing from after
-        // the last note, so dragging past the end stops at it.
-        onCursor?.(Math.max(0, Math.min(beats, beat)));
+        // Bounded by what was written rather than by what is drawn: there is
+        // nothing to start playing from after the last note, and the staff now
+        // runs on past it to show a loop repeating.
+        onCursor?.(Math.max(0, Math.min(written, beat)));
     }
 
     /**
@@ -690,7 +769,7 @@
     function handleClick(event: MouseEvent) {
         if (!editable) return;
         const { beat, step: pitch } = pointAt(event);
-        const index = indexAtBeat(track.data, beat);
+        const index = insertionAtBeat(track.data, beat);
         const degree = degreeForStep(pitch, track.data.scale, track.data.key);
         add(index, degree);
         say(
@@ -733,6 +812,30 @@
             <div class="line" style:top="{heightOf(line)}%"></div>
         {/each}
         <div class="clef" aria-hidden="true">{TrebleClef}</div>
+        <!-- The other tracks, and this one's loop repeats, drawn behind the
+             notes being edited so an edited notehead is never hidden by one.
+             Decorative: they carry no information a creator can act on here,
+             since the only way to change them is to select the track they
+             belong to — and a few hundred unfocusable labels between the notes
+             that *are* editable would bury them. What they sound like is a
+             press of the whole-music play button away. -->
+        {#each reference as mark (mark.id)}
+            <div
+                class="mark reference"
+                class:active={playing === 'music' ||
+                    (playing === 'track' && mark.track === 0)}
+                aria-hidden="true"
+                style:left="calc({mark.beat} * var(--per-beat))"
+                style:top="{heightOf(mark.step)}%"
+                style:--level={mark.level}
+            >
+                {#if mark.accidental}<span class="accidental"
+                        >{mark.accidental}</span
+                    >{/if}{mark.glyph}{#if mark.track > 0}<sup class="label"
+                        >{mark.label}</sup
+                    >{/if}
+            </div>
+        {/each}
         <!-- One cursor, not two: where playing has reached while it plays, and where
          it will start from when it isn't. Two lines meant a creator had to
          work out which was which, and the still one stopped meaning anything
@@ -756,7 +859,7 @@
             onpointerdown={startScrub}
             onclick={(event) => event.stopPropagation()}
         ></div>
-        {#each marks as mark (keyOf(mark))}
+        {#each mine as mark (keyOf(mark))}
             {@const at = atOf(mark)}
             <button
                 type="button"
@@ -801,7 +904,7 @@
              bounced with the melody would be unreadable. Decorative: the same
              text is readable and editable as a labelled field in the palette
              beside this, and each notehead announces its own beat. -->
-        {#each marks as mark (`${keyOf(mark)} words`)}
+        {#each mine as mark (`${keyOf(mark)} words`)}
             {#if mark.words !== undefined}
                 <div
                     class="words"
@@ -812,7 +915,7 @@
                 </div>
             {/if}
         {/each}
-        {#if marks.length === 0}
+        {#if mine.length === 0}
             <!-- An empty track still needs somewhere to click. -->
             <div class="empty" aria-hidden="true">{glyphFor(1, true)}</div>
         {/if}
@@ -885,6 +988,49 @@
 
     .mark:active {
         cursor: grabbing;
+    }
+
+    /* A note from another track, or from a repeat of this one's loop. Drawn in
+       the inactive color rather than at a lower opacity so it reads as "not
+       yours to edit" the way every other unavailable control in the app does,
+       and so it keeps its contrast in both color schemes.
+
+       Transparent to the pointer, so clicking one places a note in unison with
+       it rather than landing on a dead spot: the staff below is what answers a
+       click, and every point on it should. */
+    .mark.reference {
+        color: var(--wordplay-inactive-color);
+        pointer-events: none;
+        cursor: default;
+    }
+
+    /* Active while it is actually being heard, which is what tells a whole-music
+       preview from a solo of the track being edited. */
+    .mark.reference.active {
+        color: inherit;
+    }
+
+    /* Which track a reference note came from, as the emoji the stage's own
+       sheet uses — a picture reads the same in every language, and with three
+       parts superimposed the alternative is guessing. Only on notes from other
+       tracks: this track's own echoes are obviously its own instrument.
+
+       Placed and sized as the stage places it: at the tip of the stem, where
+       it costs no horizontal room, and small. Faded because an emoji takes no
+       color, so opacity is the only way to say "reference" about one — at full
+       size and strength the labels read as the subject of the staff rather
+       than as an annotation on it. */
+    .label {
+        position: absolute;
+        top: -0.35em;
+        inset-inline-start: 0.62em;
+        font-size: 26%;
+        line-height: 1;
+        opacity: 0.6;
+    }
+
+    .mark.reference.active .label {
+        opacity: 0.85;
     }
 
     .mark:focus {

--- a/src/components/palette/MusicEditor.svelte
+++ b/src/components/palette/MusicEditor.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
     /**
-     * The music editor: one track at a time on an editable staff, with the
-     * track's own properties beneath it.
+     * The music editor: one track at a time on a staff that draws them all,
+     * with the track's own properties beneath it.
      *
      * A carousel rather than a stack of staves, because a palette is a column
      * about a hand's width and several staves at once would each be too short
-     * to read a pitch off. Editing is always about one track; the music's own
-     * properties are the palette rows above this.
+     * to read a pitch off — so the other tracks share this one, drawn for
+     * reference. Editing is always about one track; the music's own properties
+     * are the palette rows above this.
      *
      * Rendered by `Palette.svelte` after the music's property rows, the way
      * `TextStyleEditor` is rendered after a phrase's face — a bespoke editor
@@ -29,7 +30,6 @@
     import readMusic, {
         isEditable,
         musicSignature,
-        type EditableTrack,
     } from '@edit/output/editableMusic';
     import { getTrackProperties } from '@edit/output/MusicProperties';
     import {
@@ -202,6 +202,9 @@
     let tracks = $derived(read?.tracks ?? []);
     let index = $derived(Math.max(0, Math.min(at, tracks.length - 1)));
     let track = $derived(tracks[index]);
+    /** The rest of the music, which the staff draws behind the edited track so
+     * a part can be written against the ones it plays with. */
+    let others = $derived(tracks.filter((_, which) => which !== index));
 
     /** The focused note's own expression, when there is one. */
     let focusedEntry = $derived(
@@ -332,11 +335,19 @@
      */
     let cursor = $state(0);
 
-    /** Put the cursor at the start of the music when the track changes. */
-    let cursorFor: EditableTrack | undefined = undefined;
+    /**
+     * Put the cursor at the start of the music when the carousel moves to
+     * another track.
+     *
+     * Keyed on which track, not on the track itself: an edit replaces the
+     * track's nodes, so an identity check would drag the cursor back to the
+     * top of the track on every note placed — the same mistake the staff's
+     * scroll position made.
+     */
+    let cursorFor: number | undefined = undefined;
     $effect(() => {
-        if (track === undefined || track === cursorFor) return;
-        cursorFor = track;
+        if (track === undefined || index === cursorFor) return;
+        cursorFor = index;
         // Not beat zero: an imported track entering late opens with hundreds
         // of beats of rest, and playing from zero is silence.
         cursor = firstSoundingBeat(track.data) ?? 0;
@@ -598,6 +609,8 @@
             </div>
             <EditableSheet
                 {track}
+                trackIndex={index}
+                {others}
                 {editable}
                 {add}
                 {remove}
@@ -605,6 +618,7 @@
                 {reorder}
                 {cursor}
                 playhead={wrapped($previewPosition)}
+                playing={$isPreviewing ? playingWhat : undefined}
                 onCursor={(beat) => (cursor = beat)}
                 onFocus={(note) => {
                     focusedNote = note;

--- a/src/output/Music/InstrumentSamples.ts
+++ b/src/output/Music/InstrumentSamples.ts
@@ -33,14 +33,26 @@ type Loaded = {
  * `failed` is a real state rather than an absence: it's what tells the player
  * to give up waiting and synthesize instead, which is exactly the distinction
  * a bare `undefined` couldn't make.
+ *
+ * `fetched` separates the two halves of the wait, and it exists because they
+ * end at different times. Bytes stop arriving when the network is done;
+ * decoding can't even begin until an `AudioContext` exists, and the player's
+ * is created inside a gesture — so an instrument that has fully downloaded sits
+ * here indefinitely for a project nobody has pressed play on. Reported as
+ * "loading", that was a spinner over an open project that never went away —
+ * which is also the wrong thing to say, since nothing is being waited for but
+ * the creator.
  */
-export type SampleState = 'fetching' | 'ready' | 'failed';
+export type SampleState = 'fetching' | 'fetched' | 'ready' | 'failed';
 
 class InstrumentSamples {
     /** Decoded zones per instrument, once they arrive. */
     private readonly loaded = new Map<string, Loaded[]>();
     /** Fetched bytes waiting for a context to decode them. */
-    private readonly fetched = new Map<string, { zone: Zone; bytes: ArrayBuffer }[]>();
+    private readonly fetched = new Map<
+        string,
+        { zone: Zone; bytes: ArrayBuffer }[]
+    >();
     /** How far along each instrument is. Absent means never asked for. */
     private readonly state = new Map<string, SampleState>();
     /** Called whenever a state changes, so the UI can say what's happening. */
@@ -68,7 +80,12 @@ class InstrumentSamples {
         return this.state.get(instrument) === 'failed';
     }
 
-    /** The instruments still being fetched, for the stage's loading indicator. */
+    /**
+     * The instruments still coming over the network, for the stage's loading
+     * indicator. Not the ones that have arrived and are waiting for a context
+     * to decode with — that wait is over the moment the creator presses play,
+     * so showing it says "still working" about something that isn't.
+     */
     loading(): string[] {
         return this.inState('fetching');
     }
@@ -177,17 +194,24 @@ class InstrumentSamples {
     /** Decode whatever has been fetched, if a context exists to decode with. */
     private async decodeFetched(instrument: string) {
         const context = getDecodeContext();
-        // No context yet: the bytes wait in `fetched`, and `decode()` picks
-        // them up when the player makes one. State stays `fetching`, which is
-        // honest — this instrument isn't playable yet.
-        if (context === undefined) return;
+        // No context yet: the bytes wait in `fetched`, and `decodePending`
+        // picks them up when the player makes one. Still not playable, so not
+        // `ready` — but nothing is in flight either, so not `fetching`.
+        if (context === undefined) {
+            if (this.state.get(instrument) === 'fetching')
+                this.announce(instrument, 'fetched');
+            return;
+        }
         const pending = this.fetched.get(instrument);
         if (pending === undefined) return;
         this.fetched.delete(instrument);
         const decoded: Loaded[] = [];
         for (const { zone, bytes } of pending) {
             try {
-                decoded.push({ zone, buffer: await context.decodeAudioData(bytes) });
+                decoded.push({
+                    zone,
+                    buffer: await context.decodeAudioData(bytes),
+                });
             } catch {
                 // A zone that won't decode simply isn't among the choices.
             }

--- a/src/output/Music/instrumentSamples.test.ts
+++ b/src/output/Music/instrumentSamples.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest';
+import samples from '@output/Music/InstrumentSamples';
+import { Zones } from '@output/Music/samples.generated';
+
+/** Wait for the loader to say something, or give up. */
+function settled(done: () => boolean): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (done()) return resolve();
+        const timer = setTimeout(() => {
+            stop();
+            reject(new Error('the loader never settled'));
+        }, 5000);
+        const stop = samples.observe(() => {
+            if (!done()) return;
+            clearTimeout(timer);
+            stop();
+            resolve();
+        });
+    });
+}
+
+test('an instrument that has finished downloading is no longer loading', async () => {
+    // Any sampled instrument; the state machine is the same for all of them.
+    const instrument = Object.keys(Zones)[0];
+    expect(instrument, 'no sampled instruments to test with').toBeDefined();
+
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+        new Response(new ArrayBuffer(8), { status: 200 })) as typeof fetch;
+    try {
+        samples.request(instrument);
+        // In flight, which is worth telling a creator about.
+        expect(samples.loading()).toContain(instrument);
+
+        await settled(() => !samples.loading().includes(instrument));
+
+        // Downloaded. There is nothing left to wait for on the network, so the
+        // stage must not still be saying it is loading — that indicator sat on
+        // an open project forever, since decoding waits for an AudioContext
+        // and the player only makes one when someone presses play.
+        expect(samples.loading()).not.toContain(instrument);
+        expect(samples.failedInstruments()).not.toContain(instrument);
+        // But it isn't playable yet either: the player still has to wait for
+        // the decode that its own context will trigger.
+        expect(samples.ready(instrument)).toBe(false);
+    } finally {
+        globalThis.fetch = original;
+    }
+});
+
+test('an instrument whose files are all missing falls back to synthesis', async () => {
+    const instrument = Object.keys(Zones)[1] ?? Object.keys(Zones)[0];
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+        new Response(null, { status: 404 })) as typeof fetch;
+    try {
+        samples.request(instrument);
+        await settled(() => samples.failedInstruments().includes(instrument));
+        // Ready, in the sense the player needs: stop waiting and synthesize,
+        // rather than hold the piece for files that are never coming.
+        expect(samples.ready(instrument)).toBe(true);
+        expect(samples.loading()).not.toContain(instrument);
+    } finally {
+        globalThis.fetch = original;
+    }
+});

--- a/src/output/Music/musicData.ts
+++ b/src/output/Music/musicData.ts
@@ -172,22 +172,36 @@ export function firstSoundingBeat(track: TrackData): number | undefined {
 }
 
 /**
- * Which entry a beat lands in — the inverse of `noteOnset`, for turning a
- * click on the staff into a place in the note list.
+ * Where in the note list a beat asks for a note — for turning a click on the
+ * staff into an insertion.
  *
- * A beat past the end answers the length rather than the last index, so the
- * result reads as "insert here" for every beat, including the one after the
- * final note. A held note answers its own index throughout, so clicking the
- * middle of a whole note is still clicking that note.
+ * The places a note can go are the *boundaries* between notes, so a beat
+ * answers the boundary it is nearest: the gap the creator pointed at. Asking
+ * instead which note is *sounding* at that beat — the obvious reading, and
+ * what this used to do — is half a note out everywhere, because a notehead is
+ * drawn straddling its onset while its span begins there. Clicking just left
+ * of a notehead landed a note before the note *before* it, and the whole width
+ * of the last note read as "before the last note", so the empty staff after a
+ * track could not be clicked to extend it.
+ *
+ * A beat past the end answers the length, which appends; a negative one
+ * answers zero.
  */
-export function indexAtBeat(track: TrackData, beat: number): number {
-    if (beat < 0) return 0;
+export function insertionAtBeat(track: TrackData, beat: number): number {
+    let best = 0;
+    let closest = Math.abs(beat);
     let onset = 0;
     for (let index = 0; index < track.notes.length; index++) {
         onset += track.notes[index].beats;
-        if (beat < onset) return index;
+        const distance = Math.abs(beat - onset);
+        // Strictly nearer, so a beat exactly between two boundaries takes the
+        // earlier one rather than sliding right as the list is walked.
+        if (distance < closest) {
+            closest = distance;
+            best = index + 1;
+        }
     }
-    return track.notes.length;
+    return best;
 }
 
 /**

--- a/src/output/Music/schedule.test.ts
+++ b/src/output/Music/schedule.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest';
 import type { MusicData, TrackData } from '@output/Music/musicData';
 import {
     firstSoundingBeat,
-    indexAtBeat,
+    insertionAtBeat,
     signatureOf,
 } from '@output/Music/musicData';
 import {
@@ -505,33 +505,47 @@ test('a whole degree still schedules exactly one note', () => {
         ).toHaveLength(3);
 });
 
-test('a beat reads back as the entry it lands in', () => {
-    // The inverse of noteOnset, for turning a click on the staff into a place
-    // in the note list.
+test('a beat asks for a note at the gap it is nearest', () => {
+    // For turning a click on the staff into a place in the note list. The
+    // boundaries between notes are where a note can go, so each beat answers
+    // the one it is closest to.
     const t = track([1, 2, 3]);
-    expect(indexAtBeat(t, 0)).toBe(0);
-    expect(indexAtBeat(t, 0.5)).toBe(0);
-    expect(indexAtBeat(t, 1)).toBe(1);
-    expect(indexAtBeat(t, 2.99)).toBe(2);
-    // Past the end answers the length, so every beat reads as "insert here"
-    // including the one after the last note.
-    expect(indexAtBeat(t, 3)).toBe(3);
-    expect(indexAtBeat(t, 99)).toBe(3);
-    expect(indexAtBeat(t, -1)).toBe(0);
-    expect(indexAtBeat(track([]), 0)).toBe(0);
+    expect(insertionAtBeat(t, 0)).toBe(0);
+    expect(insertionAtBeat(t, 0.4)).toBe(0);
+    // Past the middle of a note is past the note: this is what the staff shows,
+    // since a notehead is drawn straddling its onset.
+    expect(insertionAtBeat(t, 0.6)).toBe(1);
+    expect(insertionAtBeat(t, 1)).toBe(1);
+    // A beat exactly between two gaps takes the earlier one.
+    expect(insertionAtBeat(t, 1.5)).toBe(1);
+    expect(insertionAtBeat(t, -1)).toBe(0);
+    expect(insertionAtBeat(track([]), 0)).toBe(0);
 });
 
-test('a held note owns every beat it sustains', () => {
-    // Clicking the middle of a whole note is clicking that note, not the
-    // silence a naive onset comparison would put there.
+test('the staff after the last note can be clicked to extend the track', () => {
+    // The bug this rule exists for: the whole width of the last note read as
+    // "before the last note", so a click in the empty staff after a track put
+    // the new note second to last and there was no way to append by pointer.
+    const t = track([1, 2, 3]);
+    expect(insertionAtBeat(t, 2.6)).toBe(3);
+    expect(insertionAtBeat(t, 3)).toBe(3);
+    expect(insertionAtBeat(t, 99)).toBe(3);
+});
+
+test('a long note is one gap wide, not one beat', () => {
+    // A whole note ending a track has four beats of staff to itself; half of
+    // them belong to the gap after it, or a click anywhere near it would land
+    // before it.
     const held = track([1, 2]);
     const long = {
         ...held,
         notes: [{ degrees: [1], beats: 4, volume: 1 }, held.notes[1]],
     };
-    expect(indexAtBeat(long, 0)).toBe(0);
-    expect(indexAtBeat(long, 3.9)).toBe(0);
-    expect(indexAtBeat(long, 4)).toBe(1);
+    expect(insertionAtBeat(long, 0)).toBe(0);
+    expect(insertionAtBeat(long, 1.9)).toBe(0);
+    expect(insertionAtBeat(long, 2.1)).toBe(1);
+    expect(insertionAtBeat(long, 4)).toBe(1);
+    expect(insertionAtBeat(long, 4.6)).toBe(2);
 });
 
 test('a track that enters late reports where it actually starts', () => {

--- a/src/output/Music/sheet.test.ts
+++ b/src/output/Music/sheet.test.ts
@@ -28,6 +28,7 @@ import {
     Rests,
     MinBeatWidth,
     placeStep,
+    referenceMarks,
     Sharp,
     staffCenterOf,
     staffLines,
@@ -665,6 +666,72 @@ test('a rest that something plays through is not drawn', () => {
     ]);
     // The whole-note rest overlaps nothing here, so it stays.
     expect(marksOf([covered], 0, 8).some((mark) => mark.rest)).toBe(true);
+});
+
+/* ---------------------------------------------------------------- *
+ * Reference marks
+ * ---------------------------------------------------------------- */
+
+test('reference marks keep the other tracks and drop the edited pass', () => {
+    const both = music([
+        track([
+            { degrees: [1], beats: 1 },
+            { degrees: [2], beats: 1 },
+        ]),
+        track([{ degrees: [5], beats: 1 }], { instrument: 'drums' }),
+    ]);
+    const reference = referenceMarks(marksOf([both], 0, 8), 0, 2);
+    // Nothing of the track being edited, everything of the other one.
+    expect(reference.every((mark) => mark.track === 1)).toBe(true);
+    expect(reference).toHaveLength(1);
+});
+
+test('a looping edited track keeps its repeats and only its repeats', () => {
+    const notes = [
+        { degrees: [1], beats: 1 },
+        { degrees: [2], beats: 1 },
+    ];
+    const looping = music([track(notes, { loop: true })]);
+    const echoes = referenceMarks(marksOf([looping], 0, 8), 0, 2);
+    // The first pass is what is being edited; every later one is an echo.
+    expect(echoes.length).toBeGreaterThan(0);
+    expect(echoes.every((mark) => mark.beat >= 2)).toBe(true);
+
+    // Turning the loop off leaves nothing to echo, which is what makes
+    // looping visible on the staff.
+    const once = music([track(notes)]);
+    expect(referenceMarks(marksOf([once], 0, 8), 0, 2)).toHaveLength(0);
+});
+
+test('reference marks never include a rest', () => {
+    const resting = music([
+        track([
+            { degrees: [1], beats: 1 },
+            { degrees: [], beats: 1 },
+        ]),
+        track(
+            [
+                { degrees: [], beats: 1 },
+                { degrees: [5], beats: 1 },
+            ],
+            { instrument: 'drums' },
+        ),
+    ]);
+    expect(
+        referenceMarks(marksOf([resting], 0, 8), 0, 2).some(
+            (mark) => mark.rest,
+        ),
+    ).toBe(false);
+
+    // Even alone, where `marksOf` keeps rests for a single readable line.
+    const alone = music([
+        track([
+            { degrees: [1], beats: 1 },
+            { degrees: [], beats: 1 },
+        ]),
+    ]);
+    expect(marksOf([alone], 0, 8).some((mark) => mark.rest)).toBe(true);
+    expect(referenceMarks(marksOf([alone], 0, 8), 0, 2)).toHaveLength(0);
 });
 
 test('tracks that drift against each other still never crowd', () => {

--- a/src/output/Music/sheet.ts
+++ b/src/output/Music/sheet.ts
@@ -234,6 +234,31 @@ export function marksOf(
 }
 
 /**
+ * The marks an editor draws as reference rather than as the score it is
+ * editing: every other track, plus the repeats of the selected track's own
+ * loop.
+ *
+ * The echoes are what make looping visible — without them a four-beat loop
+ * under a thirty-two beat melody looks like a track that stops after four
+ * beats, and toggling `loop` changes nothing on the staff. Never a rest, for
+ * the same reason {@link marksOf} drops them from a multi-track score: a rest
+ * superimposed on other tracks says nothing a reader can use.
+ *
+ * `length` is one pass of the selected track, so anything of its own at or
+ * past it is a repetition rather than the pass being edited.
+ */
+export function referenceMarks(
+    marks: readonly Mark[],
+    selected: number,
+    length: number,
+): Mark[] {
+    return marks.filter(
+        (mark) =>
+            !mark.rest && !(mark.track === selected && mark.beat < length),
+    );
+}
+
+/**
  * Drop any rest that something else is playing through.
  *
  * Every track is superimposed on one staff, so a rest only means anything when

--- a/tests/end2end/music-editor.spec.ts
+++ b/tests/end2end/music-editor.spec.ts
@@ -18,7 +18,10 @@ async function loadCode(
     await editor.click();
     await page.keyboard.press('ControlOrMeta+a');
     await page.keyboard.press('Backspace');
-    await page.evaluate((source) => navigator.clipboard.writeText(source), code);
+    await page.evaluate(
+        (source) => navigator.clipboard.writeText(source),
+        code,
+    );
     await page.keyboard.press('ControlOrMeta+v');
     await expect
         .poll(async () => (await editor.textContent()) ?? '', {
@@ -30,7 +33,9 @@ async function loadCode(
 test('the playhead appears and advances while previewing', async ({ page }) => {
     test.setTimeout(90000);
 
-    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
     await createTestProject(page);
     // Slow and long, so the head has somewhere to travel and time to do it.
     await loadCode(page, 'Music(Track([1 2 3 4 5 6 7 8]) tempo: 60beats/min)');
@@ -72,10 +77,9 @@ test('the playhead appears and advances while previewing', async ({ page }) => {
     // audio clock, so this is the only way to tell a live head from a drawn one.
     const at = async () =>
         Number(
-            (await playhead.evaluate((el) => getComputedStyle(el).left)).replace(
-                'px',
-                '',
-            ),
+            (
+                await playhead.evaluate((el) => getComputedStyle(el).left)
+            ).replace('px', ''),
         );
     const first = await at();
     await page.waitForTimeout(1500);
@@ -89,7 +93,9 @@ test('the playhead appears and advances while previewing', async ({ page }) => {
 test('only one play button owns the preview at a time', async ({ page }) => {
     test.setTimeout(90000);
 
-    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
     await createTestProject(page);
     await loadCode(page, 'Music(Track([1 2 3 4]) tempo: 60beats/min)');
 
@@ -118,6 +124,255 @@ test('only one play button owns the preview at a time', async ({ page }) => {
     await expect(music).toHaveAttribute('aria-disabled', 'false');
 });
 
+test('the other tracks are drawn for reference, and only sound active when they sound', async ({
+    page,
+}) => {
+    test.setTimeout(90000);
+
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await createTestProject(page);
+    // A melody and a short loop under it — the pairing the reference layer
+    // exists for. The melody is selected first, since it is track one.
+    await loadCode(
+        page,
+        'Music([Track([1 2 3 4 5 6 7 8] loop: ⊥) Track([1 1] loop: ⊤ instrument: Instrument.drums)] tempo: 60beats/min)',
+    );
+
+    await page.locator('[data-uiid="paletteExpand"]').click();
+    const editor = page.getByTestId('editor').first();
+    await editor.getByText('Track', { exact: false }).first().click();
+
+    const palette = page.getByTestId('palette');
+    const staff = palette.locator('.staff');
+    await expect(staff).toBeVisible({ timeout: 10000 });
+
+    // The edited track keeps exactly its own eight noteheads...
+    const mine = staff.locator('.mark:not(.reference)');
+    await expect(mine).toHaveCount(8, { timeout: 10000 });
+    // ...and the drum loop repeats across the melody beneath them.
+    const reference = staff.locator('.mark.reference');
+    await expect(reference.first()).toBeVisible({ timeout: 10000 });
+    expect(await reference.count()).toBeGreaterThan(2);
+
+    // Reference notes are there to look at, not to reach: nothing to focus,
+    // nothing to click, and nothing for a screen reader to wade through.
+    expect(
+        await reference.evaluateAll((notes) =>
+            notes.every(
+                (note) =>
+                    note.getAttribute('aria-hidden') === 'true' &&
+                    note.tagName !== 'BUTTON' &&
+                    getComputedStyle(note).pointerEvents === 'none',
+            ),
+        ),
+        'reference notes should be inert',
+    ).toBe(true);
+
+    // Grey while nothing is playing.
+    await expect(staff.locator('.mark.reference.active')).toHaveCount(0);
+
+    // Soloing this track leaves the drum grey: it isn't being heard.
+    await palette.locator('[data-uiid="playTrack"]').click();
+    await expect(staff.locator('.mark.reference.active')).toHaveCount(0, {
+        timeout: 5000,
+    });
+    await palette.locator('[data-uiid="playTrack"]').click();
+
+    // Playing the whole music lights every reference note up, because every
+    // one of them is now sounding.
+    await palette.locator('[data-uiid="playMusic"]').click();
+    const drawn = await reference.count();
+    await expect
+        .poll(
+            async () =>
+                (await staff.locator('.mark.reference.active').count()) ===
+                drawn,
+            { message: 'reference notes did not go active', timeout: 5000 },
+        )
+        .toBe(true);
+});
+
+test('clicking the empty staff after a track adds a note to the end of it', async ({
+    page,
+}) => {
+    test.setTimeout(90000);
+
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await createTestProject(page);
+    // Every note the same, so where the added one lands is unambiguous — it is
+    // the only one that won't be a 1.
+    await loadCode(page, 'Music(Track([1 1 1 1] loop: ⊥))');
+
+    await page.locator('[data-uiid="paletteExpand"]').click();
+    const editor = page.getByTestId('editor').first();
+    await editor.getByText('Track', { exact: false }).first().click();
+
+    const staff = page.getByTestId('palette').locator('.staff');
+    const notes = staff.locator('.mark:not(.reference)');
+    await expect(notes).toHaveCount(4, { timeout: 10000 });
+
+    // A beat to the right of the last notehead: empty staff, unambiguously
+    // after the track. This used to insert second to last, because the whole
+    // width of the last note read as "before the last note".
+    const last = (await notes.last().boundingBox())!;
+    const box = (await staff.boundingBox())!;
+    await staff.click({
+        position: { x: last.x - box.x + 44, y: 20 },
+    });
+
+    await expect(notes).toHaveCount(5, { timeout: 10000 });
+    // The high note the click placed is last, not second to last. Read from
+    // the note list itself; the editor renders zero-width separators between
+    // every token, and a line number before them.
+    const source = ((await editor.textContent()) ?? '').replace(/​/g, '');
+    const list =
+        source
+            .match(/\[([^\]]*)\]/)?.[1]
+            .trim()
+            .split(/\s+/) ?? [];
+    expect(list, `the track reads ${list.join(' ')}`).toHaveLength(5);
+    expect(
+        list[list.length - 1],
+        `the added note should be last, but the track reads ${list.join(' ')}`,
+    ).not.toBe('1');
+
+    // And the note that was added is the one being edited. Focus used to land
+    // on the note before it, because the slot was clamped against the list as
+    // it was before the edit landed — which also dragged the cursor
+    // back to that note, since the focused note is where playing starts.
+    const focused = () =>
+        page.evaluate(
+            () => document.activeElement?.getAttribute('data-note') ?? null,
+        );
+    await expect.poll(focused, { timeout: 10000 }).toBe('4:0');
+    await expect
+        .poll(() =>
+            staff.evaluate((region) => {
+                const line = region.querySelector('.cursor');
+                const perBeat = parseFloat(
+                    getComputedStyle(region).getPropertyValue('--per-beat'),
+                );
+                return line === null
+                    ? -1
+                    : parseFloat(getComputedStyle(line).left) / perBeat;
+            }),
+        )
+        .toBe(4);
+
+    // Deleting it hands focus back to the note before, rather than stranding
+    // the staff with no tab stop at all.
+    await page.keyboard.press('Backspace');
+    await expect(notes).toHaveCount(4, { timeout: 10000 });
+    await expect.poll(focused).toBe('3:0');
+
+    // Enter repeats the focused note after it, which is another append.
+    await page.keyboard.press('Enter');
+    await expect(notes).toHaveCount(5, { timeout: 10000 });
+    await expect.poll(focused).toBe('4:0');
+});
+
+test('the first note added to an empty track is the one being edited', async ({
+    page,
+}) => {
+    test.setTimeout(90000);
+
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await createTestProject(page);
+    await loadCode(page, 'Music(Track([] loop: ⊥))');
+
+    await page.locator('[data-uiid="paletteExpand"]').click();
+    const editor = page.getByTestId('editor').first();
+    await editor.getByText('Track', { exact: false }).first().click();
+
+    const staff = page.getByTestId('palette').locator('.staff');
+    await expect(staff).toBeVisible({ timeout: 10000 });
+
+    // An empty track had no note to clamp a focus claim to, so the claim was
+    // refused and the note a creator had just placed wasn't the one they were
+    // editing.
+    await staff.click({ position: { x: 120, y: 40 } });
+    const focused = () =>
+        page.evaluate(
+            () => document.activeElement?.getAttribute('data-note') ?? null,
+        );
+    await expect.poll(focused, { timeout: 10000 }).toBe('0:0');
+
+    // Removing the only note leaves nothing to focus, and says so rather than
+    // holding a claim on a note that no longer exists.
+    await page.keyboard.press('Backspace');
+    await expect(staff.locator('.mark:not(.reference)')).toHaveCount(0, {
+        timeout: 10000,
+    });
+    await expect.poll(focused).toBeNull();
+});
+
+test('editing a note leaves the staff scrolled where it was', async ({
+    page,
+}) => {
+    test.setTimeout(90000);
+
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await createTestProject(page);
+    // Long enough to scroll, and a second track to switch to.
+    const many = Array.from({ length: 40 }, (_, i) => 1 + (i % 7)).join(' ');
+    await loadCode(
+        page,
+        `Music([Track([${many}] loop: ⊥) Track([1 2] loop: ⊥ instrument: Instrument.bell)])`,
+    );
+
+    await page.locator('[data-uiid="paletteExpand"]').click();
+    const editor = page.getByTestId('editor').first();
+    await editor.getByText('Track', { exact: false }).first().click();
+
+    const palette = page.getByTestId('palette');
+    const staff = palette.locator('.staff');
+    await expect(staff.locator('.mark').first()).toBeVisible({
+        timeout: 10000,
+    });
+    const scrolled = () => staff.evaluate((region) => region.scrollLeft);
+
+    await staff.evaluate((region) => (region.scrollLeft = 600));
+    await expect.poll(scrolled).toBe(600);
+
+    /** Wait for an edit to reach the program, whatever it was. Waiting on the
+     * source rather than on the noteheads, which are windowed to what fits. */
+    const edited = async (was: string) => {
+        await expect
+            .poll(async () => (await editor.textContent()) ?? '', {
+                message: 'the edit never reached the program',
+                timeout: 10000,
+            })
+            .not.toBe(was);
+    };
+
+    // Every edit mints new nodes, and the staff used to read that as a change
+    // of track and scroll back to the first note — out from under the hand
+    // that was editing.
+    let source = (await editor.textContent()) ?? '';
+    await staff.click({ position: { x: 200, y: 40 } });
+    await edited(source);
+    expect(await scrolled(), 'placing a note moved the staff').toBe(600);
+
+    // Same for an edit from the keyboard, which lands on the focused note.
+    source = (await editor.textContent()) ?? '';
+    await page.keyboard.press('ArrowUp');
+    await edited(source);
+    expect(await scrolled(), 'transposing a note moved the staff').toBe(600);
+
+    // But a real change of track still shows that track's first note, which is
+    // the behavior the identity check was there for.
+    await palette.locator('.tracks').first().locator('button').last().click();
+    await expect.poll(scrolled).not.toBe(600);
+});
+
 /** A Standard MIDI File with `tracks` x `perTrack` notes, built in memory. */
 function midiBytes(tracks: number, perTrack: number): Buffer {
     const bytes: number[] = [];
@@ -138,8 +393,14 @@ function midiBytes(tracks: number, perTrack: number): Buffer {
         return out;
     };
     bytes.push(
-        0x4d, 0x54, 0x68, 0x64,
-        ...u32(6), ...u16(1), ...u16(tracks), ...u16(480),
+        0x4d,
+        0x54,
+        0x68,
+        0x64,
+        ...u32(6),
+        ...u16(1),
+        ...u16(tracks),
+        ...u16(480),
     );
     for (let t = 0; t < tracks; t++) {
         const data: number[] = [];
@@ -158,7 +419,9 @@ test('importing a large MIDI file finishes rather than hanging', async ({
 }) => {
     test.setTimeout(120000);
 
-    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
     await createTestProject(page);
 
     // No code loaded on purpose. The importer sits beside the "+music" offer,
@@ -175,13 +438,11 @@ test('importing a large MIDI file finishes rather than hanging', async ({
     // the quadratic path ever comes back, this fails instead of freezing a tab
     // for someone to discover by hand.
     const started = Date.now();
-    await palette
-        .locator('input[type="file"]')
-        .setInputFiles({
-            name: 'big.mid',
-            mimeType: 'audio/midi',
-            buffer: midiBytes(4, 800),
-        });
+    await palette.locator('input[type="file"]').setInputFiles({
+        name: 'big.mid',
+        mimeType: 'audio/midi',
+        buffer: midiBytes(4, 800),
+    });
 
     // An import writes two sources: the program that plays the music, and a
     // second one holding the notes. So the program gets a borrow and a
@@ -203,8 +464,7 @@ test('importing a large MIDI file finishes rather than hanging', async ({
     );
 
     const elapsed = Date.now() - started;
-    expect(
-        elapsed,
-        `import of 3,200 notes took ${elapsed}ms`,
-    ).toBeLessThan(30000);
+    expect(elapsed, `import of 3,200 notes took ${elapsed}ms`).toBeLessThan(
+        30000,
+    );
 });


### PR DESCRIPTION
# Context

The palette's editable staff drew only the track being edited, so writing a part *against* another one — setting a drum beat under a melody — meant guessing where the other notes fell. There was nothing on the staff to line up with.

Every track is now drawn. The edited one keeps the normal foreground color and stays editable; the rest are inert — inactive color, `aria-hidden`, `pointer-events: none` — and carry their instrument's emoji at the stem tip, the way the stage's read-only sheet labels its notes. A looping track's repeats are drawn the same way, including the edited track's own, so *that a track loops* is something the staff shows rather than something only the `loop` toggle says. Color follows what is sounding: playing the whole music turns every note active, while soloing a track turns only that track and its repeats.

The staff now spans the whole music and centers on it, so a pitch sits at the same height whichever track is selected. Without that, switching tracks slid every reference note vertically and the comparison the feature exists for wouldn't hold still.

Four bugs turned up on the way, three of them in the same click-and-focus path:

- **Clicking couldn't extend a track.** The insertion index asked which note was *sounding* at that beat, which is half a note out for an insertion — a notehead is drawn straddling its onset while its span begins there. The whole width of the last note read as "before the last note", so the empty staff after a track could not be clicked to extend it, and every other insertion landed one slot left of the gap that was clicked. `indexAtBeat` becomes `insertionAtBeat`, answering the gap a beat is nearest.
- **The staff scrolled back to the start on every edit.** It decided the carousel had moved by comparing `EditableTrack` identity, and every edit revises the project and mints a new one. Keyed on which track instead — as is the play cursor, which had the same bug.
- **Focus landed on the wrong note after an edit.** It was clamped against the note list as it stood *before* the edit landed, so appending focused the note before the new one and dragged the cursor there with it, while the first note added to an empty track got no focus at all. Removing a note is the only caller that shrinks the list, so that branch now says where focus goes itself.
- **The stage's speaker chip spun forever.** On a project that was only being edited, a fully downloaded instrument stayed `fetching` — decoding needs an `AudioContext`, and the player only makes one inside a play gesture. A `fetched` state separates the two halves of the wait, so the chip reports only what is actually in flight. This is the one fix to shipped behavior; the other three are to the music editor, which hasn't been released yet.

## Related issues

-   Related Issue #390

## Verification

`npm run check:now` and `npm test` (4805 passing) are clean. Playwright `music-editor` and `accessibility-authed` suites pass in Chromium against the Firebase emulator:

```bash
npm run build && npx firebase emulators:exec \
  "npx playwright test music-editor accessibility-authed --project=chromium" \
  --project=demo-wordplay --log-verbosity QUIET
```

Every fix has a regression test that fails against the old behavior:

- `sheet.test.ts` — `referenceMarks`: other tracks kept, the edited pass dropped, loop echoes kept only when `loop` is on, rests never included.
- `schedule.test.ts` — `insertionAtBeat`: the gap nearest a beat, the staff after the last note appending, a long note being one gap wide rather than one beat.
- `instrumentSamples.test.ts` — a finished download must stop reporting as loading, and a 404'd instrument must still report ready so the player synthesizes.
- `music-editor.spec.ts` — reference notes render and are inert; they go active under ▶🎶 but not ▶🎵; clicking past the last note appends and focuses the new note with the cursor on it; the first note in an empty track takes focus and deleting the only note releases it; the scroll position survives a pointer edit and a keyboard edit but still moves on a real track change.

Checked by hand in Chromium, light and dark: a melody over a drum loop and a bell reads correctly, a four-note looping track alone draws four black noteheads then four grey repeats that vanish when `loop` is turned off, and the reported speaker chip is gone on the program that triggered it.

## Checklist

-   [ ] **Screen reader verification (VoiceOver/NVDA) has not been done** and should be before merge. The reference layer is `aria-hidden` and unfocusable by design, so the accessibility tree should be unchanged from before — one tab stop on the staff, reaching only the edited track's notes — but that needs confirming with a real screen reader. Worth checking too that deleting the last note still leaves the staff reachable, since focus is released there.
-   [ ] Only Chromium was exercised; Firefox and WebKit haven't been checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
