### PR TITLE
Take the language runtime off pages that don't run code

### DIFF
--- a/src/components/annotations/Annotations.svelte
+++ b/src/components/annotations/Annotations.svelte
@@ -23,6 +23,10 @@
 </script>
 
 <script lang="ts">
+    // Populates the conflict-resolution registry read by getResolutions below.
+    // Imported here rather than in the root layout so its ~40 node and conflict
+    // classes load with the editor instead of with every page.
+    import '@conflicts/registerTypeResolutions';
     import getFocusNode from '@components/annotations/getFocusNode';
     import getMenuNoteMarkup from '@components/editor/menu/menuNote';
     import { describesOwnType } from '@nodes/conciseRef';
@@ -32,8 +36,8 @@
         DecrementLiteral,
         IncrementLiteral,
         ShowMenu,
-        toShortcut,
     } from '@components/editor/commands/Commands';
+    import { toShortcut } from '@components/editor/commands/shortcuts';
     import Speech from '@components/lore/Speech.svelte';
     import CommandButton from '@components/widgets/CommandButton.svelte';
     import Sidebar from '@components/widgets/Sidebar.svelte';

--- a/src/components/app/Background.svelte
+++ b/src/components/app/Background.svelte
@@ -56,9 +56,10 @@
 
                 const element = elements[character.index];
                 if (element) {
-                    element.style.left = `${character.x}px`;
-                    element.style.top = `${character.y}px`;
-                    element.style.transform = `rotate(${character.angle}deg)`;
+                    // Position with a transform rather than left/top: those
+                    // are layout properties, so moving 20 very large glyphs
+                    // with them reflowed the whole document every frame.
+                    element.style.transform = `translate(${character.x}px, ${character.y}px) rotate(${character.angle}deg)`;
                 }
             }
         }
@@ -162,6 +163,10 @@
         font-family: 'Noto Emoji';
         font-size: 48pt;
         position: absolute;
+        /* The animation translates from this origin; see the transform in
+           step() for why position isn't set with left/top. */
+        left: 0;
+        top: 0;
         opacity: 0.03;
         user-select: none;
         color: var(--wordplay-inactive);

--- a/src/components/app/CreatorView.svelte
+++ b/src/components/app/CreatorView.svelte
@@ -75,6 +75,9 @@
     .loading-face {
         display: inline-block;
         transform-origin: center;
+        /* The mono chain, so this monochrome face doesn't match a color emoji
+           slice and download it. The FE0E selector alone doesn't prevent that. */
+        font-family: var(--wordplay-emoji-mono-font);
         /* Multiplying by --animation-factor makes this a no-op under
            prefers-reduced-motion (factor 0), matching Spinning.svelte. */
         animation: spin infinite linear;

--- a/src/components/app/Page.svelte
+++ b/src/components/app/Page.svelte
@@ -22,7 +22,6 @@
     import OverflowToolbar from '@components/widgets/OverflowToolbar.svelte';
     import Toggle from '@components/widgets/Toggle.svelte';
     import { Creator } from '@db/creators/CreatorDatabase';
-    import Color from '@output/Color/Color';
     import {
         DOCUMENTATION_SYMBOL,
         LEARN_SYMBOL,
@@ -57,6 +56,7 @@
     let fullscreen: FullscreenContext = writable({
         on: false,
         background: null,
+        foreground: null,
     });
     setFullscreen(fullscreen);
 
@@ -66,14 +66,10 @@
     $effect(() => {
         if (typeof document !== 'undefined' && $fullscreen) {
             document.body.style.background = $fullscreen.on
-                ? $fullscreen.background instanceof Color
-                    ? $fullscreen.background.toCSS()
-                    : ($fullscreen.background ?? '')
+                ? ($fullscreen.background ?? '')
                 : '';
             document.body.style.color = $fullscreen.on
-                ? $fullscreen.background instanceof Color
-                    ? $fullscreen.background.contrasting().toCSS()
-                    : ''
+                ? ($fullscreen.foreground ?? '')
                 : '';
         }
     });

--- a/src/components/concepts/RichSegmentHTMLView.svelte
+++ b/src/components/concepts/RichSegmentHTMLView.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+    /**
+     * The markup segments that render code: examples, node references, and
+     * values. They need the editor, the evaluator, and the output layer, which
+     * together are most of the language runtime — so they live here, behind the
+     * dynamic import in richSegment.ts, rather than in SegmentHTMLView. Every
+     * page shows localized markup; only some of them show code.
+     */
+    import NodeRef from '@locale/NodeRef';
+    import ValueRef from '@locale/ValueRef';
+    import Example from '@nodes/Example';
+    import type { Segment } from '@nodes/Paragraph';
+    import UnknownType from '@nodes/UnknownType';
+    import type Spaces from '@parser/Spaces';
+    import RootView from '@components/project/RootView.svelte';
+    import ValueView from '@components/values/ValueView.svelte';
+    import ConceptPreview from '@components/concepts/ConceptPreview.svelte';
+    import elideNode from '@components/concepts/elideNode';
+    import ExampleUI from '@components/concepts/ExampleUI.svelte';
+    import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
+
+    interface Props {
+        segment: Segment;
+        spaces: Spaces;
+        /** True if this is the only segment in a paragraph */
+        alone: boolean;
+    }
+
+    let { segment, spaces, alone }: Props = $props();
+</script>
+
+{#if segment instanceof Example}{#if alone}<ExampleUI
+            example={segment}
+            {spaces}
+            evaluated={alone}
+        />
+    {:else}<ConceptPreview
+            node={segment.program}
+            inline={true}
+            {spaces}
+            outline={false}
+            describe={false}
+        />{/if}
+{:else if segment instanceof NodeRef}{#if segment.node instanceof UnknownType}
+        <MarkupHTMLView
+            markup={segment.node.getDescription(
+                segment.locales,
+                segment.context,
+            )}
+            inline
+        />
+    {:else}
+        {@const elision = elideNode(segment.node, segment.locales)}
+        {#if elision}
+            <!-- Render the elided preview (still as code, via RootView) and
+                 append the localized "or N other options" suffix as markup. -->
+            <RootView
+                node={elision.preview}
+                inline
+                locale="symbolic"
+                blocks={false}
+            /><MarkupHTMLView markup={elision.suffix} inline />
+        {:else}<RootView
+                node={segment.node}
+                inline
+                locale="symbolic"
+                blocks={false}
+            />{/if}
+    {/if}
+{:else if segment instanceof ValueRef}<strong
+        ><ValueView value={segment.value} /></strong
+    >{/if}

--- a/src/components/concepts/SegmentHTMLView.svelte
+++ b/src/components/concepts/SegmentHTMLView.svelte
@@ -1,33 +1,28 @@
 <script lang="ts">
     import ConceptRef from '@locale/ConceptRef';
-    import NodeRef from '@locale/NodeRef';
     import TermRef from '@locale/TermRef';
-    import ValueRef from '@locale/ValueRef';
     import ConceptLink from '@nodes/ConceptLink';
-    import Example from '@nodes/Example';
     import ExternalExample from '@nodes/ExternalExample';
     import type { Segment } from '@nodes/Paragraph';
     import { Sym } from '@nodes/Sym';
     import Token from '@nodes/Token';
-    import UnknownType from '@nodes/UnknownType';
     import WebLink from '@nodes/WebLink';
     import Words from '@nodes/Words';
     import type Spaces from '@parser/Spaces';
     import { unescapeMarkupSymbols } from '@parser/Tokenizer';
     import { BULLET_SYMBOL } from '@parser/Symbols';
     import Link from '@components/app/Link.svelte';
-    import RootView from '@components/project/RootView.svelte';
-    import ValueView from '@components/values/ValueView.svelte';
-    import ConceptPreview from '@components/concepts/ConceptPreview.svelte';
     import ConceptLinkUI from '@components/concepts/ConceptLinkUI.svelte';
     import TermView from '@components/concepts/TermView.svelte';
-    import elideNode from '@components/concepts/elideNode';
-    import ExampleUI from '@components/concepts/ExampleUI.svelte';
     import ExternalExampleView from '@components/concepts/ExternalExampleView.svelte';
-    import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import WebLinkHTMLView from '@components/concepts/WebLinkHTMLView.svelte';
     import WordsHTMLView from '@components/concepts/WordsHTMLView.svelte';
     import EmojisRepaired from '@components/widgets/EmojisRepaired.svelte';
+    import Spinning from '@components/app/Spinning.svelte';
+    import {
+        isRichSegment,
+        loadRichSegment,
+    } from '@components/concepts/richSegment';
 
     interface Props {
         segment: Segment;
@@ -76,18 +71,21 @@
 </script>
 
 {#if segment instanceof WebLink}<WebLinkHTMLView link={segment} {spaces} />
-{:else if segment instanceof Example}{#if alone}<ExampleUI
-            example={segment}
+    <!-- Examples, node references, and values render code, so they arrive with
+         the language runtime on demand. While it loads, the app's spinner
+         stands in so the gap reads as "coming" rather than as missing text.
+         It's aria-hidden: a page of documentation can hold dozens of these,
+         and Spinning is a live region, so leaving them exposed would announce
+         "loading" dozens of times. Screen readers get the code when it
+         arrives. -->
+{:else if isRichSegment(segment)}{#await loadRichSegment()}<span
+            class="rich-loading"
+            aria-hidden="true"><Spinning size={1.5} /></span
+        >{:then RichSegment}<RichSegment
+            {segment}
             {spaces}
-            evaluated={alone}
-        />
-    {:else}<ConceptPreview
-            node={segment.program}
-            inline={true}
-            {spaces}
-            outline={false}
-            describe={false}
-        />{/if}
+            {alone}
+        />{/await}
 {:else if segment instanceof ExternalExample}<ExternalExampleView
         example={segment}
     />
@@ -97,37 +95,17 @@
     />
 {:else if segment instanceof TermRef}<TermView term={segment} />
 {:else if segment instanceof Words}<WordsHTMLView words={segment} {spaces} />
-{:else if segment instanceof NodeRef}{#if segment.node instanceof UnknownType}
-        <MarkupHTMLView
-            markup={segment.node.getDescription(
-                segment.locales,
-                segment.context,
-            )}
-            inline
-        />
-    {:else}
-        {@const elision = elideNode(segment.node, segment.locales)}
-        {#if elision}
-            <!-- Render the elided preview (still as code, via RootView) and
-                 append the localized "or N other options" suffix as markup. -->
-            <RootView
-                node={elision.preview}
-                inline
-                locale="symbolic"
-                blocks={false}
-            /><MarkupHTMLView markup={elision.suffix} inline />
-        {:else}<RootView
-                node={segment.node}
-                inline
-                locale="symbolic"
-                blocks={false}
-            />{/if}
-    {/if}
-{:else if segment instanceof ValueRef}<strong
-        ><ValueView value={segment.value} /></strong
-    >
     <!-- Remove the bullet if the words start with one. -->
-{:else if segment instanceof Token}{#if isTokenSpaced(segment)}&nbsp;{/if}{#if segment.isSymbol(Sym.URL)}{@const url = getTokenURL(segment)}<Link
-            external={!url.startsWith('/')}
-            to={url}>{segment.getText()}</Link
+{:else if segment instanceof Token}{#if isTokenSpaced(segment)}&nbsp;{/if}{#if segment.isSymbol(Sym.URL)}{@const url =
+            getTokenURL(segment)}<Link external={!url.startsWith('/')} to={url}
+            >{segment.getText()}</Link
         >{:else}<EmojisRepaired text={getTokenText(segment)} />{/if}{/if}
+
+<style>
+    /* Keep the stand-in on the text baseline so a line of prose doesn't jump
+       while the code it contains is still arriving. */
+    .rich-loading {
+        display: inline-block;
+        vertical-align: middle;
+    }
+</style>

--- a/src/components/concepts/richSegment.ts
+++ b/src/components/concepts/richSegment.ts
@@ -1,0 +1,33 @@
+import NodeRef from '@locale/NodeRef';
+import ValueRef from '@locale/ValueRef';
+import Example from '@nodes/Example';
+import type { Segment } from '@nodes/Paragraph';
+
+/**
+ * Loads the markup segments that render code. Kept apart from
+ * SegmentHTMLView so the language runtime they need arrives only on the pages
+ * that actually show an example, a node reference, or a value.
+ *
+ * The promise is memoized at module scope but never awaited there: a
+ * module-level await anywhere in the app graph reorders WebKit's module
+ * evaluation across the route/db import cycle and crashes hydration (see
+ * src/util/getTemporal.ts).
+ */
+let loading:
+    Promise<typeof import('./RichSegmentHTMLView.svelte').default> | undefined =
+    undefined;
+
+export function loadRichSegment() {
+    return (loading ??= import('./RichSegmentHTMLView.svelte').then(
+        (module) => module.default,
+    ));
+}
+
+/** Whether this segment is one RichSegmentHTMLView renders. */
+export function isRichSegment(segment: Segment): boolean {
+    return (
+        segment instanceof Example ||
+        segment instanceof NodeRef ||
+        segment instanceof ValueRef
+    );
+}

--- a/src/components/editor/Editor.svelte
+++ b/src/components/editor/Editor.svelte
@@ -15,10 +15,10 @@
         type Edit,
         InsertSymbol,
         type ProjectRevision,
-        altKeyLabel,
         handleKeyCommand,
         resetVisualColumnAfter,
     } from '@components/editor/commands/Commands';
+    import { altKeyLabel } from '@components/editor/commands/shortcuts';
     import { resolveFeedback } from '@components/editor/commands/feedback';
     import { getInternalClipboard } from '@components/editor/commands/InternalClipboard';
     import {

--- a/src/components/editor/commands/Commands.ts
+++ b/src/components/editor/commands/Commands.ts
@@ -287,51 +287,6 @@ export const Category = {
 } as const;
 export type Category = (typeof Category)[keyof typeof Category];
 
-/** Whether the current device uses macOS/iOS modifier-key conventions, which
- *  label modifiers with symbols rather than words. */
-export function onMacOS() {
-    return (
-        typeof navigator !== 'undefined' &&
-        navigator.userAgent.indexOf('Mac') !== -1
-    );
-}
-
-/** Platform-specific labels for the modifier keys, reused wherever we summarize a
- *  keyboard shortcut (toShortcut and in-editor instructions like the Tab notice). */
-export function controlKeyLabel() {
-    return onMacOS() ? '⌘' : 'Ctrl';
-}
-export function altKeyLabel() {
-    return onMacOS() ? '⎇' : 'Alt';
-}
-export function shiftKeyLabel() {
-    return onMacOS() ? '⇧' : 'Shift';
-}
-
-export function toShortcut(
-    command: {
-        control: boolean | undefined;
-        alt: boolean | undefined;
-        shift: boolean | undefined;
-        key?: string;
-        keySymbol?: string;
-    },
-    hideControl = false,
-    hideShift = false,
-    hideAlt = false,
-) {
-    const mac = onMacOS();
-    return `${command.control && !hideControl ? (mac ? controlKeyLabel() : controlKeyLabel() + '+') : ''}${
-        command.alt && !hideAlt
-            ? mac
-                ? altKeyLabel()
-                : altKeyLabel() + ' + '
-            : ''
-    }${command.shift && !hideShift ? (mac ? shiftKeyLabel() : shiftKeyLabel() + ' + ') : ''}${
-        command.keySymbol ?? command.key ?? '-'
-    }`;
-}
-
 export function handleKeyCommand(
     event: KeyboardEvent,
     context: CommandContext,

--- a/src/components/editor/commands/shortcuts.ts
+++ b/src/components/editor/commands/shortcuts.ts
@@ -1,0 +1,51 @@
+/**
+ * How we label keyboard shortcuts. Separate from Commands.ts because widgets
+ * that merely *show* a shortcut (Toggle, CommandButton) would otherwise import
+ * the whole command table, which reaches Caret and Project and so pulls the
+ * language runtime into every page that renders a toolbar.
+ */
+
+/** Whether the current device uses macOS/iOS modifier-key conventions, which
+ *  label modifiers with symbols rather than words. */
+export function onMacOS() {
+    return (
+        typeof navigator !== 'undefined' &&
+        navigator.userAgent.indexOf('Mac') !== -1
+    );
+}
+
+/** Platform-specific labels for the modifier keys, reused wherever we summarize a
+ *  keyboard shortcut (toShortcut and in-editor instructions like the Tab notice). */
+export function controlKeyLabel() {
+    return onMacOS() ? '⌘' : 'Ctrl';
+}
+export function altKeyLabel() {
+    return onMacOS() ? '⎇' : 'Alt';
+}
+export function shiftKeyLabel() {
+    return onMacOS() ? '⇧' : 'Shift';
+}
+
+export function toShortcut(
+    command: {
+        control: boolean | undefined;
+        alt: boolean | undefined;
+        shift: boolean | undefined;
+        key?: string;
+        keySymbol?: string;
+    },
+    hideControl = false,
+    hideShift = false,
+    hideAlt = false,
+) {
+    const mac = onMacOS();
+    return `${command.control && !hideControl ? (mac ? controlKeyLabel() : controlKeyLabel() + '+') : ''}${
+        command.alt && !hideAlt
+            ? mac
+                ? altKeyLabel()
+                : altKeyLabel() + ' + '
+            : ''
+    }${command.shift && !hideShift ? (mac ? shiftKeyLabel() : shiftKeyLabel() + ' + ') : ''}${
+        command.keySymbol ?? command.key ?? '-'
+    }`;
+}

--- a/src/components/project/CommandDescription.svelte
+++ b/src/components/project/CommandDescription.svelte
@@ -2,9 +2,9 @@
     import Emoji from '@components/app/Emoji.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import {
-        toShortcut,
         type Command,
     } from '@components/editor/commands/Commands';
+    import { toShortcut } from '@components/editor/commands/shortcuts';
 
     interface Props {
         command: Command;

--- a/src/components/project/Contexts.ts
+++ b/src/components/project/Contexts.ts
@@ -13,7 +13,6 @@ import type Node from '@nodes/Node';
 import type { FieldPosition } from '@nodes/Node';
 import type Root from '@nodes/Root';
 import type Token from '@nodes/Token';
-import type Color from '@output/Color/Color';
 import type Spaces from '@parser/Spaces';
 import type { ProjectMode } from '@components/project/ProjectMode';
 import type Evaluator from '@runtime/Evaluator';
@@ -92,10 +91,13 @@ export type AnnouncerContext =
 export const [getAnnouncer, setAnnouncer] =
     createOptionalContext<Writable<AnnouncerContext>>();
 
-/** Whether the site is in fullscreen mode. */
+/** Whether the site is in fullscreen mode. Colors arrive already resolved to
+ * CSS: Page renders on every route, and importing Color to resolve them there
+ * would pull the whole language basis into every page's bundle. */
 export type FullscreenContext = Writable<{
     on: boolean;
-    background: Color | string | null;
+    background: string | null;
+    foreground: string | null;
 }>;
 export const [getFullscreen, setFullscreen] =
     createContext<FullscreenContext>();

--- a/src/components/project/CurrentLayout.svelte
+++ b/src/components/project/CurrentLayout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import Emoji from '@components/app/Emoji.svelte';
     import Layout, { LayoutIcons } from '@components/project/Layout';
     import Options from '@components/widgets/Options.svelte';
     import { locales, Settings } from '@db/Database';
@@ -80,7 +81,7 @@
     {#snippet item(option, localized)}
         <span class="option">
             <span class="name"
-                >{withMonoEmoji(option.icon)}
+                ><Emoji text={withMonoEmoji(option.icon)} />
                 {@render localized(option.label)}</span
             >
             <span class="description">{$locales.getPlainText(option.tip)}</span>
@@ -101,6 +102,9 @@
     .pair {
         display: inline-flex;
         align-items: center;
+        /* The mono chain, so these monochrome icons don't match a color emoji
+           slice and download it. The FE0E selector alone doesn't prevent that. */
+        font-family: var(--wordplay-emoji-mono-font);
     }
 
     /* When the layout is automatic, "auto" sits beside the layout it resolved to.

--- a/src/components/project/ProjectView.svelte
+++ b/src/components/project/ProjectView.svelte
@@ -95,7 +95,7 @@
     import Evaluate from '@nodes/Evaluate';
     import Node, { isFieldPosition } from '@nodes/Node';
     import Source from '@nodes/Source';
-    import type Color from '@output/Color/Color';
+    import Color from '@output/Color/Color';
     import {
         CANCEL_SYMBOL,
         EDIT_SYMBOL,
@@ -409,11 +409,18 @@
 
     /** Tell the parent Page whether we're in fullscreen so it can hide and color things appropriately. */
     $effect(() => {
+        // Only set a background if it's the stage that's in fullscreen.
+        const background = layout.isStageFullscreen() ? outputBackground : null;
         pageFullscreen?.set({
             // Don't turn on fullscreen if we were requested to show output.
             on: layout.isFullscreen() && !showOutput,
-            // Only set a background if it's the stage that's in fullscreen
-            background: layout.isStageFullscreen() ? outputBackground : null,
+            // Resolved here rather than in Page, which every route renders.
+            background:
+                background instanceof Color ? background.toCSS() : background,
+            foreground:
+                background instanceof Color
+                    ? background.contrasting().toCSS()
+                    : null,
         });
     });
 

--- a/src/components/widgets/CommandButton.svelte
+++ b/src/components/widgets/CommandButton.svelte
@@ -5,9 +5,9 @@
     import { tokenize } from '@parser/Tokenizer';
     import {
         resetVisualColumnAfter,
-        toShortcut,
         type Command,
     } from '@components/editor/commands/Commands';
+    import { toShortcut } from '@components/editor/commands/shortcuts';
     import { resolveFeedback } from '@components/editor/commands/feedback';
     import TokenView from '@components/editor/tokens/TokenView.svelte';
     import {

--- a/src/components/widgets/FormattedEditor.svelte
+++ b/src/components/widgets/FormattedEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Emoji from '@components/app/Emoji.svelte';
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
-    import { toShortcut } from '@components/editor/commands/Commands';
+    import { toShortcut } from '@components/editor/commands/shortcuts';
     import Button from '@components/widgets/Button.svelte';
     import Switch from '@components/widgets/Switch.svelte';
     import TextBox from '@components/widgets/TextBox.svelte';

--- a/src/components/widgets/Toggle.svelte
+++ b/src/components/widgets/Toggle.svelte
@@ -6,10 +6,9 @@
     import type { TemplateInputs } from '@locale/Locales';
     import { untrack, type Snippet } from 'svelte';
     import type { ToggleText } from '@locale/UITexts';
-    import {
-        toShortcut,
-        type Command,
-    } from '@components/editor/commands/Commands';
+    // Type-only, so this widget carries no runtime edge to the command table.
+    import type { Command } from '@components/editor/commands/Commands';
+    import { toShortcut } from '@components/editor/commands/shortcuts';
 
     interface Props {
         tips: (locale: LocaleText) => ToggleText;

--- a/src/conflicts/registerTypeResolutions.ts
+++ b/src/conflicts/registerTypeResolutions.ts
@@ -3,7 +3,10 @@
  * `Conflict`. This file is loaded as a top-level side effect:
  *
  * - Tests: imported by `vitest.config.ts` via `setupFiles`.
- * - App: side-effect-imported by `src/routes/+layout.svelte`.
+ * - App: side-effect-imported by `src/components/annotations/Annotations.svelte`,
+ *   the only caller of `Conflict.getResolutions`. It lives there rather than in
+ *   the root layout so the node classes it pulls load with the editor rather
+ *   than with every page.
  *
  * Loading order matters: this file imports a slew of node classes that
  * themselves import the conflict classes. Routing resolution through the

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -504,6 +504,32 @@ export class Database {
         if (recovered) this.flushUnsavedWork();
     }
 
+    /**
+     * Bring the project subsystem online: read the local cache and, if signed
+     * in, start syncing. Kept off the import path and out of the constructor
+     * because hydration deserializes every cached project, and each one builds
+     * a `Basis` — seconds of main-thread work on a phone, spent before first
+     * paint on pages that show no projects at all. Idempotent.
+     *
+     * Waiting is safe for unsaved work: edits are recorded in a durable dirty
+     * table, so anything pending replays once this runs.
+     */
+    async startProjectWork(): Promise<void> {
+        await this.Projects.start();
+        if (this.user !== null) this.Projects.saveSoon();
+    }
+
+    /** Whether this device has project work worth starting: a signed-in
+     *  creator, or projects cached locally from a previous visit. */
+    async shouldStartProjectWork(): Promise<boolean> {
+        if (this.user !== null) return true;
+        try {
+            return (await this.localDB.projects.count()) > 0;
+        } catch {
+            return false;
+        }
+    }
+
     /** Re-push every domain's unsaved edits to the cloud. Each call is a no-op
      *  when that domain has nothing unsaved, so it's safe to fire on any
      *  reconnect signal (browser `online` or Firebase reachability recovery). */

--- a/src/db/characters/Character.ts
+++ b/src/db/characters/Character.ts
@@ -9,7 +9,9 @@
  *
  * All units are interpreted in pixels, on a 128x128 square canvas.
  */
-import { LCHtoRGB } from '@output/Color/Color';
+// From the standalone module, not Color: Character is reachable from the
+// database, and Color pulls the whole basis.
+import { LCHtoRGB } from '@output/Color/lch';
 import z from 'zod';
 
 const PointSchema = z.object({ x: z.number(), y: z.number() });

--- a/src/db/galleries/GalleryDatabase.svelte.ts
+++ b/src/db/galleries/GalleryDatabase.svelte.ts
@@ -30,7 +30,7 @@ import isQuotaError from '@db/isQuotaError';
 import SaveTracker from '@db/SaveTracker.svelte';
 import supportsIndexedDB from '@db/supportsIndexedDB';
 import type Project from '@db/projects/Project';
-import { ProjectsCollection } from '@db/projects/ProjectsDatabase.svelte';
+
 import {
     ClassesCollection,
     ClassSchema,
@@ -686,7 +686,7 @@ export default class GalleryDatabase {
         // so concurrent shares to the same gallery accumulate rather than clobber.
         const batch = writeBatch(firestore);
         batch.set(
-            doc(firestore, ProjectsCollection, projectID),
+            doc(firestore, Domain.Projects, projectID),
             updated.asPersisted().serialize(),
         );
         batch.update(doc(firestore, GalleriesCollection, galleryID), {
@@ -751,7 +751,7 @@ export default class GalleryDatabase {
         // Atomic batch: clear project.gallery and remove from the gallery's projects array.
         const batch = writeBatch(firestore);
         batch.set(
-            doc(firestore, ProjectsCollection, projectID),
+            doc(firestore, Domain.Projects, projectID),
             updated.asPersisted().serialize(),
         );
         if (targetGalleryID !== null) {
@@ -876,7 +876,7 @@ export default class GalleryDatabase {
 
         const batch = writeBatch(firestore);
         for (const projectID of projectsToRemove) {
-            batch.update(doc(firestore, ProjectsCollection, projectID), {
+            batch.update(doc(firestore, Domain.Projects, projectID), {
                 gallery: null,
             });
         }

--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -5,7 +5,7 @@ import { Domain } from '@db/Domains';
 import exceedsDocLimit from '@db/exceedsDocLimit';
 import { firestore } from '@db/firebase';
 import type Gallery from '@db/galleries/Gallery';
-import { GalleriesCollection } from '@db/galleries/GalleryDatabase.svelte';
+
 import isQuotaError from '@db/isQuotaError';
 import { PreviewContentSchema } from '@db/projects/ProjectSchemas';
 import SaveTracker from '@db/SaveTracker.svelte';
@@ -522,10 +522,9 @@ export class HowToDatabase {
             // (a no-op when it's already linked, as on a plain edit replay).
             const batch = writeBatch(db);
             batch.set(doc(db, HowTosCollection, id), howTo.getData());
-            batch.update(
-                doc(db, GalleriesCollection, howTo.getHowToGalleryId()),
-                { howTos: arrayUnion(id) },
-            );
+            batch.update(doc(db, Domain.Galleries, howTo.getHowToGalleryId()), {
+                howTos: arrayUnion(id),
+            });
             return { name: howTo.getTitle(), write: batch.commit() };
         });
     }
@@ -672,7 +671,7 @@ export class HowToDatabase {
                 const batch = writeBatch(firestore);
                 batch.delete(doc(firestore, HowTosCollection, howToId));
                 batch.update(
-                    doc(firestore, GalleriesCollection, gallery.getID()),
+                    doc(firestore, Domain.Galleries, gallery.getID()),
                     { howTos: arrayRemove(howToId) },
                 );
                 await this.db.write(batch.commit());
@@ -778,7 +777,7 @@ export class HowToDatabase {
             // overwriting each other.
             const batch = writeBatch(firestore);
             batch.set(doc(firestore, HowTosCollection, newHowTo.id), newHowTo);
-            batch.update(doc(firestore, GalleriesCollection, gallery.getID()), {
+            batch.update(doc(firestore, Domain.Galleries, gallery.getID()), {
                 howTos: arrayUnion(newHowTo.id),
             });
 

--- a/src/db/locales/LocalesDatabase.ts
+++ b/src/db/locales/LocalesDatabase.ts
@@ -1,4 +1,3 @@
-import { Basis } from '@basis/Basis';
 import Fonts from '@basis/faces/Fonts';
 import type HowTo from '@concepts/HowTo';
 import {
@@ -345,10 +344,6 @@ export default class LocalesDatabase {
 
         // Update the locales stores
         return selected.length === 0 ? [this.defaultLocale] : selected;
-    }
-
-    getLocaleBasis(): Basis {
-        return Basis.getLocalizedBasis(this.getLocaleSet());
     }
 
     getLanguages(): LanguageCode[] {

--- a/src/db/projects/PresenceTracker.svelte.ts
+++ b/src/db/projects/PresenceTracker.svelte.ts
@@ -1,3 +1,4 @@
+import { Domain } from '@db/Domains';
 import {
     collection,
     deleteDoc,
@@ -9,7 +10,7 @@ import {
 } from 'firebase/firestore';
 import { SvelteMap } from 'svelte/reactivity';
 import { MAX_CONCURRENT_EDITORS } from '@db/projects/Project';
-import { ProjectsCollection } from '@db/projects/ProjectsDatabase.svelte';
+
 import {
     isPresenceStale,
     pickColorForClient,
@@ -107,12 +108,7 @@ export class PresenceTracker {
     private attach(): void {
         // Subscribe to all peers in this project's presence subcollection.
         this.subUnsub = onSnapshot(
-            collection(
-                this.db,
-                ProjectsCollection,
-                this.projectID,
-                'presence',
-            ),
+            collection(this.db, Domain.Projects, this.projectID, 'presence'),
             (snapshot) => {
                 for (const change of snapshot.docChanges()) {
                     const id = change.doc.id;
@@ -120,7 +116,10 @@ export class PresenceTracker {
                     if (change.type === 'removed') {
                         this.peers.delete(id);
                     } else {
-                        this.peers.set(id, change.doc.data() as PresencePayload);
+                        this.peers.set(
+                            id,
+                            change.doc.data() as PresencePayload,
+                        );
                     }
                 }
                 // Snapshot changes can open or close a slot for us.
@@ -204,7 +203,7 @@ export class PresenceTracker {
             await setDoc(
                 doc(
                     this.db,
-                    ProjectsCollection,
+                    Domain.Projects,
                     this.projectID,
                     'presence',
                     this.clientID,
@@ -261,7 +260,7 @@ export class PresenceTracker {
                 await deleteDoc(
                     doc(
                         this.db,
-                        ProjectsCollection,
+                        Domain.Projects,
                         this.projectID,
                         'presence',
                         this.clientID,

--- a/src/db/projects/ProjectsDatabase.svelte.ts
+++ b/src/db/projects/ProjectsDatabase.svelte.ts
@@ -341,12 +341,23 @@ export default class ProjectsDatabase {
      *  during the brief window between mount and first emission. */
     hydrated: boolean = $state(false);
 
+    /** The in-flight or finished hydration, so start() is idempotent. */
+    private starting: Promise<void> | undefined = undefined;
+
     constructor(database: Database) {
         this.database = database;
         this.localDB = database.localDB;
+    }
 
-        // Hydrate the editable projects from disk
-        this.hydrate();
+    /**
+     * Read the local projects and begin tracking them. Called by
+     * `Database.startProjectWork()` rather than from the constructor: every
+     * cached project is deserialized into a `Project`, and each of those builds
+     * a `Basis`, so doing it on import made every page — including ones with no
+     * projects on them — pay for it before first paint.
+     */
+    start(): Promise<void> {
+        return (this.starting ??= this.hydrate());
     }
 
     async hydrate() {

--- a/src/db/projects/YjsFirestoreProvider.ts
+++ b/src/db/projects/YjsFirestoreProvider.ts
@@ -1,3 +1,4 @@
+import { Domain } from '@db/Domains';
 import { FirebaseError } from 'firebase/app';
 import {
     addDoc,
@@ -11,7 +12,6 @@ import ProjectCRDT, {
     base64ToBytes,
     bytesToBase64,
 } from '@db/projects/ProjectCRDT';
-import { ProjectsCollection } from '@db/projects/ProjectsDatabase.svelte';
 
 /** Debounce window (ms) for batching consecutive keystrokes into a single
  *  Firestore write. Wide enough to fold a burst of typing into one update
@@ -150,7 +150,7 @@ export default class YjsFirestoreProvider {
 
         // Remote → local: subscribe to the updates subcollection.
         this.unsubscribe = onSnapshot(
-            collection(this.db, ProjectsCollection, this.projectID, 'updates'),
+            collection(this.db, Domain.Projects, this.projectID, 'updates'),
             (snapshot) => {
                 for (const change of snapshot.docChanges()) {
                     if (change.type !== 'added') continue;
@@ -240,7 +240,7 @@ export default class YjsFirestoreProvider {
         };
         const updatesCollection = collection(
             this.db,
-            ProjectsCollection,
+            Domain.Projects,
             this.projectID,
             'updates',
         );
@@ -273,12 +273,10 @@ export default class YjsFirestoreProvider {
                         this.ownDocIDs.add(retryRef.id);
                         return;
                     } catch (retryErr) {
-                        if (
-                            !(
-                                retryErr instanceof FirebaseError &&
-                                retryErr.code === 'permission-denied'
-                            )
-                        ) {
+                        if (!(
+                            retryErr instanceof FirebaseError &&
+                            retryErr.code === 'permission-denied'
+                        )) {
                             // Refresh or retry failed transiently —
                             // re-queue and let the next flush try
                             // again. We've already burned our retry

--- a/src/db/teachers/TeacherDatabase.svelte.ts
+++ b/src/db/teachers/TeacherDatabase.svelte.ts
@@ -1,10 +1,11 @@
+import { Domain } from '@db/Domains';
 // Provide schemas and database access for all teaching functionality.
 // By design, we get all data on demand here, rather than caching, using a
 // more transactional model.
 
 import { DB, Galleries } from '@db/Database';
 import { firestore as db } from '@db/firebase';
-import { GalleriesCollection } from '@db/galleries/GalleryDatabase.svelte';
+
 import {
     arrayRemove,
     arrayUnion,
@@ -142,7 +143,7 @@ export async function addTeacher(classy: Class, uid: string): Promise<boolean> {
         teachers: arrayUnion(uid),
     });
     for (const galleryID of classy.galleries) {
-        batch.update(doc(db, GalleriesCollection, galleryID), {
+        batch.update(doc(db, Domain.Galleries, galleryID), {
             curators: arrayUnion(uid),
         });
     }
@@ -202,7 +203,7 @@ export async function addStudent(
         info: arrayUnion(learner),
     });
     for (const galleryID of classy.galleries) {
-        batch.update(doc(db, GalleriesCollection, galleryID), {
+        batch.update(doc(db, Domain.Galleries, galleryID), {
             creators: arrayUnion(uid),
         });
     }

--- a/src/output/Color/Color.ts
+++ b/src/output/Color/Color.ts
@@ -1,3 +1,4 @@
+import { LCHtoRGB } from '@output/Color/lch';
 import { getBind } from '@locale/getBind';
 import { SHARE_SYMBOL, TYPE_SYMBOL } from '@parser/Symbols';
 import type Value from '@values/Value';
@@ -343,14 +344,6 @@ export function toColor(value: Value | undefined) {
     const h = toDecimal(hVal);
 
     return l && c && h ? new Color(value, l, c, h) : undefined;
-}
-
-/** l: 0-1, c: 0-infinity, h=0-360 */
-export function LCHtoRGB(l: number, c: number, h: number) {
-    return `lch(${l * 100}% ${c} ${h}deg)`;
-    // The previous way we converted to rgb prior to LCH support.
-    // const color = new ColorJS(ColorJS.spaces.lch, [l * 100, c, h], 1);
-    // return color.to('srgb').toString();
 }
 
 /**

--- a/src/output/Color/lch.ts
+++ b/src/output/Color/lch.ts
@@ -1,0 +1,4 @@
+/** l: 0-1, c: 0-infinity, h=0-360 */
+export function LCHtoRGB(l: number, c: number, h: number) {
+    return `lch(${l * 100}% ${c} ${h}deg)`;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,6 @@
     // registry. Loaded once at app startup so the registry is populated by
     // the time any annotation asks for resolutions. See the file's header
     // for why it can't be imported by the conflict files directly.
-    import '@conflicts/registerTypeResolutions';
 
     // Notifications state lives in @db so the databases that write it don't
     // import from this route component (that cycle crashes WebKit hydration).
@@ -139,6 +138,22 @@
         // catches and what it can't.
         const cleanupSaveOnUnload = DB.Projects.installSaveOnUnloadListeners();
 
+        // Read the local project cache once the page is up rather than on
+        // import: hydration deserializes every cached project and each one
+        // builds a Basis, which is seconds of main-thread work on a phone and
+        // used to happen before first paint on every page. Only devices with
+        // project work to do pay for it at all — a first-time visitor reading
+        // the landing page never does. Pending edits aren't at risk while we
+        // wait; they live in a durable dirty table and replay when this runs.
+        const startProjects = () =>
+            void DB.shouldStartProjectWork().then((should) => {
+                if (should) void DB.startProjectWork();
+            });
+        const idleSupported = typeof window.requestIdleCallback === 'function';
+        const idle = idleSupported
+            ? window.requestIdleCallback(startProjects)
+            : window.setTimeout(startProjects, 200);
+
         // Warn before closing/reloading the tab when there are edits not yet
         // saved online (e.g. made offline). The save-on-unload handlers above
         // flush to the LOCAL cache, but local-only edits would still be lost on
@@ -157,6 +172,8 @@
 
         // Have the Database cleanup database connections when this is unmounted.
         return () => {
+            if (idleSupported) window.cancelIdleCallback(idle);
+            else window.clearTimeout(idle);
             cleanupNetworkListeners();
             cleanupSaveOnUnload();
             window.removeEventListener('beforeunload', warnUnsaved);

--- a/src/routes/[[locale]]/Iconified.svelte
+++ b/src/routes/[[locale]]/Iconified.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import Emoji from '@components/app/Emoji.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import type LocaleText from '@locale/LocaleText';
     import { withMonoEmoji } from '@unicode/emoji';
@@ -11,5 +12,9 @@
     let { icon, text }: Props = $props();
 </script>
 
-{withMonoEmoji(icon)}
+<!-- The icon goes through Emoji so it gets the mono font family. Rendered as a
+     bare text node it inherited --wordplay-app-font, which leads with 'Noto
+     Color Emoji' — and the FE0E selector doesn't stop unicode-range matching,
+     so a monochrome icon still downloaded a color emoji slice. -->
+<Emoji text={withMonoEmoji(icon)} />
 <LocalizedText path={text} />

--- a/src/routes/[[locale]]/project/[projectid]/+page.svelte
+++ b/src/routes/[[locale]]/project/[projectid]/+page.svelte
@@ -11,9 +11,9 @@
         setProject,
     } from '@components/project/Contexts';
     import ProjectView from '@components/project/ProjectView.svelte';
-    import { Galleries, Projects } from '@db/Database';
+    import { DB, Galleries, Projects } from '@db/Database';
     import type Project from '@db/projects/Project';
-    import { untrack } from 'svelte';
+    import { untrack, onMount } from 'svelte';
     import { writable } from 'svelte/store';
     import Writing from '@components/app/Writing.svelte';
 
@@ -113,6 +113,10 @@
         if (project === undefined) return false;
         else return isAuthenticated($user) && project.hasCommenter($user.uid);
     });
+
+    // This page reads projects straight away, so ask for them rather than
+    // waiting for the layout's idle warm-up.
+    onMount(() => void DB.startProjectWork());
 </script>
 
 <svelte:head>

--- a/src/routes/[[locale]]/projects/+page.svelte
+++ b/src/routes/[[locale]]/projects/+page.svelte
@@ -12,7 +12,8 @@
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import TextField from '@components/widgets/TextField.svelte';
     import Title from '@components/widgets/Title.svelte';
-    import { authAttempted, locales, Projects } from '@db/Database';
+    import { authAttempted, DB, locales, Projects } from '@db/Database';
+    import { onMount } from 'svelte';
     import type Project from '@db/projects/Project';
     import { searchProjects, type ProjectMatch } from './search';
     import { CANCEL_SYMBOL, EDIT_SYMBOL, REMIX_SYMBOL } from '@parser/Symbols';
@@ -102,6 +103,10 @@
                 .map((m) => [m.project.getID(), m.matchText!]),
         ),
     );
+
+    // This page reads projects straight away, so ask for them rather than
+    // waiting for the layout's idle warm-up.
+    onMount(() => void DB.startProjectWork());
 </script>
 
 <svelte:head>

--- a/src/util/importGraph.test.ts
+++ b/src/util/importGraph.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from 'vitest';
+import { reachFrom, staticImportsOf } from './importGraph';
+
+/**
+ * Guards what a page has to download.
+ *
+ * The language runtime — basis, evaluator, nodes, output — is ~2MB of
+ * JavaScript that only the editor, guide, and tutorial need. It reaches every
+ * other page through shared chrome, and one stray value import puts it back.
+ * These tests pin the current reach so that work to shrink it shows up as a
+ * tightened budget, and so an accidental re-entry fails here with the import
+ * chain that caused it rather than as a mystery in a bundle report.
+ *
+ * When a budget below drops, tighten it in the same change.
+ */
+
+const Root = process.cwd();
+
+/** Modules that carry the language runtime with them. */
+const Runtime = {
+    basis: 'src/basis/Basis.ts',
+    evaluator: 'src/runtime/Evaluator.ts',
+    stage: 'src/output/Output/Stage.ts',
+    templates: 'src/concepts/Templates.ts',
+    project: 'src/db/projects/Project.ts',
+    commands: 'src/components/editor/commands/Commands.ts',
+};
+
+test('type-only imports are not edges, but value imports are', () => {
+    expect(staticImportsOf("import type X from 'a';")).toEqual([]);
+    expect(staticImportsOf("import { type X, type Y } from 'a';")).toEqual([]);
+    expect(staticImportsOf("import X from 'a';")).toEqual(['a']);
+    expect(staticImportsOf("import { type X, y } from 'a';")).toEqual(['a']);
+    expect(staticImportsOf("import X, { type Y } from 'a';")).toEqual(['a']);
+    expect(staticImportsOf("import 'a';")).toEqual(['a']);
+    expect(staticImportsOf("export { x } from 'a';")).toEqual(['a']);
+    // Deferred by design: a dynamic import is its own chunk.
+    expect(staticImportsOf("const m = await import('a');")).toEqual([]);
+    expect(staticImportsOf("// import X from 'a';")).toEqual([]);
+});
+
+test('the shortcut helpers stay free of the command table', () => {
+    // Toggle and CommandButton render shortcuts on pages that have no editor;
+    // importing Commands for them reaches Caret and Project.
+    const reach = reachFrom(
+        'src/components/editor/commands/shortcuts.ts',
+        Root,
+    );
+    expect(Array.from(reach.files)).toEqual([
+        'src/components/editor/commands/shortcuts.ts',
+    ]);
+});
+
+test('resolving a color needs no basis', () => {
+    // Character (reachable from the database) and Page both format LCH colors;
+    // going through Color for it pulls the whole basis.
+    const reach = reachFrom('src/output/Color/lch.ts', Root);
+    expect(reach.files.has(Runtime.basis)).toBe(false);
+});
+
+/**
+ * Current reach, in files and source bytes. These are budgets, not targets:
+ * they may only go down. The `true` expectations record which runtime modules
+ * are still reachable today — as each door closes, flip it to `false`.
+ */
+test.each([
+    ['src/routes/+layout.svelte', 620, 4.6],
+    ['src/components/app/Page.svelte', 640, 4.8],
+    ['src/routes/[[locale]]/+page.svelte', 655, 4.8],
+])('%s stays within its import budget', (entry, maxFiles, maxMB) => {
+    const reach = reachFrom(entry, Root);
+    expect(
+        reach.files.size,
+        `${entry} reaches ${reach.files.size} files`,
+    ).toBeLessThanOrEqual(maxFiles);
+    expect(
+        reach.bytes / 1024 / 1024,
+        `${entry} carries ${(reach.bytes / 1024 / 1024).toFixed(2)}MB`,
+    ).toBeLessThanOrEqual(maxMB);
+});
+
+test('the doors the runtime still comes through are the known ones', () => {
+    const reach = reachFrom('src/routes/+layout.svelte', Root);
+    /** The chain to a module, named by file, for a readable failure. */
+    const via = (target: string) =>
+        reach
+            .chainTo(target)
+            ?.map((f) => f.split('/').pop())
+            .join(' -> ');
+    // Markup no longer drags the editor and evaluator along: the segments that
+    // render code load on demand (see richSegment.ts). Keep it that way.
+    expect(
+        reach.files.has(Runtime.evaluator),
+        `evaluator via ${via(Runtime.evaluator)}`,
+    ).toBe(false);
+    expect(
+        reach.files.has(Runtime.commands),
+        `commands via ${via(Runtime.commands)}`,
+    ).toBe(false);
+    // One door left: the database still builds projects eagerly, so it carries
+    // the basis with it. That's the next stage; flip these when it lands.
+    expect(
+        reach.files.has(Runtime.project),
+        `project via ${via(Runtime.project)}`,
+    ).toBe(true);
+});

--- a/src/util/importGraph.ts
+++ b/src/util/importGraph.ts
@@ -1,0 +1,190 @@
+/**
+ * A static import-graph walker, used by importGraph.test.ts to keep the
+ * language runtime out of pages that don't need it.
+ *
+ * The app's route graph is the thing that decides what every page downloads:
+ * one stray value import of `Color` or `Commands` in shared chrome pulls the
+ * basis, the evaluator, and the output layer into every route's bundle. This
+ * resolves imports the way the bundler does — aliases from svelte.config.js,
+ * `import type` erased — so a test can assert what a route can reach and print
+ * the chain when the answer is wrong.
+ */
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+
+/** Alias prefixes mirroring svelte.config.js. */
+const Aliases: [string, string][] = [
+    ['@components', 'src/components'],
+    ['@nodes', 'src/nodes'],
+    ['@runtime', 'src/runtime'],
+    ['@values', 'src/values'],
+    ['@conflicts', 'src/conflicts'],
+    ['@locale', 'src/locale'],
+    ['@parser', 'src/parser'],
+    ['@input', 'src/input'],
+    ['@output', 'src/output'],
+    ['@basis', 'src/basis'],
+    ['@edit', 'src/edit'],
+    ['@db', 'src/db'],
+    ['@unicode', 'src/unicode'],
+    ['@concepts', 'src/concepts'],
+    ['@util', 'src/util'],
+];
+
+/** Extensions tried when a specifier has none, in resolution order. */
+const Extensions = ['', '.ts', '.svelte', '.svelte.ts', '/index.ts'];
+
+/**
+ * Every `import`/`export … from` specifier in a source file, with `import type`
+ * and `export type` dropped — those are erased at build time and cost nothing.
+ * Dynamic `import()` is also dropped: it produces a separate chunk, which is
+ * exactly the deferral this guard is protecting.
+ */
+export function staticImportsOf(source: string): string[] {
+    // Strip line and block comments so commented-out imports don't count.
+    const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/.*$/gm, '$1');
+    const specifiers: string[] = [];
+    const pattern =
+        /(?:^|[\s;}])(import|export)\s+([\s\S]*?)?from\s*['"]([^'"]+)['"]|(?:^|[\s;}])import\s*['"]([^'"]+)['"]/g;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(code)) !== null) {
+        const clause = match[2] ?? '';
+        const specifier = match[3] ?? match[4];
+        if (specifier === undefined) continue;
+        // `import type X` / `import { type X }`-only clauses are erased. A
+        // clause mixing type and value imports still carries a value edge.
+        if (/^\s*type\s/.test(clause)) continue;
+        if (clause.includes('{')) {
+            const named = clause.slice(
+                clause.indexOf('{') + 1,
+                clause.lastIndexOf('}'),
+            );
+            const before = clause.slice(0, clause.indexOf('{')).trim();
+            const items = named
+                .split(',')
+                .map((i) => i.trim())
+                .filter((i) => i.length > 0);
+            const allTypes =
+                items.length > 0 && items.every((i) => /^type\s/.test(i));
+            // A default import beside the braces is still a value edge.
+            if (allTypes && before.replace(/,$/, '').trim() === '') continue;
+        }
+        specifiers.push(specifier);
+    }
+    return specifiers;
+}
+
+/** Resolve a specifier to a repo-relative path, or undefined if it's external
+ * (a node_module, a Svelte/SvelteKit builtin, or a non-code asset). */
+export function resolveSpecifier(
+    fromFile: string,
+    specifier: string,
+    root: string,
+): string | undefined {
+    let base: string | undefined;
+    if (specifier.startsWith('.'))
+        base = resolve(root, dirname(fromFile), specifier);
+    else {
+        const alias = Aliases.find(
+            ([prefix]) =>
+                specifier === prefix || specifier.startsWith(prefix + '/'),
+        );
+        if (alias === undefined) return undefined;
+        base = resolve(root, alias[1] + specifier.slice(alias[0].length));
+    }
+    for (const extension of Extensions) {
+        const candidate = base + extension;
+        if (existsSync(candidate) && statSync(candidate).isFile())
+            return relative(root, candidate);
+    }
+    return undefined;
+}
+
+export type Reach = {
+    /** Every repo-relative file statically reachable from the entry. */
+    files: Set<string>;
+    /** Total source bytes, a proxy for what the route's chunks must carry. */
+    bytes: number;
+    /** The shortest import chain from the entry to a file, for diagnostics. */
+    chainTo: (target: string) => string[] | undefined;
+};
+
+/** Parsed imports and size per file, shared across walks: the entries overlap
+ * almost entirely, and re-reading ~900 files per entry is enough I/O to slow
+ * the whole test run. */
+const parsed = new Map<
+    string,
+    { imports: string[]; bytes: number } | undefined
+>();
+
+function parseFile(file: string, root: string) {
+    const cached = parsed.get(file);
+    if (cached !== undefined || parsed.has(file)) return cached;
+    let entry: { imports: string[]; bytes: number } | undefined;
+    try {
+        const source = readFileSync(resolve(root, file), 'utf8');
+        entry = { imports: staticImportsOf(source), bytes: source.length };
+    } catch {
+        entry = undefined;
+    }
+    parsed.set(file, entry);
+    return entry;
+}
+
+export type ReachOptions = {
+    /**
+     * Edges to pretend aren't there. The doors the runtime comes through are
+     * being closed one at a time, and each one hides the others: while the
+     * database still reaches Project, every component that reads a store from
+     * it measures as heavy. Cutting an edge here answers "what would this
+     * reach once that stage lands", which is what makes the stages plannable
+     * separately.
+     */
+    skip?: (from: string, to: string) => boolean;
+};
+
+/** Walk every static import edge reachable from `entry`. */
+export function reachFrom(
+    entry: string,
+    root: string,
+    options: ReachOptions = {},
+): Reach {
+    const files = new Set<string>([entry]);
+    const parent = new Map<string, string>();
+    const queue = [entry];
+    let bytes = 0;
+    while (queue.length > 0) {
+        const file = queue.shift();
+        if (file === undefined) continue;
+        const contents = parseFile(file, root);
+        if (contents === undefined) continue;
+        bytes += contents.bytes;
+        for (const specifier of contents.imports) {
+            const next = resolveSpecifier(file, specifier, root);
+            if (next === undefined || files.has(next)) continue;
+            if (options.skip?.(file, next) === true) continue;
+            files.add(next);
+            parent.set(next, file);
+            queue.push(next);
+        }
+    }
+    return {
+        files,
+        bytes,
+        chainTo(target: string) {
+            if (!files.has(target)) return undefined;
+            const chain = [target];
+            let at = target;
+            while (at !== entry) {
+                const from = parent.get(at);
+                if (from === undefined) break;
+                chain.unshift(from);
+                at = from;
+            }
+            return chain;
+        },
+    };
+}

--- a/tests/end2end/localize-badges.spec.ts
+++ b/tests/end2end/localize-badges.spec.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import type LocaleText from '../../src/locale/LocaleText';
-import { expect, test, type Locator, type Page } from '../../playwright/fixtures';
+import {
+    expect,
+    test,
+    type Locator,
+    type Page,
+} from '../../playwright/fixtures';
 
 /**
  * Localization mode's 💭 tip badges are pinned to their control's corner rather
@@ -36,6 +41,17 @@ async function localizeOn(page: Page) {
         })
         .click();
     await expect(page.getByText('Localize', { exact: true })).toBeVisible();
+    await settled(page);
+}
+
+/**
+ * Wait for markup that embeds code to finish arriving. Examples, node
+ * references, and values load the language runtime on demand and show a
+ * stand-in until it lands (see SegmentHTMLView), so a box measured before then
+ * is a layout that is still one chunk away from final.
+ */
+async function settled(page: Page) {
+    await expect(page.locator('.rich-loading')).toHaveCount(0);
 }
 
 async function size(locator: Locator) {
@@ -50,6 +66,7 @@ test('turning on localization mode does not resize the controls it annotates', a
     page,
 }) => {
     await page.goto('/en-US/projects');
+    await settled(page);
 
     const gear = page.getByRole('button', { name: 'show settings dialog' });
     const toggle = page


### PR DESCRIPTION
# Context

Safari was slow to browse on iPhone and macOS: pages rendered half-blank and filled in seconds later, links lagged, and the background animated choppily. Profiling the production build in WebKit and Chromium found the cause was **payload and eager main-thread work, not font decode**. The landing page shipped 5.8MB decoded (7.7MB in Safari) — 3.4MB of JS dominated by a single 2.18MB chunk holding `Basis`, `Evaluator`, `Stage`, and `Project`, imported by every route. A page showing a language chooser paid for the entire programming language.

**Three plausible fixes were measured and refuted rather than shipped**, which is most of why this took the shape it did:

- **OT-SVG emoji decode.** A first A/B showed 1880ms vs 271ms — but that was WebKit's *first-launch warmup*. Controlled (warmup discarded, order alternated) it's 233ms vs 235ms. Blocking the emoji font entirely changes load by ~2ms.
- **woff2-compressing those slices** saves **2%**; the `SVG ` table is already gzip-compressed internally.
- **Serving Safari the COLRv1 font.** WebKit renders COLRv1 in color but reports `font-tech(color-COLRv1)` as `false`, so the natural feature query would have silently changed nothing.

## What this does

| | before | after |
| --- | --- | --- |
| Root layout import reach | 903 files / 6.38MB | **609 files / 4.45MB** |
| Largest shared chunk | 2184KB | **1688KB** |
| Landing-page JS | 3405KB | **2962KB** |
| Load @ 6× CPU throttle | 1098ms | **786ms** |
| Click→galleries @ 6× CPU | 1804ms | **1481ms** |

- **Background** positions with one `transform` instead of `left`/`top`, so 20 glyphs at 128–256pt no longer reflow the document every frame. 2D `translate()` deliberately, not `translate3d`/`will-change` — 20 promoted layers would cost GPU memory on a phone.
- **Markup that renders code** (examples, node references, values) moved into `RichSegmentHTMLView` behind a memoized dynamic import. Every page shows localized markup; only some show code. This alone takes `Evaluator` and `Commands` off the layout, footer, and landing page.
- **Project hydration** moved out of the `ProjectsDatabase` constructor into `DB.startProjectWork()`, run at idle and gated on actually having project work. It used to deserialize every cached project — each building a `Basis` — before first paint, on every page. Pending edits stay safe: they live in the durable dirty table and replay when hydration runs.
- **Smaller edges:** the footer no longer imports `Color` (`FullscreenContext` carries resolved CSS strings), conflict resolvers load with the editor rather than every route, shortcut labels no longer drag in the command table, `Character` formats colors without the basis, and a dead `getLocaleBasis()` is gone.

`src/util/importGraph.ts` and its test keep it that way: they walk the real import graph (aliases resolved, `import type` erased, dynamic imports treated as deferred), hold each entry to a file/byte budget, and **print the offending chain** when a forbidden module returns. It paid for itself repeatedly during this work — it caught an extra `GalleryDatabase → ProjectsDatabase` edge I'd written off as optional, proved `FormattedEditor` needed no change, and flagged its own stale assertion the moment a door closed.

## Related issues

Found by device testing; no tracking issue.

-   Related Issue #
-   Closes #

## Verification

`npm run check:now` clean; **`npm test` green (5107)**; e2e green on the paths this could break — `offline-replay`, `cloud-updates`, `collaborative-editing`, `unauthenticated-project`, `seeded-load`, `chat`, `gallery-sharing` (18 tests), plus the markup-sensitive `aria-snapshots`, `accessibility`, `localize-*`, `page-headers` batch.

**One deliberate behavior change:** markup containing code now renders empty-then-filled while its chunk loads. The app's `Spinning` indicator stands in, wrapped `aria-hidden` — a documentation page can hold dozens of these and `Spinning` is a live region, so exposing them would announce "loading" dozens of times; screen readers get the code when it arrives. `localize-badges` gained a `settled()` helper because it measured bounding boxes mid-load; on a clean tree that batch passes 49/49, and the change made that measurement racy rather than broken.

**Accessibility.** Axe suites pass in both schemes. The stand-in is `aria-hidden` and takes the text baseline, so prose doesn't jump. No new announcements. Screen-reader verification with VoiceOver is **not yet done**.

**Browsers.** Chromium and WebKit via Playwright, plus a manual desktop pass on Chrome and Safari (macOS), which is noticeably snappier. **Mobile Safari testing is still outstanding** — the symptoms that prompted this aren't reproducible headlessly.

## Checklist

-   [ ] Mobile Safari pass on iPhone (the original report)
-   [ ] VoiceOver pass over markup containing examples
-   [ ] Follow-up: the remaining ~1.7MB (`Database → ProjectsDatabase → Project → Basis`). The `Projects` singleton has 41 consumers and ~8 sit on light routes (`Notifications` in the footer, preview tiles, the list routes), so it needs the notifications and preview-tile rework alongside it — one change, not three.
-   [ ] Follow-up: emoji UI subset font (~2839KB → ~253KB in Safari). Download-only saving; won't change how anything feels on wifi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
