### PR TITLE
Fix the WebKit nightly e2e run

### DIFF
--- a/tests/end2end/announcer.spec.ts
+++ b/tests/end2end/announcer.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { createTestProject } from '../helpers/createProject';
+import { grantClipboard } from '../helpers/clipboard';
 
 /**
  * The centralized Announcer (src/components/project/Announcer.svelte) owns
@@ -223,9 +224,7 @@ async function playing(
     page: import('@playwright/test').Page,
     code: string,
 ): Promise<() => Promise<string>> {
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     const base = page.url().split('?')[0];
     const editor = page.getByTestId('editor').first();
@@ -362,9 +361,7 @@ test('stage output is described once, by the stage', async ({ page }) => {
 test('a paused stage stays quiet while you edit', async ({ page }) => {
     // A paused stage is a preview of code being read with the caret and echo
     // announcements; describing it talks over them.
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     const editor = page.getByTestId('editor').first();
     await editor.click();

--- a/tests/end2end/editor-fuzz.spec.ts
+++ b/tests/end2end/editor-fuzz.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright/fixtures';
 import { createTestProject } from '../helpers/createProject';
+import { grantClipboard } from '../helpers/clipboard';
 
 /**
  * Stress test for the editor's render layer: the crash class fixed alongside
@@ -58,7 +59,17 @@ test('rapid editing never crashes the editor', async ({ page }) => {
     // Other console.error noise (e.g. the emulator's PresenceTracker permission
     // warnings) is unrelated and must not fail the test.
     const errors: string[] = [];
-    page.on('pageerror', (error) => errors.push(error.stack ?? String(error)));
+    page.on('pageerror', (error) => {
+        // "ResizeObserver loop completed with undelivered notifications" is a
+        // benign browser condition rather than a throw from our code: it means
+        // a resize callback caused another resize, which a resizing editor full
+        // of animated typography does constantly. WebKit reports it as a
+        // pageerror where Chromium doesn't, so it failed only the nightly.
+        if (error.message.startsWith('ResizeObserver loop')) return;
+        // Prefer the stack, but fall back to the message — WebKit leaves the
+        // stack empty on some errors, and reporting "" says nothing.
+        errors.push(error.stack || error.message || String(error));
+    });
     page.on('console', (message) => {
         if (
             message.type() === 'error' &&
@@ -67,7 +78,7 @@ test('rapid editing never crashes the editor', async ({ page }) => {
             errors.push(message.text());
     });
 
-    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
 
     await createTestProject(page);
     const editor = page.getByTestId('editor').first();

--- a/tests/end2end/keyboard-navigation.spec.ts
+++ b/tests/end2end/keyboard-navigation.spec.ts
@@ -10,7 +10,18 @@ import { createTestProject } from '../helpers/createProject';
 
 test('home page primary navigation is reachable by keyboard, in order', async ({
     page,
+    browserName,
 }) => {
+    // WebKit leaves links out of the tab order entirely — Safari's "press Tab
+    // to highlight each item on a webpage" is off by default, so Tab visits
+    // form controls only. That's a browser preference, not something our
+    // markup decides: the same links focus fine via element.focus() in WebKit,
+    // and Chromium covers the ordering this test is really about.
+    test.skip(
+        browserName === 'webkit',
+        'WebKit omits links from the tab order by default',
+    );
+
     await page.goto('/en-US/');
     await expect(page.getByRole('heading').first()).toBeVisible();
 

--- a/tests/end2end/music-editor.spec.ts
+++ b/tests/end2end/music-editor.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright/fixtures';
 import { createTestProject } from '../helpers/createProject';
+import { grantClipboard } from '../helpers/clipboard';
 
 /**
  * The music editor's playback feedback, which can only be observed in a
@@ -33,9 +34,7 @@ async function loadCode(
 test('the playhead appears and advances while previewing', async ({ page }) => {
     test.setTimeout(90000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     // Slow and long, so the head has somewhere to travel and time to do it.
     await loadCode(page, 'Music(Track([1 2 3 4 5 6 7 8]) tempo: 60beats/min)');
@@ -93,9 +92,7 @@ test('the playhead appears and advances while previewing', async ({ page }) => {
 test('only one play button owns the preview at a time', async ({ page }) => {
     test.setTimeout(90000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     await loadCode(page, 'Music(Track([1 2 3 4]) tempo: 60beats/min)');
 
@@ -129,9 +126,7 @@ test('the other tracks are drawn for reference, and only sound active when they 
 }) => {
     test.setTimeout(90000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     // A melody and a short loop under it — the pairing the reference layer
     // exists for. The melody is selected first, since it is track one.
@@ -199,9 +194,7 @@ test('clicking the empty staff after a track adds a note to the end of it', asyn
 }) => {
     test.setTimeout(90000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     // Every note the same, so where the added one lands is unambiguous — it is
     // the only one that won't be a 1.
@@ -280,9 +273,7 @@ test('the first note added to an empty track is the one being edited', async ({
 }) => {
     test.setTimeout(90000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     await loadCode(page, 'Music(Track([] loop: ⊥))');
 
@@ -317,9 +308,7 @@ test('editing a note leaves the staff scrolled where it was', async ({
 }) => {
     test.setTimeout(90000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     // Long enough to scroll, and a second track to switch to.
     const many = Array.from({ length: 40 }, (_, i) => 1 + (i % 7)).join(' ');
@@ -419,9 +408,7 @@ test('importing a large MIDI file finishes rather than hanging', async ({
 }) => {
     test.setTimeout(120000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
 
     // No code loaded on purpose. The importer sits beside the "+music" offer,

--- a/tests/end2end/palette-gated-output.spec.ts
+++ b/tests/end2end/palette-gated-output.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright/fixtures';
 import { createTestProject } from '../helpers/createProject';
+import { grantClipboard } from '../helpers/clipboard';
 
 /**
  * Output selection and the chrome that draws it belong to the palette: with the palette
@@ -37,9 +38,7 @@ async function loadCode(
 test('output chrome and selection need the palette open', async ({ page }) => {
     test.setTimeout(60000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     await loadCode(page, "Phrase('hi')");
 
@@ -73,9 +72,7 @@ test('an unselected output border is dashed, a selected one glows', async ({
 }) => {
     test.setTimeout(60000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     await loadCode(page, "Group(Stack() [Phrase('hi') Phrase('there')])");
 
@@ -131,9 +128,7 @@ test('an empty phrase is visible and laid out like any other', async ({
 }) => {
     test.setTimeout(60000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
     await loadCode(page, "Phrase('')");
 

--- a/tests/end2end/palette-selection.spec.ts
+++ b/tests/end2end/palette-selection.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright/fixtures';
 import { createTestProject } from '../helpers/createProject';
+import { grantClipboard } from '../helpers/clipboard';
 
 /**
  * The palette is the only thing on screen that explains an output selection, and the
@@ -17,9 +18,7 @@ test('collapsing the palette clears the output selection underline', async ({
 }) => {
     test.setTimeout(60000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
 
     const editor = page.getByTestId('editor').first();

--- a/tests/end2end/phrase-text-editing.spec.ts
+++ b/tests/end2end/phrase-text-editing.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../../playwright/fixtures';
 import { createTestProject } from '../helpers/createProject';
+import { grantClipboard } from '../helpers/clipboard';
 
 /**
  * Editing a phrase's text on stage must behave like a text field. It doesn't come for free:
@@ -23,9 +24,7 @@ test('typing in a phrase on stage inserts in order, without accumulating quotes'
 }) => {
     test.setTimeout(60000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
 
     const editor = page.getByTestId('editor').first();
@@ -71,9 +70,7 @@ test('a formatted phrase opens the palette rather than a plain text field', asyn
 }) => {
     test.setTimeout(60000);
 
-    await page
-        .context()
-        .grantPermissions(['clipboard-read', 'clipboard-write']);
+    await grantClipboard(page);
     await createTestProject(page);
 
     const editor = page.getByTestId('editor').first();

--- a/tests/helpers/clipboard.ts
+++ b/tests/helpers/clipboard.ts
@@ -1,0 +1,17 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Grant clipboard access, where the browser has a permission to grant.
+ *
+ * Only Chromium gates scripted clipboard access behind a permission. WebKit
+ * has no such permission name, and `grantPermissions` throws `Unknown
+ * permission: clipboard-write` rather than ignoring it — which failed every
+ * clipboard-using spec on the WebKit nightly, before any of them reached an
+ * assertion.
+ */
+export async function grantClipboard(page: Page): Promise<void> {
+    if (page.context().browser()?.browserType().name() !== 'chromium') return;
+    await page
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write']);
+}


### PR DESCRIPTION
# Context

The nightly WebKit e2e run has been failing every night since at least August 3. Three separate problems, all in the tests rather than the app — nothing here changes shipped behavior.

**Clipboard permissions (16 call sites, 6 specs).** Only Chromium gates scripted clipboard access behind a permission. WebKit has no such permission name, and `grantPermissions` throws `Unknown permission: clipboard-write` rather than ignoring it — so every clipboard-using spec died before reaching an assertion. A new `grantClipboard` helper grants only where there's something to grant. WebKit reaches `navigator.clipboard` fine without it, which is what makes the skip safe rather than a silent loss of coverage.

**The fuzz test.** WebKit reports `ResizeObserver loop completed with undelivered notifications` as a `pageerror`; Chromium doesn't. It's a benign browser condition — a resize callback causing another resize, which a resizing editor full of animated typography does constantly — not a throw from our code, so it's now filtered. Separately, WebKit leaves that error's `stack` empty and the listener preferred the stack, so the failure reported `""` and said nothing about what broke; it now falls back to the message. That second part is why this took longer to diagnose than it should have, and it'll pay off the next time something fails here.

**Tab order.** WebKit omits links from the tab order entirely: Safari's "press Tab to highlight each item on a webpage" is off by default, so Tab visits form controls only. I verified this rather than assuming — walking the tab order in WebKit yields only `BUTTON` elements, while the same links focus fine via `element.focus()`. So it's a browser preference, not something our markup decides, and the one test asserting link tab-reachability is skipped on WebKit and keeps its Chromium coverage.

## Related issues

The nightly failures; no tracking issue.

-   Related Issue #
-   Closes #

## Verification

- **Full WebKit suite, macOS:** 135 passed, 1 skipped (the tab-order test above). Reproduced each failure locally first, then confirmed the fix.
- **Chromium:** the 7 affected specs still pass (33 tests) — the clipboard grant still happens there.
- `npm run check:now` clean, `npm test` green (5100).

Two notes on what I did *not* treat as real failures. The nightly also showed `page-headers › Learn link loads` failing after 21s; it passes locally and reads as a timeout under runner contention, so I left it alone rather than papering over it. And a first full-suite run showed the two `tutorial lesson has no WCAG 2.2 AA violations` scans failing; they pass in isolation and pass in a full run with CI's retry count, matching the emulator-contention note already in `playwright.config.ts`. If either turns out to be a persistent flake, it deserves its own fix rather than being bundled here.

## Checklist

-   [ ] Confirm the next nightly run goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
