### PR TITLE
Load the language runtime only where code actually runs

### DIFF
--- a/src/components/annotations/Annotation.svelte
+++ b/src/components/annotations/Annotation.svelte
@@ -13,7 +13,8 @@
     import { CONFIRM_SYMBOL } from '@parser/Symbols';
     import { fade } from 'svelte/transition';
     import { get } from 'svelte/store';
-    import { Projects, animationDuration, locales } from '@db/Database';
+    import { animationDuration, locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { default as MarkupHTMLView } from '@components/concepts/MarkupHTMLView.svelte';
     import Speech from '@components/lore/Speech.svelte';
     import getFocusNode from '@components/annotations/getFocusNode';

--- a/src/components/app/AddProject.svelte
+++ b/src/components/app/AddProject.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
     import Button from '@components/widgets/Button.svelte';
     import { locales } from '@db/Database';
-    import Project from '@db/projects/Project';
-    import Source from '@nodes/Source';
+    import type Project from '@db/projects/Project';
 
     interface Props {
         add: (newProject: Project) => void;
@@ -19,6 +18,13 @@
 
     async function newProject() {
         creating = true;
+        // Making a project needs the language runtime; imported on the click
+        // rather than statically, so merely showing this button on the
+        // projects list doesn't pull it in. The button spins while it loads.
+        const [{ default: Project }, { default: Source }] = await Promise.all([
+            import('@db/projects/Project'),
+            import('@nodes/Source'),
+        ]);
         add(
             Project.make(
                 null,

--- a/src/components/app/GalleryPreview.svelte
+++ b/src/components/app/GalleryPreview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { browser } from '$app/environment';
     import { goto } from '$app/navigation';
-    import { Projects, locales } from '@db/Database';
+    import { DB, locales } from '@db/Database';
     import type Project from '@db/projects/Project';
     import { onMount } from 'svelte';
     import type Gallery from '@db/galleries/Gallery';
@@ -53,7 +53,7 @@
         async function show(i: number) {
             const projects = gallery.getProjects();
             if (projects.length === 0) return;
-            const next = await Projects.get(projects[i]);
+            const next = await (await DB.loadProjects()).get(projects[i]);
             if (unmounted) return;
             project = next;
         }

--- a/src/components/app/ProjectPreview.svelte
+++ b/src/components/app/ProjectPreview.svelte
@@ -3,14 +3,14 @@
     import { navigating } from '$app/state';
     import CreatorView from '@components/app/CreatorView.svelte';
     import Emoji from '@components/app/Emoji.svelte';
-    import { UncomputablePreview } from '@components/app/extractPreview';
+    import { UncomputablePreview } from '@components/app/previewTypes';
     import GlyphTile from '@components/app/GlyphTile.svelte';
     import Link from '@components/app/Link.svelte';
     import Spinning from '@components/app/Spinning.svelte';
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import { getUser, isAuthenticated } from '@components/project/Contexts';
     import Note from '@components/widgets/Note.svelte';
-    import { Chats, Creators, DB, locales, Projects } from '@db/Database';
+    import { Chats, Creators, DB, LoadedProjects, locales } from '@db/Database';
     import { getLocalizedProjectName } from '@db/projects/getLocalizedProjectName';
     import { isFlagged } from '@db/projects/Moderation';
     import { isAudience } from '@db/projects/ModerationUtils';
@@ -115,8 +115,13 @@
                     ...extracted,
                 };
                 displayed = full;
-                if (Projects.isEditable(project))
-                    Projects.setAutoPreview(project.getID(), extracted);
+                // Reading what's loaded rather than importing it: a tile is
+                // only ever handed a Project once the database exists, and a
+                // static import would put the runtime in every page that
+                // lists projects.
+                const projects = DB.MaybeProjects;
+                if (projects?.isEditable(project))
+                    projects.setAutoPreview(project.getID(), extracted);
             })
             .catch(() => {
                 if (cancelled) return;
@@ -158,7 +163,7 @@
 
     const owner = $derived(project.getOwner());
     const collaborators = $derived(project.getCollaborators());
-    const editable = $derived(Projects.isEditable(project));
+    const editable = $derived($LoadedProjects?.isEditable(project) ?? false);
 
     // Read the chat from the global chats cache (kept current by the single
     // `participants array-contains` listener) rather than fetching it per tile.

--- a/src/components/app/Status.svelte
+++ b/src/components/app/Status.svelte
@@ -63,13 +63,19 @@
             l.ui.project.save.failureReason.projectContainsPII,
         'project-too-large': (l) =>
             l.ui.project.save.failureReason.projectTooLarge,
-        'no-cloud-target': (l) =>
-            l.ui.project.save.failureReason.noCloudTarget,
+        'no-cloud-target': (l) => l.ui.project.save.failureReason.noCloudTarget,
     };
 
     /** Per-domain save counts (saved on this device, in the cloud, unsaved). */
     let counts = $derived<Record<SyncDomain, SaveCounts>>({
-        projects: DB.Projects.saveCounts,
+        // Zeroes until the projects database loads. This renders in the footer
+        // on every page, so it reads what's in memory rather than forcing the
+        // language runtime to load — and nothing is in memory to be unsaved.
+        projects: DB.MaybeProjects?.saveCounts ?? {
+            device: 0,
+            cloud: 0,
+            unsaved: 0,
+        },
         galleries: DB.Galleries.saveCounts,
         characters: DB.Characters.saveCounts,
         howtos: DB.HowTos.saveCounts,
@@ -188,51 +194,41 @@
     /** All save failures across every document type. Projects keep their richer
      *  failure flow via the `status` store; the other domains expose `saveErrors`. */
     let allErrors = $derived<DomainError[]>([
-        ...$status.failures.map(
-            (f): DomainError => ({
-                domain: 'projects',
-                key: f.projectId,
-                name: f.projectName,
-                reason: f.reason,
-                detail: f.detail,
-            }),
-        ),
-        ...DB.Galleries.saveErrors.map(
-            (e): DomainError => ({
-                domain: 'galleries',
-                key: e.id,
-                name: e.name,
-                reason: e.reason,
-                detail: e.detail,
-            }),
-        ),
-        ...DB.Characters.saveErrors.map(
-            (e): DomainError => ({
-                domain: 'characters',
-                key: e.id,
-                name: e.name,
-                reason: e.reason,
-                detail: e.detail,
-            }),
-        ),
-        ...DB.HowTos.saveErrors.map(
-            (e): DomainError => ({
-                domain: 'howtos',
-                key: e.id,
-                name: e.name,
-                reason: e.reason,
-                detail: e.detail,
-            }),
-        ),
-        ...DB.Chats.saveErrors.map(
-            (e): DomainError => ({
-                domain: 'chats',
-                key: e.id,
-                name: e.name,
-                reason: e.reason,
-                detail: e.detail,
-            }),
-        ),
+        ...$status.failures.map((f): DomainError => ({
+            domain: 'projects',
+            key: f.projectId,
+            name: f.projectName,
+            reason: f.reason,
+            detail: f.detail,
+        })),
+        ...DB.Galleries.saveErrors.map((e): DomainError => ({
+            domain: 'galleries',
+            key: e.id,
+            name: e.name,
+            reason: e.reason,
+            detail: e.detail,
+        })),
+        ...DB.Characters.saveErrors.map((e): DomainError => ({
+            domain: 'characters',
+            key: e.id,
+            name: e.name,
+            reason: e.reason,
+            detail: e.detail,
+        })),
+        ...DB.HowTos.saveErrors.map((e): DomainError => ({
+            domain: 'howtos',
+            key: e.id,
+            name: e.name,
+            reason: e.reason,
+            detail: e.detail,
+        })),
+        ...DB.Chats.saveErrors.map((e): DomainError => ({
+            domain: 'chats',
+            key: e.id,
+            name: e.name,
+            reason: e.reason,
+            detail: e.detail,
+        })),
     ]);
 
     /** The errors grouped by domain, for a per-kind "couldn't save" list. */

--- a/src/components/app/TutorialView.svelte
+++ b/src/components/app/TutorialView.svelte
@@ -24,13 +24,8 @@
     import Tabbed from '@components/widgets/Tabbed.svelte';
     import TextField from '@components/widgets/TextField.svelte';
     import type ConceptIndex from '@concepts/ConceptIndex';
-    import {
-        contrastLanguage,
-        locales,
-        Locales,
-        Projects,
-        Settings,
-    } from '@db/Database';
+    import { contrastLanguage, locales, Locales, Settings } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { moderatedFlags } from '@db/projects/Moderation';
     import Project from '@db/projects/Project';
     import { PersistenceType } from '@db/projects/ProjectHistory.svelte';

--- a/src/components/app/chat/CollaborateView.svelte
+++ b/src/components/app/chat/CollaborateView.svelte
@@ -13,7 +13,8 @@
     import Mode from '@components/widgets/Mode.svelte';
     import type Chat from '@db/chats/ChatDatabase.svelte';
     import type { Creator } from '@db/creators/CreatorDatabase';
-    import { Creators, Galleries, locales, Projects } from '@db/Database';
+    import { Creators, Galleries, locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Gallery from '@db/galleries/Gallery';
     import type Project from '@db/projects/Project';
 

--- a/src/components/app/extractPreview.ts
+++ b/src/components/app/extractPreview.ts
@@ -1,3 +1,8 @@
+import { type ExtractedPreview } from '@components/app/previewTypes';
+export {
+    UncomputablePreview,
+    type ExtractedPreview,
+} from '@components/app/previewTypes';
 /**
  * Pure extractor: given an Evaluator and the project's top-level value,
  * return a {@link SerializedPreview}-shaped payload (sans `mode`) that
@@ -23,24 +28,6 @@ import type Value from '@values/Value';
 import ExceptionValue from '@values/ExceptionValue';
 import MarkupValue from '@values/MarkupValue';
 import StructureValue from '@values/StructureValue';
-
-export type ExtractedPreview = {
-    text: string;
-    foreground: string | null;
-    background: string | null;
-    face: string | null;
-    characterName: string | null;
-};
-
-/** Shown when a preview compute throws — a tile that can't be computed should
- *  read as empty, not as perpetually loading. */
-export const UncomputablePreview: ExtractedPreview = {
-    text: '—',
-    foreground: null,
-    background: null,
-    face: null,
-    characterName: null,
-};
 
 function findCharacterName(value: Value): string | null {
     if (value instanceof MarkupValue) {

--- a/src/components/app/previewTypes.ts
+++ b/src/components/app/previewTypes.ts
@@ -1,0 +1,26 @@
+/**
+ * The shape of a project tile's preview, and the placeholder shown when one
+ * can't be computed.
+ *
+ * Separate from extractPreview.ts because computing a preview needs the output
+ * layer and the evaluator, while merely *rendering* a tile needs only these
+ * two. Keeping them apart is what lets the galleries and projects pages list
+ * projects without pulling in the language runtime.
+ */
+export type ExtractedPreview = {
+    text: string;
+    foreground: string | null;
+    background: string | null;
+    face: string | null;
+    characterName: string | null;
+};
+
+/** Shown when a preview compute throws — a tile that can't be computed should
+ *  read as empty, not as perpetually loading. */
+export const UncomputablePreview: ExtractedPreview = {
+    text: '—',
+    foreground: null,
+    background: null,
+    face: null,
+    characterName: null,
+};

--- a/src/components/concepts/conceptGroups.ts
+++ b/src/components/concepts/conceptGroups.ts
@@ -5,7 +5,7 @@ import FunctionConcept from '@concepts/FunctionConcept';
 import NodeConcept from '@concepts/NodeConcept';
 import { Purpose, type PurposeType } from '@concepts/Purpose';
 import StructureConcept from '@concepts/StructureConcept';
-import { Projects } from '@db/Database';
+import { Projects } from '@db/projects/Projects';
 import type Project from '@db/projects/Project';
 import type LanguageCode from '@locale/LanguageCode';
 import {

--- a/src/components/editor/Editor.svelte
+++ b/src/components/editor/Editor.svelte
@@ -109,7 +109,6 @@
     import {
         CharactersDB,
         DB,
-        Projects,
         Settings,
         animationFactor,
         blockDensity,
@@ -119,6 +118,7 @@
         showLines,
         wrap,
     } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import {
         type RemoteCaret,
         decodeRemoteCaret,
@@ -2829,7 +2829,7 @@
         // is restored by the sync effect when composing ends.
         if (input) input.value = '';
 
-        if (insertedSymbol) DB.Projects.undoRedo(evaluator.project.getID(), -1);
+        if (insertedSymbol) Projects.undoRedo(evaluator.project.getID(), -1);
     }
 
     function handleCompositionEnd() {

--- a/src/components/editor/RemoteCaretOverlay.svelte
+++ b/src/components/editor/RemoteCaretOverlay.svelte
@@ -23,7 +23,8 @@
 -->
 <script lang="ts">
     import type { Creator } from '@db/creators/CreatorDatabase';
-    import { Creators, Projects } from '@db/Database';
+    import { Creators } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { decodeRemoteCaret } from '@db/projects/caretEncoding';
     import {
         assignDistinctColors,

--- a/src/components/editor/RemoteCarets.svelte
+++ b/src/components/editor/RemoteCarets.svelte
@@ -15,7 +15,8 @@
     import EditorNotice from '@components/editor/EditorNotice.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import { getAnnouncer } from '@components/project/Contexts';
-    import { Creators, locales, Projects } from '@db/Database';
+    import { Creators, locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type { Creator } from '@db/creators/CreatorDatabase';
     import {
         assignDistinctColors,

--- a/src/components/editor/commands/Commands.ts
+++ b/src/components/editor/commands/Commands.ts
@@ -1,3 +1,4 @@
+import { Projects } from '@db/projects/Projects';
 import type { CommandFeedback } from '@components/editor/commands/feedback';
 import Caret from '@edit/caret/Caret';
 import type { InsertContext } from '@edit/insertContext';
@@ -1113,13 +1114,13 @@ export const Undo: Command = {
     keySymbol: 'Z',
     important: true,
     active: ({ database, evaluator }) =>
-        database.Projects.getHistory(
+        Projects.getHistory(
             evaluator.project.getID(),
         )?.isUndoable() === true
             ? true
             : undefined,
     execute: ({ database, evaluator, clearLargeDeletionNotification }) => {
-        database.Projects.undoRedo(evaluator.project.getID(), -1);
+        Projects.undoRedo(evaluator.project.getID(), -1);
         // Clear large deletion notification when user undoes
         clearLargeDeletionNotification?.();
         // Always swallow the shortcut to avoid the browser or OS from handling it.
@@ -1140,13 +1141,13 @@ export const Redo: Command = {
     keySymbol: 'Z',
     important: true,
     active: ({ evaluator, database }) =>
-        database.Projects.getHistory(
+        Projects.getHistory(
             evaluator.project.getID(),
         )?.isRedoable() === true
             ? true
             : undefined,
     execute: ({ database, evaluator }) => {
-        database.Projects.undoRedo(evaluator.project.getID(), 1);
+        Projects.undoRedo(evaluator.project.getID(), 1);
         // Always swallow the shortcut to avoid the browser or OS from handling it.
         return true;
     },

--- a/src/components/editor/tokens/BooleanTokenEditor.svelte
+++ b/src/components/editor/tokens/BooleanTokenEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { getCaret } from '@components/project/Contexts';
     import setKeyboardFocus from '@components/util/setKeyboardFocus';
-    import { Projects } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import { Sym } from '@nodes/Sym';
     import Token from '@nodes/Token';

--- a/src/components/output/OutputHandles.svelte
+++ b/src/components/output/OutputHandles.svelte
@@ -4,7 +4,8 @@
         getSelectedOutput,
     } from '@components/project/Contexts';
     import setKeyboardFocus from '@components/util/setKeyboardFocus';
-    import { Projects, locales } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Evaluate from '@nodes/Evaluate';
     import {
         rotatedOutput,

--- a/src/components/output/OutputView.svelte
+++ b/src/components/output/OutputView.svelte
@@ -39,13 +39,8 @@
     // Named to avoid colliding with the Button input stream imported below.
     import ButtonWidget from '@components/widgets/Button.svelte';
     import TextField from '@components/widgets/TextField.svelte';
-    import {
-        animationFactor,
-        DB,
-        locales,
-        Projects,
-        voice,
-    } from '@db/Database';
+    import { animationFactor, DB, locales, voice } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import Button from '@input/Button/Button';
     import Camera from '@input/Camera/Camera';

--- a/src/components/output/PhraseView.svelte
+++ b/src/components/output/PhraseView.svelte
@@ -27,7 +27,8 @@
     import type Place from '@output/Place/Place';
     import type RenderContext from '@output/RenderContext';
     import { tick, untrack } from 'svelte';
-    import { DB, Projects, locales } from '@db/Database';
+    import { DB, locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import Markup from '@nodes/Markup';
     import TextValue from '@values/TextValue';
     import { getLanguageDirection } from '@locale/LanguageCode';

--- a/src/components/palette/ArrangementEditor.svelte
+++ b/src/components/palette/ArrangementEditor.svelte
@@ -2,7 +2,8 @@
     import { getProject } from '@components/project/Contexts';
     import StructureInputsEditor from '@components/palette/StructureInputsEditor.svelte';
     import Options from '@components/widgets/Options.svelte';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import type OutputPropertyValues from '@edit/output/OutputPropertyValueSet';
     import getStructureProperties from '@edit/output/getStructureProperties';

--- a/src/components/palette/BindCheckbox.svelte
+++ b/src/components/palette/BindCheckbox.svelte
@@ -2,7 +2,8 @@
     import type OutputProperty from '@edit/output/OutputProperty';
     import type OutputPropertyValues from '@edit/output/OutputPropertyValueSet';
     import BooleanLiteral from '@nodes/BooleanLiteral';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { getProject } from '@components/project/Contexts';
     import Checkbox from '@components/widgets/Checkbox.svelte';
 

--- a/src/components/palette/BindColor.svelte
+++ b/src/components/palette/BindColor.svelte
@@ -6,7 +6,7 @@
     import NumberLiteral from '@nodes/NumberLiteral';
     import Reference from '@nodes/Reference';
     import Unit from '@nodes/Unit';
-    import { Projects } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Bind from '@nodes/Bind';
     import {
         getProject,

--- a/src/components/palette/BindNumberField.svelte
+++ b/src/components/palette/BindNumberField.svelte
@@ -6,7 +6,8 @@
     import setKeyboardFocus from '@components/util/setKeyboardFocus';
     import Note from '@components/widgets/Note.svelte';
     import TextField from '@components/widgets/TextField.svelte';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type OutputProperty from '@edit/output/OutputProperty';
     import type OutputPropertyNumber from '@edit/output/OutputPropertyNumber';
     import type OutputPropertyValues from '@edit/output/OutputPropertyValueSet';

--- a/src/components/palette/BindOptions.svelte
+++ b/src/components/palette/BindOptions.svelte
@@ -4,7 +4,8 @@
     import type OutputProperty from '@edit/output/OutputProperty';
     import OutputPropertyOptions from '@edit/output/OutputPropertyOptions';
     import type OutputPropertyValues from '@edit/output/OutputPropertyValueSet';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { getProject } from '@components/project/Contexts';
     import Options from '@components/widgets/Options.svelte';
 

--- a/src/components/palette/BindSlider.svelte
+++ b/src/components/palette/BindSlider.svelte
@@ -5,7 +5,8 @@
     import { getFirstText } from '@locale/LocaleText';
     import { parseNumber } from '@parser/parseExpression';
     import type Decimal from 'decimal.js';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { toTokens } from '@parser/toTokens';
     import {
         getProject,

--- a/src/components/palette/BindText.svelte
+++ b/src/components/palette/BindText.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import setKeyboardFocus from '@components/util/setKeyboardFocus';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type OutputProperty from '@edit/output/OutputProperty';
     import type OutputPropertyValues from '@edit/output/OutputPropertyValueSet';
     import {

--- a/src/components/palette/MIDIImporter.svelte
+++ b/src/components/palette/MIDIImporter.svelte
@@ -14,12 +14,13 @@
      * a tempo change that can't be kept, a drum with no match — so there is
      * nothing for a creator to choose, only something to know.
      */
+    import { Projects } from '@db/projects/Projects';
     import Button from '@components/widgets/Button.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import MarkupHtmlView from '@components/concepts/MarkupHTMLView.svelte';
     import Dialog from '@components/widgets/Dialog.svelte';
     import Note from '@components/widgets/Note.svelte';
-    import { DB, locales } from '@db/Database';
+    import { locales } from '@db/Database';
     import type Project from '@db/projects/Project';
     import Bind from '@nodes/Bind';
     import { BORROW_SYMBOL, MUSIC_SYMBOL } from '@parser/Symbols';
@@ -191,7 +192,7 @@
         const musics = musicsIn(revised);
         const track = readMusic(revised, musics[musics.length - 1])?.tracks[0]
             ?.evaluate;
-        DB.Projects.reviseProject(
+        Projects.reviseProject(
             track === undefined
                 ? revised
                 : revised.withCaret(revised.getMain(), track),

--- a/src/components/palette/MusicEditor.svelte
+++ b/src/components/palette/MusicEditor.svelte
@@ -13,6 +13,7 @@
      * `TextStyleEditor` is rendered after a phrase's face — a bespoke editor
      * rather than a `property.type`, since what it edits is a list of lists.
      */
+    import { Projects } from '@db/projects/Projects';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import MarkupHtmlView from '@components/concepts/MarkupHTMLView.svelte';
     import Button from '@components/widgets/Button.svelte';
@@ -25,7 +26,7 @@
         getSelectedOutput,
         IdleKind,
     } from '@components/project/Contexts';
-    import { DB, locales } from '@db/Database';
+    import { locales } from '@db/Database';
     import type Project from '@db/projects/Project';
     import readMusic, {
         isEditable,
@@ -279,7 +280,7 @@
                       ),
                   );
         deferAnalysis();
-        DB.Projects.reviseProject(tidied, remember);
+        Projects.reviseProject(tidied, remember);
     }
 
     /** Rewrite the shown track's note list. */

--- a/src/components/palette/PlaceEditor.svelte
+++ b/src/components/palette/PlaceEditor.svelte
@@ -7,7 +7,8 @@
     import Evaluate from '@nodes/Evaluate';
     import NumberLiteral from '@nodes/NumberLiteral';
     import Unit from '@nodes/Unit';
-    import { Projects, locales } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
 
     interface Props {
         project: Project;

--- a/src/components/palette/PoseEditor.svelte
+++ b/src/components/palette/PoseEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
-    import { Projects, locales } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import type OutputExpression from '@edit/output/OutputExpression';
     import getPoseProperties from '@edit/output/PoseProperties';

--- a/src/components/palette/SequencePosesEditor.svelte
+++ b/src/components/palette/SequencePosesEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
-    import { Projects, locales } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import OutputExpression from '@edit/output/OutputExpression';
     import Evaluate from '@nodes/Evaluate';

--- a/src/components/palette/SequencePresetEditor.svelte
+++ b/src/components/palette/SequencePresetEditor.svelte
@@ -10,7 +10,8 @@
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import Options from '@components/widgets/Options.svelte';
     import Slider from '@components/widgets/Slider.svelte';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import type OutputExpression from '@edit/output/OutputExpression';
     import type { LocaleTextAccessor } from '@locale/Locales';
@@ -169,7 +170,9 @@
 
     // Sequence's inputs after `poses`: duration, style, count, description. Every animation
     // static declares the same ones, under the same names, and passes them through.
-    let passThroughBinds = $derived(project.shares.output.Sequence.inputs.slice(1));
+    let passThroughBinds = $derived(
+        project.shares.output.Sequence.inputs.slice(1),
+    );
 
     /**
      * The pass-through arguments explicitly given on an evaluate, as named inputs. Switching

--- a/src/components/palette/TextStyleEditor.svelte
+++ b/src/components/palette/TextStyleEditor.svelte
@@ -4,7 +4,8 @@
     import Checkbox from '@components/widgets/Checkbox.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import Options from '@components/widgets/Options.svelte';
-    import { Projects, locales } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import OutputPropertyValueSet from '@edit/output/OutputPropertyValueSet';
     import { getLanguageQuoteClose } from '@locale/LanguageCode';
@@ -26,7 +27,11 @@
     import { toTokens } from '@parser/toTokens';
     import MarkupValue from '@values/MarkupValue';
     import NamedControl from '@components/palette/NamedControl.svelte';
-    import { Faces, faceSupportsWeight, type FontWeight } from '@basis/faces/Fonts';
+    import {
+        Faces,
+        faceSupportsWeight,
+        type FontWeight,
+    } from '@basis/faces/Fonts';
     import type { LocaleTextAccessor } from '@locale/Locales';
 
     interface Props {

--- a/src/components/palette/editOutput.ts
+++ b/src/components/palette/editOutput.ts
@@ -1,3 +1,4 @@
+import { Projects } from '@db/projects/Projects';
 import type Project from '@db/projects/Project';
 import Block from '@nodes/Block';
 import type Context from '@nodes/Context';
@@ -55,7 +56,7 @@ export default function moveOutput(
 ) {
     const PlaceType = project.shares.output.Place;
 
-    db.Projects.revise(
+    Projects.revise(
         project,
         evaluates.map((evaluate) => {
             const ctx = project.getNodeContext(evaluate);
@@ -220,7 +221,7 @@ export function reviseContent(
     list: ListLiteral,
     newValues: (Expression | Spread)[],
 ) {
-    db.Projects.revise(project, [[list, ListLiteral.make(newValues)]]);
+    Projects.revise(project, [[list, ListLiteral.make(newValues)]]);
 }
 
 export function removeContent(
@@ -284,7 +285,7 @@ export function addStageContent(
         const newStage = Evaluate.make(StageType.getReference(locales), [
             ListLiteral.make([newContent]),
         ]);
-        database.Projects.reviseProject(
+        Projects.reviseProject(
             project.withRevisedNodes([[block, block.withStatement(newStage)]]),
         );
     }
@@ -618,7 +619,7 @@ export function addSoloPhrase(
     const revised = project.withRevisedNodes([
         last ? [last, phrase] : [block, block.withStatement(phrase)],
     ]);
-    db.Projects.reviseProject(revised);
+    Projects.reviseProject(revised);
     return revised;
 }
 
@@ -642,7 +643,7 @@ export function addShape(db: Database, project: Project): Project | undefined {
             [block, block.withStatement(shape)],
         ]);
     }
-    if (revised) db.Projects.reviseProject(revised);
+    if (revised) Projects.reviseProject(revised);
     return revised;
 }
 
@@ -668,7 +669,7 @@ export function addGroup(db: Database, project: Project): Project | undefined {
     );
 
     const revised = project.withRevisedNodes(target.replace(group));
-    db.Projects.reviseProject(revised);
+    Projects.reviseProject(revised);
     return revised;
 }
 
@@ -709,7 +710,7 @@ export function addStage(db: Database, project: Project): Project | undefined {
             [block, block.withStatement(stage)],
         ]);
     }
-    db.Projects.reviseProject(revised);
+    Projects.reviseProject(revised);
     return revised;
 }
 
@@ -757,7 +758,7 @@ export function addMusic(db: Database, project: Project): Project | undefined {
                   ],
               ]);
 
-    db.Projects.reviseProject(revised);
+    Projects.reviseProject(revised);
     return revised;
 }
 

--- a/src/components/project/Checkpoints.svelte
+++ b/src/components/project/Checkpoints.svelte
@@ -10,7 +10,7 @@
     import Button from '@components/widgets/Button.svelte';
     import ConfirmButton from '@components/widgets/ConfirmButton.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
-    import { Projects } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import { CANCEL_SYMBOL } from '@parser/Symbols';
     import { onMount } from 'svelte';

--- a/src/components/project/Preview.svelte
+++ b/src/components/project/Preview.svelte
@@ -3,7 +3,7 @@
     import GlyphChooser from '@components/widgets/GlyphChooser.svelte';
     import Switch from '@components/widgets/Switch.svelte';
     import TextField from '@components/widgets/TextField.svelte';
-    import { Projects } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import type { SerializedPreview } from '@db/projects/ProjectSchemas';
     import UnicodeString from '@unicode/UnicodeString';

--- a/src/components/project/ProjectFooter.svelte
+++ b/src/components/project/ProjectFooter.svelte
@@ -40,7 +40,8 @@
     import Toggle from '@components/widgets/Toggle.svelte';
     import type Chat from '@db/chats/ChatDatabase.svelte';
     import type { Creator } from '@db/creators/CreatorDatabase';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { MAX_NAME_LENGTH } from '@db/limits';
     import {
         getLocalizedProjectName,

--- a/src/components/project/ProjectView.svelte
+++ b/src/components/project/ProjectView.svelte
@@ -75,9 +75,9 @@
         locales,
         mic,
         musicVisualization,
-        Projects,
         Settings,
     } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import {
         MusicVisualizationIcons,
         MusicVisualizations,
@@ -110,11 +110,7 @@
     import { debounced } from '@util/debounce.svelte';
     import type Value from '@values/Value';
     import { onDestroy, onMount, tick, untrack } from 'svelte';
-    import {
-        writable,
-        type Readable,
-        type Writable,
-    } from 'svelte/store';
+    import { writable, type Readable, type Writable } from 'svelte/store';
     import Characters from '../../lore/BasisCharacters';
     import {
         PROJECT_PARAM_EDIT,

--- a/src/components/project/Remix.svelte
+++ b/src/components/project/Remix.svelte
@@ -4,7 +4,7 @@
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import Notice from '@components/app/Notice.svelte';
     import { isDialogOpenInURL } from '@components/widgets/dialogURL';
-    import { Projects } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import { ExamplePrefix } from '../../examples/examples';
 

--- a/src/components/project/RemixButton.svelte
+++ b/src/components/project/RemixButton.svelte
@@ -2,7 +2,7 @@
     import { goto } from '$app/navigation';
     import Button from '@components/widgets/Button.svelte';
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
-    import { Projects } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import { REMIX_SYMBOL } from '@parser/Symbols';
 

--- a/src/components/project/Sharing.svelte
+++ b/src/components/project/Sharing.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import Notice from '@components/app/Notice.svelte';
-    import { Galleries, Projects, locales } from '@db/Database';
+    import { Galleries, locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import Options from '@components/widgets/Options.svelte';

--- a/src/components/project/Translate.svelte
+++ b/src/components/project/Translate.svelte
@@ -8,7 +8,8 @@
     } from '@components/settings/LocaleSearch.svelte';
     import Button from '@components/widgets/Button.svelte';
     import Dialog from '@components/widgets/Dialog.svelte';
-    import { locales, Projects } from '@db/Database';
+    import { locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { getFunctionsInstance } from '@db/firebase';
     import type Project from '@db/projects/Project';
     import translateProject from '@db/projects/translate';

--- a/src/components/settings/Notifications.svelte
+++ b/src/components/settings/Notifications.svelte
@@ -32,16 +32,15 @@
     import type Chat from '@db/chats/ChatDatabase.svelte';
     import type { SerializedMessage } from '@db/chats/ChatDatabase.svelte';
     import {
+        DB,
         Chats,
         Galleries,
         howToNotifications,
         HowTos,
         locales,
-        Projects,
         Settings,
     } from '@db/Database';
     import type HowTo from '@db/howtos/HowToDatabase.svelte';
-    import type Project from '@db/projects/Project';
     import { NotificationsIcons } from '@db/settings/HowToNotificationsSetting';
     import type { LocaleTextAccessor } from '@locale/Locales';
     import { docToMarkup } from '@locale/LocaleText';
@@ -90,13 +89,16 @@
 
         [...Chats.chats.values()].forEach(async (chat) => {
             let galleryID: string | null = null;
-            let project: Project | undefined;
+            // Name and gallery read from the stored document rather than a
+            // constructed Project: this renders in the footer on every page,
+            // and building a Project would pull in the language runtime.
+            let project: { name: string; gallery: string | null } | undefined;
             let howTo: HowTo | undefined | false;
             const itemID = chat.getProjectID();
 
             if (chat.getType() === 'project') {
-                project = await Projects.get(itemID);
-                if (project) galleryID = project.getGallery();
+                project = await DB.getProjectSummary(itemID);
+                if (project) galleryID = project.gallery;
             } else {
                 howTo = await HowTos.getHowTo(itemID);
                 if (howTo) galleryID = howTo.getHowToGalleryId();
@@ -122,7 +124,7 @@
                         title:
                             chat.getType() === 'project'
                                 ? project
-                                    ? project.getName()
+                                    ? project.name
                                     : ''
                                 : howTo
                                   ? howTo.getTitle()

--- a/src/components/widgets/Hint.svelte
+++ b/src/components/widgets/Hint.svelte
@@ -227,12 +227,16 @@
         display: block;
     }
 
+    /* Dimming secondary-locale echoes and the shortcut suffix has to stay
+       above AA: opacity multiplies against the background, so 0.7 over already
+       grey-ish text lands at ~3:1 and axe fails it. 0.92 still reads as
+       secondary while keeping the text legible. */
     .hint-entry.secondary {
-        opacity: 0.7;
+        opacity: 0.92;
     }
 
     .hint-shortcut {
-        opacity: 0.7;
+        opacity: 0.92;
     }
 
     @keyframes appear {

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -7,7 +7,13 @@ import { type SupportedLocale } from '@locale/SupportedLocales';
 // Value symbols from firebase/auth are dynamically imported at use so the auth
 // SDK stays out of the eager chunk; only the erased types are imported here.
 import { type Unsubscribe, type User } from 'firebase/auth';
-import { deleteDoc, doc, getDocFromServer, setDoc } from 'firebase/firestore';
+import {
+    deleteDoc,
+    doc,
+    getDoc,
+    getDocFromServer,
+    setDoc,
+} from 'firebase/firestore';
 import {
     derived,
     get,
@@ -27,8 +33,9 @@ import CreatorDatabase, {
 import GalleryDatabase from '@db/galleries/GalleryDatabase.svelte';
 import { HowToDatabase } from '@db/howtos/HowToDatabase.svelte';
 import LocalesDatabase from '@db/locales/LocalesDatabase';
-import ProjectsDatabase from '@db/projects/ProjectsDatabase.svelte';
+import type ProjectsDatabase from '@db/projects/ProjectsDatabase.svelte';
 import { Domain, SyncDomains, type SyncDomain } from '@db/Domains';
+import { ProjectSchema } from '@db/projects/ProjectSchemas';
 import { WordplayDexie } from '@db/WordplayDexie';
 import SettingsDatabase from '@db/settings/SettingsDatabase';
 
@@ -136,8 +143,16 @@ export class Database {
      *  schemas for the same DB name conflict). */
     readonly localDB = new WordplayDexie();
 
-    /** An IndexedDB backed database of projects, allowing for scalability of local persistence. */
-    readonly Projects: ProjectsDatabase;
+    /** The projects database, once the language runtime it needs has loaded.
+     *  Undefined until then; see loadProjects(). */
+    private projects: ProjectsDatabase | undefined = undefined;
+    private projectsLoading: Promise<ProjectsDatabase> | undefined = undefined;
+    /** The same value as a store, so views that list projects re-render when
+     *  the database arrives. A plain field can't do that: a `$derived` reading
+     *  it captures `undefined` and never re-runs, which silently leaves the
+     *  projects page empty forever. */
+    private readonly projectsStore: Writable<ProjectsDatabase | undefined> =
+        writable(undefined);
 
     /** A collection of Galleries loaded from the database */
     readonly Galleries: GalleryDatabase;
@@ -242,7 +257,6 @@ export class Database {
             concretize,
             this.Settings.settings.locales,
         );
-        this.Projects = new ProjectsDatabase(this);
         this.Galleries = new GalleryDatabase(this);
         this.Creators = new CreatorDatabase(this);
         this.Chats = new ChatDatabase(this);
@@ -262,7 +276,7 @@ export class Database {
      *  that would discard local-only edits. */
     getUnsavedCount(): number {
         return (
-            this.Projects.saveCounts.unsaved +
+            (this.projects?.saveCounts.unsaved ?? 0) +
             this.Galleries.saveCounts.unsaved +
             this.Characters.saveCounts.unsaved +
             this.HowTos.saveCounts.unsaved +
@@ -514,10 +528,90 @@ export class Database {
      * Waiting is safe for unsaved work: edits are recorded in a durable dirty
      * table, so anything pending replays once this runs.
      */
-    async startProjectWork(): Promise<void> {
-        await this.Projects.start();
-        if (this.user !== null) this.Projects.saveSoon();
+    /**
+     * Load the language runtime and the projects database that needs it, once.
+     *
+     * The dynamic import lives inside this method on purpose: a module-level
+     * await anywhere in the app graph reorders WebKit's module evaluation
+     * across the route/db import cycle and crashes hydration (see
+     * src/util/getTemporal.ts).
+     */
+    loadProjects(): Promise<ProjectsDatabase> {
+        return (this.projectsLoading ??= import('@db/projects/Projects').then(
+            ({ Projects }) => {
+                this.projects = Projects;
+                this.projectsStore.set(Projects);
+                return Projects;
+            },
+        ));
     }
+
+    /** The projects database if the runtime has already loaded, else
+     *  undefined. For synchronous paths that must not force a load — unsaved
+     *  counts read from `beforeunload`, reconnect flushes, locale re-sync —
+     *  where "not loaded" correctly means "nothing in memory to act on". */
+    get MaybeProjects(): ProjectsDatabase | undefined {
+        return this.projects;
+    }
+
+    /** {@link MaybeProjects} as a store, for views that must re-render when the
+     *  projects database finishes loading. */
+    get LoadedProjects(): Readable<ProjectsDatabase | undefined> {
+        return this.projectsStore;
+    }
+
+    /** Whether the projects database is loaded and usable synchronously. */
+    get projectsReady(): boolean {
+        return this.projects !== undefined;
+    }
+
+    /**
+     * A project's name and gallery, read straight from its stored document.
+     *
+     * For paths that need to label a project rather than work with it — chat
+     * notifications, moderation lists. Constructing a `Project` to ask its
+     * name would build a `Basis` and pull the whole language runtime into the
+     * footer, which renders on every page.
+     */
+    async getProjectSummary(
+        id: string,
+    ): Promise<{ name: string; gallery: string | null } | undefined> {
+        try {
+            const local = await this.localDB.getProject(id);
+            if (local !== undefined)
+                return { name: local.name, gallery: local.gallery };
+        } catch {
+            // Fall through to the cloud copy below.
+        }
+        if (firestore === undefined) return undefined;
+        try {
+            const remote = await getDoc(doc(firestore, Domain.Projects, id));
+            const data = remote.data();
+            if (data === undefined) return undefined;
+            const serialized = ProjectSchema.safeParse(data);
+            return serialized.success
+                ? {
+                      name: serialized.data.name,
+                      gallery: serialized.data.gallery,
+                  }
+                : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    async startProjectWork(): Promise<void> {
+        const projects = await this.loadProjects();
+        await projects.start();
+        // Installed here rather than at page load: these handlers flush
+        // project edits on unload, and until projects are in memory there is
+        // nothing for them to flush.
+        this.cleanupSaveOnUnload ??= projects.installSaveOnUnloadListeners();
+        if (this.user !== null) projects.saveSoon();
+    }
+
+    /** Removes the save-on-unload handlers installed by startProjectWork. */
+    private cleanupSaveOnUnload: (() => void) | undefined = undefined;
 
     /** Whether this device has project work worth starting: a signed-in
      *  creator, or projects cached locally from a previous visit. */
@@ -534,7 +628,7 @@ export class Database {
      *  when that domain has nothing unsaved, so it's safe to fire on any
      *  reconnect signal (browser `online` or Firebase reachability recovery). */
     private flushUnsavedWork() {
-        this.Projects.saveSoon();
+        this.projects?.saveSoon();
         void this.Galleries.flushUnsaved();
         void this.Characters.flushUnsaved();
         void this.HowTos.flushUnsaved();
@@ -846,7 +940,7 @@ export class Database {
             // Logout (or an involuntary auth drop): tear down every realtime
             // listener and reset the per-domain sync status. These syncUser
             // calls are no-ops/ignores when the user is null.
-            this.Projects.syncUser(remove);
+            this.projects?.syncUser(remove);
             this.Characters.syncUser();
             this.HowTos.syncUser();
             this.Chats.syncUser();
@@ -884,12 +978,17 @@ export class Database {
         const superseded = () =>
             sequence !== this.syncSequence || this.user === null;
 
-        this.Projects.syncUser(remove);
+        // Being signed in IS having project work, so this deliberately loads
+        // the projects database rather than skipping when it isn't there —
+        // skipping would mean a creator's projects never arrive from the
+        // cloud. It does NOT wait for local hydration: reading the cache is a
+        // separate concern, and blocking sync behind it stalls every domain.
+        (await this.loadProjects()).syncUser(remove);
         // Now that the user is known, flush any project edits whose cloud write
         // didn't confirm before the last reload (durable dirty flag → unsaved on
         // hydrate). persist() only writes unsaved histories, so this is a no-op
         // when everything is saved.
-        this.Projects.saveSoon();
+        this.projects?.saveSoon();
         await this.domainSettled(Domain.Projects);
         if (superseded()) return;
 
@@ -957,7 +1056,7 @@ export class Database {
      *  a null user, so an involuntary auth drop (a flaky connection that can't
      *  refresh the token) can't erase a creator's local projects. */
     async logout() {
-        await this.Projects.deleteLocal();
+        await (await this.loadProjects()).deleteLocal();
         await this.Characters.clearLocal();
         await this.Chats.clearLocal();
         await this.Galleries.clearLocal();
@@ -976,10 +1075,12 @@ export class Database {
 
     /** Clean up listeners */
     clean() {
+        this.cleanupSaveOnUnload?.();
+        this.cleanupSaveOnUnload = undefined;
         if (this.authUnsubscribe) this.authUnsubscribe();
         if (this.authRefreshUnsubscribe) this.authRefreshUnsubscribe();
 
-        this.Projects.unmount();
+        this.projects?.unmount();
         this.Galleries.clean();
         this.Chats.ignore();
         this.Characters.ignore();
@@ -1010,7 +1111,7 @@ export class Database {
         if (firestore === undefined) return 'failed';
 
         try {
-            await this.Projects.deleteOwnedProjects();
+            await (await this.loadProjects()).deleteOwnedProjects();
         } catch (err) {
             this.reportBanner((l) => l.ui.banner.deleteFailed, err);
             return 'failed';
@@ -1068,8 +1169,8 @@ export const DB = new Database(
     DefaultLocale,
 );
 
+export const LoadedProjects = DB.LoadedProjects;
 export const Settings = DB.Settings;
-export const Projects = DB.Projects;
 export const Locales = DB.Locales;
 export const Galleries = DB.Galleries;
 export const Creators = DB.Creators;

--- a/src/db/characters/CharacterDatabase.svelte.ts
+++ b/src/db/characters/CharacterDatabase.svelte.ts
@@ -421,9 +421,15 @@ export class CharactersDatabase {
                 // Collect failures from project updates
                 const failedProjects: Project[] = [];
 
+                // Renaming a character rewrites the projects that use it, so
+                // this genuinely needs the projects database — loaded here
+                // rather than imported, so editing a character is what pulls
+                // in the language runtime rather than opening any page.
+                const projects = await this.db.loadProjects();
+
                 // Collect all revision promises
                 const revisionPromises =
-                    this.db.Projects.allEditableProjects.map(
+                    projects.allEditableProjects.map(
                         async (project) => {
                             const revisions: [Node, Node | undefined][] = [];
 
@@ -460,7 +466,7 @@ export class CharactersDatabase {
                                 const newProject =
                                     project.withRevisedNodes(revisions);
                                 const failure =
-                                    await this.db.Projects.reviseProject(
+                                    await projects.reviseProject(
                                         newProject,
                                     );
 

--- a/src/db/characters/CharacterDatabase.test.ts
+++ b/src/db/characters/CharacterDatabase.test.ts
@@ -35,10 +35,13 @@ describe('CharactersDatabase', () => {
             setStatus: vi.fn(),
             reportBanner: vi.fn(),
             track: vi.fn((write) => write),
-            Projects: {
-                allEditableProjects: [],
+            // The projects database is loaded on demand now, so the fake
+            // exposes it the same way Database does.
+            projectsFake: {
+                allEditableProjects: [] as unknown[],
                 reviseProject: vi.fn(),
             },
+            loadProjects: vi.fn(async () => mockDatabase.projectsFake),
         };
 
         charactersDb = new CharactersDatabase(mockDatabase);
@@ -80,7 +83,7 @@ describe('CharactersDatabase', () => {
             };
 
             // Mock the Projects.allEditableProjects to return our mock project
-            mockDatabase.Projects.allEditableProjects = [mockProject];
+            mockDatabase.projectsFake.allEditableProjects = [mockProject];
 
             // Set up existing character
             charactersDb.byID.set('char1', oldCharacter);

--- a/src/db/chats/ChatDatabase.svelte.ts
+++ b/src/db/chats/ChatDatabase.svelte.ts
@@ -2,7 +2,6 @@
 import type { NotificationData } from '@components/settings/Notifications.svelte';
 import {
     HowTos,
-    Projects,
     type Database,
     type SaveCounts,
     type SaveError,
@@ -463,7 +462,7 @@ export class ChatDatabase {
 
         // Make sure we're listening to updates on the chat's project.
         if (chat.getType() === 'project') {
-            this.db.Projects.listen(projectID, this.projectsListener);
+            this.db.MaybeProjects?.listen(projectID, this.projectsListener);
         } else {
             this.db.HowTos.addListener(projectID, this.howToListener);
         }
@@ -722,8 +721,10 @@ export class ChatDatabase {
             type: 'project',
         };
 
-        return this.createChat(newChat, () =>
-            Projects.reviseProject(project.withChat(newChat.project)),
+        return this.createChat(newChat, async () =>
+            (await this.db.loadProjects()).reviseProject(
+                project.withChat(newChat.project),
+            ),
         );
     }
 
@@ -781,7 +782,9 @@ export class ChatDatabase {
         const uid = this.db.getUser()?.uid;
         if (uid !== undefined && gallery.getCurators().includes(uid)) {
             for (const projectID of gallery.getProjects()) {
-                const project = await this.db.Projects.get(projectID);
+                const project = await (
+                    await this.db.loadProjects()
+                ).get(projectID);
                 if (project) this.syncParticipants(project, gallery);
             }
         }
@@ -1027,7 +1030,7 @@ export class ChatDatabase {
                             change.doc.data().type === 'project' &&
                             this.projectsListener
                         )
-                            this.db.Projects.ignore(
+                            this.db.MaybeProjects?.ignore(
                                 projectID,
                                 this.projectsListener,
                             );
@@ -1059,10 +1062,10 @@ export class ChatDatabase {
                         let galleryID: string = '';
 
                         if (chatData.getType() === 'project') {
-                            const project = await this.db.Projects.get(
+                            const project = await this.db.getProjectSummary(
                                 chatData.getProjectID(),
                             );
-                            if (project) title = project.getName();
+                            if (project) title = project.name;
                         } else {
                             const howto = await this.db.HowTos.getHowTo(
                                 chatData.getProjectID(),

--- a/src/db/galleries/GalleryDatabase.svelte.ts
+++ b/src/db/galleries/GalleryDatabase.svelte.ts
@@ -328,7 +328,7 @@ export default class GalleryDatabase {
                         this.accessibleGalleries.set(gallery.getID(), gallery);
 
                         // Notify the project's database that gallery permissions changed, requring a reload of the any projects in the gallery to see new permissions.
-                        this.database.Projects.refreshGallery(gallery);
+                        this.database.MaybeProjects?.refreshGallery(gallery);
                     } else {
                         // user is only a how-to viewer, which means they have expanded scope access only
                         this.expandedScopeGalleries.set(
@@ -366,7 +366,7 @@ export default class GalleryDatabase {
                     .join(',');
                 if (watchedKey !== this.watchedGalleryKey) {
                     this.watchedGalleryKey = watchedKey;
-                    this.database.Projects.syncUser(false);
+                    this.database.MaybeProjects?.syncUser(false);
                 }
 
                 // Mark the database loaded.
@@ -598,7 +598,7 @@ export default class GalleryDatabase {
 
         // Remove all projects from the gallery.
         for (const projectID of gallery.getProjects()) {
-            const project = await this.database.Projects.get(projectID);
+            const project = await (await this.database.loadProjects()).get(projectID);
             if (project) await this.removeProjectFromGallery(project);
         }
 
@@ -660,7 +660,7 @@ export default class GalleryDatabase {
         // Update the in-memory project to reflect the new gallery. Pass persist=false
         // so we can include the project doc write in our atomic batch below rather than
         // letting the project history's separate persist() race with it.
-        const editResult = await this.database.Projects.edit(
+        const editResult = await (await this.database.loadProjects()).edit(
             project.withGallery(galleryID),
             false,
             false,
@@ -671,7 +671,7 @@ export default class GalleryDatabase {
 
         // Get the just-edited project so we can serialize its latest form into the batch.
         const updated =
-            this.database.Projects.getHistory(projectID)?.getCurrent();
+            this.database.MaybeProjects?.getHistory(projectID)?.getCurrent();
         if (updated === undefined) return;
 
         // If a concurrent share/unshare ran between our history edit and now,
@@ -716,8 +716,8 @@ export default class GalleryDatabase {
         void this.trackSave(galleryID, galleryName, batch.commit()).then(
             (ok) => {
                 if (ok)
-                    this.database.Projects.getHistory(projectID)?.markSaved();
-                else this.database.Projects.saveSoon();
+                    this.database.MaybeProjects?.getHistory(projectID)?.markSaved();
+                else this.database.MaybeProjects?.saveSoon();
             },
         );
     }
@@ -730,7 +730,7 @@ export default class GalleryDatabase {
         const targetGalleryID = galleryID ?? project.getGallery();
 
         // Update the in-memory project to clear its gallery field (no persist; batched below).
-        const editResult = await this.database.Projects.edit(
+        const editResult = await (await this.database.loadProjects()).edit(
             project.withGallery(null),
             false,
             false,
@@ -740,7 +740,7 @@ export default class GalleryDatabase {
         if (editResult !== undefined) return;
 
         const updated =
-            this.database.Projects.getHistory(projectID)?.getCurrent();
+            this.database.MaybeProjects?.getHistory(projectID)?.getCurrent();
         if (updated === undefined) return;
 
         // Same race-collapsing check as addProject: if a concurrent share ran after
@@ -773,8 +773,8 @@ export default class GalleryDatabase {
                 batch.commit(),
             ).then((ok) => {
                 if (ok)
-                    this.database.Projects.getHistory(projectID)?.markSaved();
-                else this.database.Projects.saveSoon();
+                    this.database.MaybeProjects?.getHistory(projectID)?.markSaved();
+                else this.database.MaybeProjects?.saveSoon();
             });
         } else {
             // No gallery doc in the batch — it's just the project write; let the
@@ -782,16 +782,16 @@ export default class GalleryDatabase {
             void this.database
                 .track(batch.commit())
                 .then(() =>
-                    this.database.Projects.getHistory(projectID)?.markSaved(),
+                    this.database.MaybeProjects?.getHistory(projectID)?.markSaved(),
                 )
-                .catch(() => this.database.Projects.saveSoon());
+                .catch(() => this.database.MaybeProjects?.saveSoon());
         }
     }
 
     // Remove the project from whatever gallery it is in, but only the project side
     // (used by gallery deletion, where the gallery doc itself is about to be deleted).
     async removeProjectFromGallery(project: Project) {
-        await this.database.Projects.edit(
+        await (await this.database.loadProjects()).edit(
             project.withGallery(null),
             false,
             true,
@@ -866,7 +866,7 @@ export default class GalleryDatabase {
         const projectsToRemove: string[] = [];
         for (const projectID of gallery.getProjects()) {
             try {
-                const project = await this.database.Projects.get(projectID);
+                const project = await (await this.database.loadProjects()).get(projectID);
                 if (project !== undefined && project.getOwner() === uid)
                     projectsToRemove.push(projectID);
             } catch (err) {

--- a/src/db/galleries/GalleryDatabase.test.ts
+++ b/src/db/galleries/GalleryDatabase.test.ts
@@ -151,11 +151,19 @@ describe('GalleryDatabase atomic project + gallery updates', () => {
                 getLocaleSet: () => ({ getMultilingualText: () => 'Test' }),
                 locales: { subscribe: () => () => {} },
             },
-            Projects: {
+            // Awaited calls go through loadProjects(); best-effort
+            // bookkeeping reads MaybeProjects. Both point at one fake.
+            projectsFake: {
                 edit: projectsEditMock,
                 getHistory: getHistoryMock,
                 get: vi.fn(async () => undefined),
                 refreshGallery: vi.fn(),
+                saveSoon: vi.fn(),
+                syncUser: vi.fn(),
+            },
+            loadProjects: vi.fn(async () => mockDatabase.projectsFake),
+            get MaybeProjects() {
+                return mockDatabase.projectsFake;
             },
         };
 
@@ -299,7 +307,7 @@ describe('GalleryDatabase atomic project + gallery updates', () => {
             });
             db.accessibleGalleries.set('g1', gallery);
 
-            mockDatabase.Projects.get = vi.fn(async (id: string) => {
+            mockDatabase.projectsFake.get = vi.fn(async (id: string) => {
                 if (id === 'p1') return project1;
                 if (id === 'p2') return project2;
                 if (id === 'p3') return project3;
@@ -354,7 +362,7 @@ describe('GalleryDatabase atomic project + gallery updates', () => {
                 projects: [],
             });
             db.accessibleGalleries.set('g1', gallery);
-            mockDatabase.Projects.get = vi.fn(async () => undefined);
+            mockDatabase.projectsFake.get = vi.fn(async () => undefined);
 
             await db.removeCurator(gallery, 'teacher-uid');
 

--- a/src/db/locales/LocalesDatabase.ts
+++ b/src/db/locales/LocalesDatabase.ts
@@ -299,7 +299,11 @@ export default class LocalesDatabase {
                                 response.ok ? await response.json() : undefined,
                             )
                             .catch(() => undefined),
-                        fetch(versioned(`/locales/${lang}/${lang}-datetimes.json`))
+                        fetch(
+                            versioned(
+                                `/locales/${lang}/${lang}-datetimes.json`,
+                            ),
+                        )
                             .then(async (response) =>
                                 response.ok ? await response.json() : undefined,
                             )
@@ -368,8 +372,10 @@ export default class LocalesDatabase {
         // Try to load locales for the requested languages
         const locales = await this.loadLocales(preferredLocales);
 
-        // Revise all projects to have the new locale
-        this.database.Projects.localize(locales);
+        // Revise all projects to have the new locale. Best-effort: if the
+        // projects database hasn't loaded there is nothing in memory to
+        // re-localize, and deserialization reads the current locales anyway.
+        this.database.MaybeProjects?.localize(locales);
 
         // Sync the locales store to update all uses of the current locales.
         this.syncLocales();

--- a/src/db/projects/Projects.ts
+++ b/src/db/projects/Projects.ts
@@ -1,0 +1,24 @@
+import { DB } from '@db/Database';
+import ProjectsDatabase from '@db/projects/ProjectsDatabase.svelte';
+
+/**
+ * The one projects database.
+ *
+ * It lives here rather than on `Database` because constructing it reaches
+ * `Project`, and `Project` is the language runtime — the basis, the nodes, the
+ * evaluator, the output layer. Anything that imports `Database` for a locale
+ * store would otherwise carry all of that, on every page, whether or not the
+ * page shows a project.
+ *
+ * Importing this module IS asking for the runtime. Only modules that are
+ * already part of it should do so statically; everything else should go
+ * through `DB.loadProjects()`, which imports this on demand.
+ *
+ * Constructed at module scope, which is safe precisely because this module is
+ * only ever evaluated inside that deferred chunk. Note the import direction:
+ * heavy depends on light (`@db/Database`), never the reverse, so the
+ * basis→database cycle the codebase guards against stays open.
+ */
+export const Projects = new ProjectsDatabase(DB);
+
+export default Projects;

--- a/src/db/projects/ProjectsDatabase.svelte.ts
+++ b/src/db/projects/ProjectsDatabase.svelte.ts
@@ -357,8 +357,22 @@ export default class ProjectsDatabase {
      * projects on them — pay for it before first paint.
      */
     start(): Promise<void> {
-        return (this.starting ??= this.hydrate());
+        // Resolves when projects are actually IN MEMORY, not merely when the
+        // subscription is set up: hydrate() returns as soon as it has
+        // subscribed, but the first emission — which deserializes the cached
+        // projects — lands later. Callers ask for this because they want to
+        // read projects, and returning early let a character rename iterate an
+        // empty set and silently rewrite nothing.
+        return (this.starting ??= this.hydrate().then(
+            () => this.firstHydration,
+        ));
     }
+
+    /** Resolves once the first hydration pass has put projects in memory. */
+    private readonly firstHydration: Promise<void> = new Promise((resolve) => {
+        this.resolveFirstHydration = resolve;
+    });
+    private resolveFirstHydration: (() => void) | undefined = undefined;
 
     async hydrate() {
         // Local DB support?
@@ -377,18 +391,21 @@ export default class ProjectsDatabase {
                         if (firstEmission) {
                             firstEmission = false;
                             this.hydrated = true;
+                            this.resolveFirstHydration?.();
                         }
                     });
                 });
             } else {
                 // Observable didn't materialize — nothing to wait for.
                 this.hydrated = true;
+                this.resolveFirstHydration?.();
             }
         } else {
             // No IndexedDB at all (e.g. private-window mode in some
             // browsers). Nothing to hydrate; the page should show
             // whatever's in memory immediately.
             this.hydrated = true;
+            this.resolveFirstHydration?.();
         }
 
         // We don't pull projects from the cloud. That's handled by syncUser() when the user changes.

--- a/src/db/projects/previewQueue.ts
+++ b/src/db/projects/previewQueue.ts
@@ -21,14 +21,10 @@
  * `requestIdleCallback` is unavailable (Safari < 17).
  */
 
-import {
-    extractPreview,
-    type ExtractedPreview,
-} from '@components/app/extractPreview';
+import { type ExtractedPreview } from '@components/app/extractPreview';
 import type { Database } from '@db/Database';
 import type Project from '@db/projects/Project';
 import type Locales from '@locale/Locales';
-import Evaluator from '@runtime/Evaluator';
 
 import type { ProjectID } from '@db/projects/ProjectSchemas';
 
@@ -80,6 +76,15 @@ export function enqueuePreviewCompute(
 
     const job = workerChain.then(async () => {
         await yieldToBrowser();
+        // Imported here rather than at module scope: computing a preview is
+        // the only thing on this path that needs the evaluator, and a static
+        // import would put it in every page that renders a project tile. The
+        // job is already async, so this costs nothing it wasn't already
+        // paying. Never at module top level — see src/util/getTemporal.ts.
+        const [{ default: Evaluator }, { extractPreview }] = await Promise.all([
+            import('@runtime/Evaluator'),
+            import('@components/app/extractPreview'),
+        ]);
         const evaluator = new Evaluator(
             project,
             db,

--- a/src/edit/output/OutputPropertyValueSet.ts
+++ b/src/edit/output/OutputPropertyValueSet.ts
@@ -1,3 +1,4 @@
+import { Projects } from '@db/projects/Projects';
 import Evaluate from '@nodes/Evaluate';
 import type Expression from '@nodes/Expression';
 import type Node from '@nodes/Node';
@@ -200,7 +201,7 @@ export default class OutputPropertyValueSet {
         // Find all the values that are given, then map them to [ Evaluate, Evaluate ] pairs
         // that represent the original Evaluate and the replacement without the given value.
         // If the property is required, replace with a default value.
-        projects.Projects.revise(
+        Projects.revise(
             project,
             project.getBindReplacements(
                 this.values
@@ -216,7 +217,7 @@ export default class OutputPropertyValueSet {
 
     /** Given a project, set this property to a reasonable starting value */
     set(db: Database, project: Project, locales: Locales) {
-        db.Projects.revise(
+        Projects.revise(
             project,
             project.getBindReplacements(
                 this.values

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -131,12 +131,6 @@
         // Install browser online/offline + visibilitychange listeners.
         const cleanupNetworkListeners = DB.installNetworkListeners();
 
-        // Install best-effort save-on-unload handlers so local edits
-        // (especially in-memory CRDT state) survive a tab close that
-        // beats saveSoon's debounce. See
-        // ProjectsDatabase.installSaveOnUnloadListeners for what it
-        // catches and what it can't.
-        const cleanupSaveOnUnload = DB.Projects.installSaveOnUnloadListeners();
 
         // Read the local project cache once the page is up rather than on
         // import: hydration deserializes every cached project and each one
@@ -175,7 +169,6 @@
             if (idleSupported) window.cancelIdleCallback(idle);
             else window.clearTimeout(idle);
             cleanupNetworkListeners();
-            cleanupSaveOnUnload();
             window.removeEventListener('beforeunload', warnUnsaved);
             DB.clean();
         };

--- a/src/routes/[[locale]]/character/[id]/+page.svelte
+++ b/src/routes/[[locale]]/character/[id]/+page.svelte
@@ -45,7 +45,7 @@
     } from '@db/characters/Character';
     import { MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH } from '@db/limits';
     import { Creator } from '@db/creators/CreatorDatabase';
-    import { CharactersDB, disconnected, locales } from '@db/Database';
+    import { DB, CharactersDB, disconnected, locales } from '@db/Database';
     import type Project from '@db/projects/Project';
     import Locales from '@locale/Locales';
     import type LocaleText from '@locale/LocaleText';
@@ -68,7 +68,7 @@
     import { NameRegExPattern } from '@parser/Tokenizer';
     import UnicodeString from '@unicode/UnicodeString';
     import { localeGoto } from '@util/localeGoto';
-    import { untrack } from 'svelte';
+    import { untrack, onMount } from 'svelte';
 
     const DrawingMode = {
         Select: 0,
@@ -1615,6 +1615,11 @@
             }
         }
     }
+
+    // Renaming a character rewrites the projects that reference it, which
+    // reads the loaded projects — so bring them in when the page opens
+    // rather than making the rename itself wait.
+    onMount(() => void DB.startProjectWork());
 </script>
 
 <svelte:head>

--- a/src/routes/[[locale]]/galleries/+page.svelte
+++ b/src/routes/[[locale]]/galleries/+page.svelte
@@ -26,13 +26,7 @@
     import Tabbed from '@components/widgets/Tabbed.svelte';
     import TextField from '@components/widgets/TextField.svelte';
     import Title from '@components/widgets/Title.svelte';
-    import {
-        authAttempted,
-        DB,
-        Galleries,
-        locales,
-        Projects,
-    } from '@db/Database';
+    import { authAttempted, DB, Galleries, locales } from '@db/Database';
     import { firestore } from '@db/firebase';
     import type { SerializedGallery } from '@db/galleries/Gallery';
     import Gallery, { upgradeGallery } from '@db/galleries/Gallery';
@@ -239,7 +233,11 @@
                     ),
                 ),
             ];
-            Promise.all(ids.map((id) => Projects.get(id))).then((projects) => {
+            // The runtime arrives with the examples rather than with the
+            // page, so the gallery list renders before any project does.
+            DB.loadProjects()
+                .then((db) => Promise.all(ids.map((id) => db.get(id))))
+                .then((projects) => {
                 allExampleProjects = projects.filter(
                     (p): p is Project => p !== undefined,
                 );

--- a/src/routes/[[locale]]/gallery/[galleryid]/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/+page.svelte
@@ -18,11 +18,10 @@
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import TextBox from '@components/widgets/TextBox.svelte';
     import TextField from '@components/widgets/TextField.svelte';
-    import {
+    import { DB,
         authAttempted,
         disconnected,
         Galleries,
-        Projects,
         locales,
     } from '@db/Database';
     import { MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH } from '@db/limits';
@@ -115,7 +114,9 @@
             await Promise.all(
                 gallery
                     .getProjects()
-                    .map((projectID) => Projects.get(projectID)),
+                    .map(async (projectID) =>
+                        (await DB.loadProjects()).get(projectID),
+                    ),
             )
         ).filter((proj): proj is Project => proj !== undefined);
     }
@@ -210,9 +211,11 @@
 
                 {#if editable || addable}
                     <AddProject
-                        add={(template) => {
+                        add={async (template) => {
                             if (gallery) {
-                                const newProjectID = Projects.copy(
+                                const newProjectID = (
+                                    await DB.loadProjects()
+                                ).copy(
                                     template,
                                     $user?.uid ?? null,
                                     gallery.getID(),
@@ -247,11 +250,12 @@
                                   label: '👁️',
                               }}
                         copy={{
-                            description: (l) =>
-                                l.ui.project.button.remix.tip,
-                            action: (project) =>
+                            description: (l) => l.ui.project.button.remix.tip,
+                            action: async (project) =>
                                 localeGoto(
-                                    Projects.remix(project).getLink(false),
+                                    (await DB.loadProjects())
+                                        .remix(project)
+                                        .getLink(false),
                                 ),
                             label: REMIX_SYMBOL,
                         }}

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToUsedBy.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToUsedBy.svelte
@@ -2,7 +2,8 @@
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
     import Button from '@components/widgets/Button.svelte';
     import Options, { type Option } from '@components/widgets/Options.svelte';
-    import { HowTos, Projects } from '@db/Database';
+    import { HowTos } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import HowTo from '@db/howtos/HowToDatabase.svelte';
     import type Project from '@db/projects/Project';
     import { CANCEL_SYMBOL } from '@parser/Symbols';

--- a/src/routes/[[locale]]/moderate/+page.svelte
+++ b/src/routes/[[locale]]/moderate/+page.svelte
@@ -26,7 +26,8 @@
     import Spinning from '@components/app/Spinning.svelte';
     import { getUser, setConceptPath } from '@components/project/Contexts';
     import Button from '@components/widgets/Button.svelte';
-    import { DB, disconnected, Projects, locales } from '@db/Database';
+    import { DB, disconnected, locales } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import { firestore } from '@db/firebase';
     import type { ModerationState } from '@db/projects/Moderation';
     import {
@@ -116,7 +117,9 @@
         lastBatch = documentSnapshots.docs[documentSnapshots.docs.length - 1];
 
         // Convert the docs to galleries
-        const projectData = documentSnapshots.docs.map((snap) => snap.data())[0];
+        const projectData = documentSnapshots.docs.map((snap) =>
+            snap.data(),
+        )[0];
 
         project = await Projects.parseProject(projectData);
 

--- a/src/routes/[[locale]]/project/[projectid]/+page.svelte
+++ b/src/routes/[[locale]]/project/[projectid]/+page.svelte
@@ -11,7 +11,8 @@
         setProject,
     } from '@components/project/Contexts';
     import ProjectView from '@components/project/ProjectView.svelte';
-    import { DB, Galleries, Projects } from '@db/Database';
+    import { DB, Galleries } from '@db/Database';
+    import { Projects } from '@db/projects/Projects';
     import type Project from '@db/projects/Project';
     import { untrack, onMount } from 'svelte';
     import { writable } from 'svelte/store';

--- a/src/routes/[[locale]]/projects/+page.svelte
+++ b/src/routes/[[locale]]/projects/+page.svelte
@@ -12,7 +12,7 @@
     import LocalizedText from '@components/widgets/LocalizedText.svelte';
     import TextField from '@components/widgets/TextField.svelte';
     import Title from '@components/widgets/Title.svelte';
-    import { authAttempted, DB, locales, Projects } from '@db/Database';
+    import { DB, LoadedProjects, authAttempted, locales } from '@db/Database';
     import { onMount } from 'svelte';
     import type Project from '@db/projects/Project';
     import { searchProjects, type ProjectMatch } from './search';
@@ -31,7 +31,7 @@
     const debouncedTerm = debounced(() => searchTerm);
 
     let allOwnedProjects = $derived(
-        Projects.allEditableProjects.filter(
+        ($LoadedProjects?.allEditableProjects ?? []).filter(
             (p) => p.getOwner() === $user?.uid || !p.hasOwner(),
         ),
     );
@@ -39,7 +39,7 @@
     let allSharedProjects = $derived(
         !isAuthenticated($user)
             ? []
-            : Projects.allEditableProjects.filter(
+            : ($LoadedProjects?.allEditableProjects ?? []).filter(
                   (p) => p.hasOwner() && p.getOwner() !== $user.uid,
               ),
     );
@@ -49,7 +49,9 @@
     $effect(() => {
         if (!isAuthenticated($user)) return;
 
-        commenterViewerProjects = [...Projects.readonlyProjects.values()]
+        commenterViewerProjects = [
+            ...($LoadedProjects?.readonlyProjects.values() ?? []),
+        ]
             .filter((project) => project !== undefined)
             .filter((project) => {
                 return (
@@ -62,7 +64,7 @@
 
     // Add archived projects to search scope
     let allArchivedProjects = $derived(
-        Projects.allArchivedProjects.filter(
+        ($LoadedProjects?.allArchivedProjects ?? []).filter(
             (p) => p.getOwner() === $user?.uid || !p.hasOwner(),
         ),
     );
@@ -133,8 +135,8 @@
              a `$user === undefined` gate would hide the button forever. -->
         <AddProject
             ready={$authAttempted}
-            add={(template) => {
-                const newProjectID = Projects.copy(
+            add={async (template) => {
+                const newProjectID = (await DB.loadProjects()).copy(
                     template,
                     $user?.uid ?? null,
                     null,
@@ -144,7 +146,7 @@
         />
     </div>
 
-    {#if !browser || !Projects.hydrated}
+    {#if !browser || !($LoadedProjects?.hydrated ?? false)}
         <!-- Show the placeholder where the project list will appear, so the
              user has feedback instead of staring at an empty page during the
              gap between mount and the first IndexedDB emission.
@@ -176,8 +178,10 @@
             }}
             copy={{
                 description: (l) => l.ui.project.button.remix.tip,
-                action: (project) =>
-                    localeGoto(Projects.remix(project).getLink(false)),
+                action: async (project) =>
+                    localeGoto(
+                        (await DB.loadProjects()).remix(project).getLink(false),
+                    ),
                 label: REMIX_SYMBOL,
             }}
             remove={(project) => {
@@ -185,8 +189,11 @@
                     prompt: (l) => l.ui.page.projects.confirm.archive.prompt,
                     description: (l) =>
                         l.ui.page.projects.confirm.archive.description,
-                    action: () =>
-                        Projects.archiveProject(project.getID(), true),
+                    action: async () =>
+                        (await DB.loadProjects()).archiveProject(
+                            project.getID(),
+                            true,
+                        ),
                     label: '🗑️',
                 };
             }}
@@ -196,7 +203,7 @@
     {/if}
 
     <!-- If there are any shared projects, make a shared section. -->
-    {#if Projects.hydrated && shared.length + commenterViewerProjects.length > 0}
+    {#if ($LoadedProjects?.hydrated ?? false) && shared.length + commenterViewerProjects.length > 0}
         <Subheader text={(l) => l.ui.page.projects.subheader.shared} />
         <ProjectPreviewSet
             set={shared.concat(commenterViewerProjects)}
@@ -209,8 +216,10 @@
             }}
             copy={{
                 description: (l) => l.ui.project.button.remix.tip,
-                action: (project) =>
-                    localeGoto(Projects.remix(project).getLink(false)),
+                action: async (project) =>
+                    localeGoto(
+                        (await DB.loadProjects()).remix(project).getLink(false),
+                    ),
                 label: REMIX_SYMBOL,
             }}
             remove={() => false}
@@ -220,7 +229,7 @@
     {/if}
 
     <!-- If there are archived projects in search results, show them -->
-    {#if Projects.hydrated && debouncedTerm.current.trim() && archived.length > 0}
+    {#if ($LoadedProjects?.hydrated ?? false) && debouncedTerm.current.trim() && archived.length > 0}
         <Subheader text={(l) => l.ui.page.projects.subheader.archived} />
         <ProjectPreviewSet
             set={archived}
@@ -228,8 +237,11 @@
             matchTexts={archivedMatchTexts}
             edit={{
                 description: (l) => l.ui.page.projects.button.unarchive,
-                action: (project) =>
-                    Projects.archiveProject(project.getID(), false),
+                action: async (project) =>
+                    (await DB.loadProjects()).archiveProject(
+                        project.getID(),
+                        false,
+                    ),
                 label: '↑🗑️',
             }}
             copy={false}
@@ -242,10 +254,12 @@
                               l.ui.page.projects.confirm.delete.prompt,
                           description: (l) =>
                               l.ui.page.projects.confirm.delete.description,
-                          action: () => {
+                          action: async () => {
                               deleteError = false;
                               try {
-                                  Projects.deleteProject(project.getID());
+                                  (await DB.loadProjects()).deleteProject(
+                                      project.getID(),
+                                  );
                               } catch (error) {
                                   deleteError = true;
                                   console.error(error);
@@ -258,7 +272,7 @@
     {/if}
 
     <!-- If there are any archived projects, make an archived section. -->
-    {#if Projects.hydrated && Projects.allArchivedProjects.length > 0}
+    {#if ($LoadedProjects?.hydrated ?? false) && ($LoadedProjects?.allArchivedProjects.length ?? 0) > 0}
         <Subheader text={(l) => l.ui.page.projects.subheader.archived} />
         <MarkupHTMLView markup={(l) => l.ui.page.projects.archiveprompt} />
         {#if $user === null}<Notice
@@ -268,11 +282,14 @@
             <Notice text={(l) => l.ui.page.projects.error.delete} />
         {/if}
         <ProjectPreviewSet
-            set={Projects.allArchivedProjects}
+            set={$LoadedProjects?.allArchivedProjects ?? []}
             edit={{
                 description: (l) => l.ui.page.projects.button.unarchive,
-                action: (project) =>
-                    Projects.archiveProject(project.getID(), false),
+                action: async (project) =>
+                    (await DB.loadProjects()).archiveProject(
+                        project.getID(),
+                        false,
+                    ),
                 label: '↑',
             }}
             copy={false}
@@ -285,10 +302,12 @@
                               l.ui.page.projects.confirm.delete.prompt,
                           description: (l) =>
                               l.ui.page.projects.confirm.delete.description,
-                          action: () => {
+                          action: async () => {
                               deleteError = false;
                               try {
-                                  Projects.deleteProject(project.getID());
+                                  (await DB.loadProjects()).deleteProject(
+                                      project.getID(),
+                                  );
                               } catch (error) {
                                   deleteError = true;
                                   console.error(error);

--- a/src/runtime/Evaluator.ts
+++ b/src/runtime/Evaluator.ts
@@ -1,3 +1,4 @@
+import { Projects } from '@db/projects/Projects';
 import ConversionDefinition from '@nodes/ConversionDefinition';
 import Expression from '@nodes/Expression';
 import FunctionDefinition from '@nodes/FunctionDefinition';
@@ -1164,7 +1165,7 @@ export default class Evaluator {
                     current.code.toString() !== valueText
                 ) {
                     // Revise the project with the new or overwritten source.
-                    const result = await this.database.Projects.reviseProject(
+                    const result = await Projects.reviseProject(
                         current
                             ? this.project.withSource(
                                   current,

--- a/src/util/importGraph.test.ts
+++ b/src/util/importGraph.test.ts
@@ -64,9 +64,11 @@ test('resolving a color needs no basis', () => {
  * are still reachable today — as each door closes, flip it to `false`.
  */
 test.each([
-    ['src/routes/+layout.svelte', 620, 4.6],
-    ['src/components/app/Page.svelte', 640, 4.8],
-    ['src/routes/[[locale]]/+page.svelte', 655, 4.8],
+    ['src/routes/+layout.svelte', 475, 3.35],
+    ['src/components/app/Page.svelte', 495, 3.55],
+    ['src/routes/[[locale]]/+page.svelte', 510, 3.6],
+    ['src/routes/[[locale]]/galleries/+page.svelte', 515, 3.65],
+    ['src/routes/[[locale]]/projects/+page.svelte', 515, 3.65],
 ])('%s stays within its import budget', (entry, maxFiles, maxMB) => {
     const reach = reachFrom(entry, Root);
     expect(
@@ -79,28 +81,32 @@ test.each([
     ).toBeLessThanOrEqual(maxMB);
 });
 
-test('the doors the runtime still comes through are the known ones', () => {
-    const reach = reachFrom('src/routes/+layout.svelte', Root);
-    /** The chain to a module, named by file, for a readable failure. */
-    const via = (target: string) =>
-        reach
-            .chainTo(target)
-            ?.map((f) => f.split('/').pop())
-            .join(' -> ');
-    // Markup no longer drags the editor and evaluator along: the segments that
-    // render code load on demand (see richSegment.ts). Keep it that way.
-    expect(
-        reach.files.has(Runtime.evaluator),
-        `evaluator via ${via(Runtime.evaluator)}`,
-    ).toBe(false);
-    expect(
-        reach.files.has(Runtime.commands),
-        `commands via ${via(Runtime.commands)}`,
-    ).toBe(false);
-    // One door left: the database still builds projects eagerly, so it carries
-    // the basis with it. That's the next stage; flip these when it lands.
-    expect(
-        reach.files.has(Runtime.project),
-        `project via ${via(Runtime.project)}`,
-    ).toBe(true);
+test('no page-wide chrome reaches the language runtime', () => {
+    // The layout, the footer, and the landing page are what every visitor
+    // loads. None of them runs code, so none of them may carry the machinery
+    // that does. Each of these was a real door once: markup rendering pulled
+    // the editor and evaluator, the database built projects eagerly, and the
+    // footer's notifications named projects by constructing them.
+    for (const entry of [
+        'src/routes/+layout.svelte',
+        'src/components/app/Page.svelte',
+        'src/routes/[[locale]]/+page.svelte',
+        // Listing projects doesn't require being able to run them: these
+        // render from stored data and load the runtime only on an action.
+        'src/routes/[[locale]]/galleries/+page.svelte',
+        'src/routes/[[locale]]/projects/+page.svelte',
+        'src/routes/[[locale]]/gallery/[galleryid]/+page.svelte',
+    ]) {
+        const reach = reachFrom(entry, Root);
+        for (const [name, target] of Object.entries(Runtime)) {
+            const chain = reach
+                .chainTo(target)
+                ?.map((f) => f.split('/').pop())
+                .join(' -> ');
+            expect(
+                reach.files.has(target),
+                `${entry} reaches ${name} via ${chain}`,
+            ).toBe(false);
+        }
+    }
 });

--- a/tests/end2end/localize-badges.spec.ts
+++ b/tests/end2end/localize-badges.spec.ts
@@ -35,11 +35,14 @@ const enUS: LocaleText = JSON.parse(
  * whenever another spec sharing this worker's account has created a project.
  */
 async function localizeOn(page: Page) {
-    await page
-        .getByRole('button', {
-            name: text(enUS.ui.localize.toggle.mode.off),
-        })
-        .click();
+    // Idempotent: these specs share an authenticated account, so the mode may
+    // already be on from a sibling test, and clicking again would turn it off.
+    // Wait for the toggle in either state first — `count()` doesn't wait, so
+    // asking before the footer renders reads zero and skips the click.
+    const enter = localizeButton(page, 'off');
+    const leave = localizeButton(page, 'on');
+    await expect(enter.or(leave)).toBeVisible({ timeout: 20000 });
+    if ((await leave.count()) === 0) await enter.click();
     await expect(page.getByText('Localize', { exact: true })).toBeVisible();
     await settled(page);
 }
@@ -50,11 +53,48 @@ async function localizeOn(page: Page) {
  * stand-in until it lands (see SegmentHTMLView), so a box measured before then
  * is a layout that is still one chunk away from final.
  */
+/** The footer's localize toggle button, found by accessible name rather than
+ *  by its ✎ glyph: project cards use the same glyph and precede the footer, so
+ *  a glyph locator silently measures a card instead. */
+function localizeButton(page: Page, state: 'on' | 'off') {
+    return page.getByRole('button', {
+        name: text(enUS.ui.localize.toggle.mode[state]),
+    });
+}
+
+/** The toggle whichever mode it's currently in, for measuring it. */
+function localizeButtonEitherState(page: Page) {
+    return page
+        .getByRole('button', {
+            name: new RegExp(
+                `${text(enUS.ui.localize.toggle.mode.off)}|${text(
+                    enUS.ui.localize.toggle.mode.on,
+                )}`.replace(/[.*+?^${}()|[\]\\]/g, (c) =>
+                    c === '|' ? '|' : `\\${c}`,
+                ),
+            ),
+        })
+        .first();
+}
+
+/** The group wrapping that button, which is what the badges pin to. */
+function localizeGroup(page: Page, state: 'on' | 'off') {
+    return localizeButton(page, state).locator(
+        'xpath=ancestor::span[contains(@class,"toggle-group")][1]',
+    );
+}
+
 async function settled(page: Page) {
     await expect(page.locator('.rich-loading')).toHaveCount(0);
 }
 
 async function size(locator: Locator) {
+    // Wait for the element itself, not merely for the absence of loading
+    // markers: an "is nothing loading" check is satisfied before anything has
+    // rendered at all.
+    // Generous: the footer's overflow toolbar measures itself and can move
+    // controls in and out while the page around it is still settling.
+    await expect(locator).toBeVisible({ timeout: 20000 });
     const box = await locator.boundingBox();
     expect(box).not.toBeNull();
     // Width and height only: the mode's header banner shifts everything down the
@@ -69,13 +109,9 @@ test('turning on localization mode does not resize the controls it annotates', a
     await settled(page);
 
     const gear = page.getByRole('button', { name: 'show settings dialog' });
-    const toggle = page
-        .locator('.toggle-group')
-        .filter({ hasText: '✎' })
-        .first()
-        // The toggle's own button, which precedes the badge buttons the mode adds.
-        .locator('button')
-        .first();
+    // Located by accessible name, not by the ✎ glyph: project cards use the
+    // same glyph and precede the footer, so a glyph locator measures a card.
+    const toggle = localizeButtonEitherState(page);
     const field = page.locator('#project-search');
 
     await expect(gear).toBeVisible();
@@ -95,14 +131,14 @@ test('turning on localization mode does not resize the controls it annotates', a
 test('a two-tip control pins one badge to each block-start corner', async ({
     page,
 }) => {
-    await page.goto('/en-US/projects');
+    // A page with no project-dependent content: this measures where the badges
+    // sit on the footer toggle, and on /projects the number of project cards
+    // the shared worker account happens to own reflows the footer around it.
+    await page.goto('/en-US/about');
     await localizeOn(page);
 
     // The localize toggle itself has an on tip and an off tip.
-    const group = page
-        .locator('.toggle-group')
-        .filter({ hasText: '✎' })
-        .first();
+    const group = localizeGroup(page, 'on');
     const groupBox = (await group.boundingBox())!;
     const badges = group.locator('.tip-badge');
     await expect(badges).toHaveCount(2);


### PR DESCRIPTION
# Context

Follows #1280. That took the runtime off the *markup* path; this takes it off the *database* path, which was the remaining ~1.7MB. `Database` owned `ProjectsDatabase`, which owns `Project` — and `Project` is the basis, the nodes, the evaluator, and the output layer. So every page that imported `@db/Database` for a locale store carried the whole language with it. Listing projects doesn't require being able to run them.

## What this does

The `Projects` singleton moves into `src/db/projects/Projects.ts`, a module that only ever evaluates inside the deferred chunk. `Database` holds it behind `loadProjects()`, with `MaybeProjects` for synchronous paths where "not loaded" correctly means "nothing in memory to act on" (unsaved counts read from `beforeunload`, reconnect flushes, locale re-sync), and a `LoadedProjects` store for views that must re-render when it arrives.

The database facades (gallery, character, chat) load it on demand rather than importing it. `Notifications` and the chat's notification path read a project's name and gallery from its stored document via a new `getProjectSummary()` instead of constructing a `Project` to ask its name — that path renders in the footer on every page. Preview tiles render from a light `previewTypes` module, `previewQueue` imports the evaluator inside its already-async job, and the list routes read projects reactively, loading on demand only when you act (remix, archive, delete, create).

**Every browsing route is now free of it:**

| entry | before #1280 | after #1280 | now |
| --- | --- | --- | --- |
| root layout | 903 files / 6.38MB | 609 / 4.45MB | **463 / 3.25MB** |
| footer (`Page.svelte`) | 919 / 6.55MB | 628 / 4.63MB | **482 / 3.43MB** |
| landing page | 928 / 6.57MB | 640 / 4.68MB | **494 / 3.48MB** |
| galleries | — | 653 / 4.82MB | **499 / 3.51MB** |
| projects | — | 655 / 4.81MB | **500 / 3.51MB** |
| one gallery | — | — | **506 / 3.51MB** |

Landing-page JS **2962KB → 2517KB**; click→galleries at 6× CPU throttle **1481ms → 621ms** (originally 1804ms). Only `/learn` and `/project/[id]` still carry the runtime, which is correct. The import guard now covers all six light entries and fails with the offending import chain if any of them reaches `Basis`, `Evaluator`, or `Project` again.

## Three defects the WebKit suite caught

All three were invisible in Chromium, whose timing happened to hide them. This is the argument for running that suite on import-graph changes.

- **`MaybeProjects` read a plain field**, so a `$derived` captured `undefined` and never re-ran — the projects page stayed permanently empty. It's a store now.
- **`startSync` skipped the projects domain** when the database wasn't loaded, so a signed-in creator's projects never arrived from the cloud. Being signed in *is* having project work, so it loads.
- **Renaming a character** rewrites the projects referencing it, which reads loaded projects. The character page brings them in on mount, and `ProjectsDatabase.start()` now resolves when projects are actually in memory rather than when the subscription is merely set up.

I also fixed a latent contrast bug this exposed: hint entries dimmed secondary-locale echoes and shortcut suffixes with `opacity: 0.7`, which lands at ~3:1 and fails AA whenever a hint is on screen during a scan. It passed before only because the hint wasn't visible when axe ran.

## Related issues

Continues the performance work from #1280. No tracking issue.

-   Related Issue #
-   Closes #

## Verification

- `npm run check:now` clean; **`npm test` green (5109)**.
- **Full Chromium e2e: 136 passed.**
- **Full WebKit e2e on macOS: 135 passed, 1 skipped** — identical to clean `main`, which I ran as a baseline to confirm the failures above were mine rather than pre-existing.
- Two test fixes, both correcting real fragility rather than accommodating the change: `localize-badges` located the footer toggle by its `✎` glyph, which project cards also use and which precede it in DOM order (the file's own comment warns about exactly this), and its `localizeOn` helper used a non-waiting `count()` that read zero before the footer rendered.

**Not yet done:** mobile Safari on device. Desktop Chrome and Safari were confirmed noticeably faster on #1280; this should improve both fresh loads and reloads further, but the phone is where it matters and only you can check it.

## Checklist

-   [ ] Mobile Safari pass on iPhone
-   [ ] Follow-up: emoji UI subset font (~2839KB → ~253KB in Safari). Download-only saving; won't change how anything feels on wifi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
