### PR TITLE
Link previews and sitemap for public projects and galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 ### Added
 
 - 🔠 We added a new example called Chamber to the [galleries](https://wordplay.dev/galleries). A hundred letters from four writing systems bounce around a sealed box, and you can turn gravity off or shake them all up again.
+- 🔗 When you share a link to a public project or gallery, it now shows its name and description in chat apps and on social media. We also added a site map so search engines can find public projects and [galleries](https://wordplay.dev/galleries). (#1133)
 
 ### Changed
 

--- a/firebase.json
+++ b/firebase.json
@@ -39,6 +39,22 @@
                 }
             },
             {
+                "regex": "^(?:/[A-Za-z0-9_+-]+)?/(?:project|gallery)/[^/]+/?$",
+                "function": {
+                    "functionId": "getPagePreview",
+                    "region": "us-central1",
+                    "pinTag": true
+                }
+            },
+            {
+                "source": "/sitemap.xml",
+                "function": {
+                    "functionId": "getSitemap",
+                    "region": "us-central1",
+                    "pinTag": true
+                }
+            },
+            {
                 "source": "**",
                 "destination": "/200.html"
             }

--- a/functions/src/getPagePreview.ts
+++ b/functions/src/getPagePreview.ts
@@ -1,0 +1,222 @@
+import type express from 'express';
+import type { Request } from 'firebase-functions/v2/https';
+import {
+    ExampleGalleries,
+    ExamplePrefix,
+    getStringField,
+    getStringMapField,
+    injectPreviewHead,
+    parsePreviewPath,
+    parseWpProjectName,
+    pickLocalizedText,
+    resolveMultilingualName,
+    withoutAnnotations,
+    type FirestoreRestDocument,
+    type PreviewMeta,
+    type PreviewTarget,
+} from './preview/shared.js';
+
+/**
+ * Serves project and gallery URLs (via Firebase Hosting rewrites) as the SPA
+ * shell with server-injected <title>/og:* metadata, so shared links unfurl
+ * and crawlers see real titles (#1133). Public docs are read through the
+ * Firestore REST API with no credentials, so security rules — not this code —
+ * decide what is visible; private or missing docs get the shell untouched,
+ * which is exactly what static hosting served before this function existed.
+ */
+
+const FETCH_TIMEOUT_MS = 5000;
+const SHELL_TTL_MS = 60_000;
+const LOCALE_TTL_MS = 60 * 60_000;
+
+/**
+ * The canonical origin, derived from the project rather than request headers:
+ * header-derived origins would be attacker-controlled text in the emitted
+ * HTML, and a wrong guess could make the shell fetch below recurse into this
+ * very function.
+ */
+export function canonicalOrigin(): string {
+    if (process.env.FUNCTIONS_EMULATOR === 'true')
+        return process.env.WORDPLAY_HOSTING_ORIGIN ?? 'http://127.0.0.1:5002';
+    return process.env.GCLOUD_PROJECT === 'wordplay-prod'
+        ? 'https://wordplay.dev'
+        : 'https://test.wordplay.dev';
+}
+
+async function fetchText(url: string): Promise<string | undefined> {
+    try {
+        const response = await fetch(url, {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (!response.ok) return undefined;
+        return await response.text();
+    } catch (error) {
+        console.error(`GET ${url} failed`, error);
+        return undefined;
+    }
+}
+
+/** In-memory caches; per-instance, refreshed on TTL and kept stale on error. */
+let shellCache: { html: string; fetched: number } | undefined;
+const localeCache = new Map<string, { json: unknown; fetched: number }>();
+
+async function getShell(origin: string): Promise<string | undefined> {
+    if (shellCache && Date.now() - shellCache.fetched < SHELL_TTL_MS)
+        return shellCache.html;
+    const html = await fetchText(`${origin}/200.html`);
+    // Guard against a proxy error page or truncated read; stale is better.
+    if (html !== undefined && html.includes('</head>'))
+        shellCache = { html, fetched: Date.now() };
+    return shellCache?.html;
+}
+
+/** The `gallery` block of a locale's JSON, fetched from hosting's static assets. */
+async function getLocaleGalleryText(
+    origin: string,
+    locale: string,
+): Promise<
+    Record<string, { name?: string; description?: string }> | undefined
+> {
+    // The locale segment was decoded from a URL; only fetch plausible locale codes.
+    if (!/^[A-Za-z0-9-]{2,20}$/.test(locale)) return undefined;
+    const cached = localeCache.get(locale);
+    if (cached && Date.now() - cached.fetched < LOCALE_TTL_MS)
+        return asGalleryText(cached.json);
+    const text = await fetchText(`${origin}/locales/${locale}/${locale}.json`);
+    if (text === undefined) return asGalleryText(cached?.json);
+    try {
+        const json: unknown = JSON.parse(text);
+        localeCache.set(locale, { json, fetched: Date.now() });
+        return asGalleryText(json);
+    } catch {
+        return asGalleryText(cached?.json);
+    }
+}
+
+function asGalleryText(
+    json: unknown,
+): Record<string, { name?: string; description?: string }> | undefined {
+    if (json === undefined || json === null || typeof json !== 'object')
+        return undefined;
+    const gallery = (json as Record<string, unknown>)['gallery'];
+    if (gallery === null || typeof gallery !== 'object') return undefined;
+    return gallery as Record<string, { name?: string; description?: string }>;
+}
+
+async function fetchFirestoreDoc(
+    collection: 'projects' | 'galleries',
+    id: string,
+): Promise<FirestoreRestDocument | undefined> {
+    const project = process.env.GCLOUD_PROJECT ?? 'demo-wordplay';
+    const emulator = process.env.FIRESTORE_EMULATOR_HOST;
+    const base = emulator
+        ? `http://${emulator}`
+        : 'https://firestore.googleapis.com';
+    const text = await fetchText(
+        `${base}/v1/projects/${project}/databases/(default)/documents/${collection}/${encodeURIComponent(id)}`,
+    );
+    if (text === undefined) return undefined;
+    try {
+        return JSON.parse(text) as FirestoreRestDocument;
+    } catch {
+        return undefined;
+    }
+}
+
+/** The preview metadata for a target, or undefined to serve the plain shell. */
+async function resolveMeta(
+    target: PreviewTarget,
+    origin: string,
+): Promise<PreviewMeta | undefined> {
+    const languages = target.locales.map((locale) => locale.split('-')[0]);
+    const localePrefix =
+        target.locales.length > 0 ? `/${target.locales.join('+')}` : '';
+    const url = `${origin}${localePrefix}/${target.kind}/${encodeURIComponent(target.id)}`;
+
+    if (target.kind === 'project') {
+        if (target.id.startsWith(ExamplePrefix)) {
+            const wp = await fetchText(
+                `${origin}/examples/${encodeURIComponent(target.id.substring(ExamplePrefix.length))}.wp`,
+            );
+            // A hosting SPA fallback can serve HTML with a 200; mirror getExample's guard.
+            if (wp === undefined || wp.trimStart().startsWith('<'))
+                return undefined;
+            const raw = parseWpProjectName(wp);
+            if (raw === undefined) return undefined;
+            return { title: resolveMultilingualName(raw, languages), url };
+        }
+        const doc = await fetchFirestoreDoc('projects', target.id);
+        if (doc === undefined) return undefined;
+        const raw = getStringField(doc, 'name');
+        if (raw === undefined || raw.trim().length === 0) return undefined;
+        return { title: resolveMultilingualName(raw.trim(), languages), url };
+    }
+
+    const example = ExampleGalleries[target.id];
+    if (example !== undefined) {
+        let name = example.name;
+        let description = example.description;
+        const primary = target.locales[0];
+        if (primary !== undefined && primary !== 'en-US') {
+            const galleryText = await getLocaleGalleryText(origin, primary);
+            const localized = galleryText?.[example.localeKey];
+            const localizedName = withoutAnnotations(localized?.name ?? '');
+            const localizedDescription = withoutAnnotations(
+                localized?.description ?? '',
+            );
+            if (localizedName.length > 0) name = localizedName;
+            if (localizedDescription.length > 0)
+                description = localizedDescription;
+        }
+        return { title: name, description, url };
+    }
+
+    const doc = await fetchFirestoreDoc('galleries', target.id);
+    if (doc === undefined) return undefined;
+    const title = pickLocalizedText(
+        getStringMapField(doc, 'name'),
+        target.locales,
+    );
+    if (title === undefined) return undefined;
+    return {
+        title,
+        description: pickLocalizedText(
+            getStringMapField(doc, 'description'),
+            target.locales,
+        ),
+        url,
+    };
+}
+
+export default async function getPagePreview(
+    request: Request,
+    response: express.Response,
+): Promise<void> {
+    const origin = canonicalOrigin();
+    const shell = await getShell(origin);
+    if (shell === undefined) {
+        // Nothing to serve yet (cold start and hosting unreachable); let the
+        // CDN retry rather than emitting a broken page.
+        response.status(503).set('Retry-After', '30').send('');
+        return;
+    }
+
+    const target = parsePreviewPath(request.path);
+    const meta =
+        target === undefined ? undefined : await resolveMeta(target, origin);
+
+    response.set('Content-Type', 'text/html; charset=utf-8');
+    // Successful previews cache longer at the CDN; misses (private, missing,
+    // or Firestore trouble) cache briefly so a newly-published doc appears
+    // promptly. Tradeoff: a project made private can keep its cached *title*
+    // (nothing more) at the CDN for up to five minutes.
+    response.set(
+        'Cache-Control',
+        meta !== undefined
+            ? 'public, max-age=0, s-maxage=300'
+            : 'public, max-age=0, s-maxage=60',
+    );
+    response
+        .status(200)
+        .send(meta === undefined ? shell : injectPreviewHead(shell, meta));
+}

--- a/functions/src/getSitemap.ts
+++ b/functions/src/getSitemap.ts
@@ -1,0 +1,119 @@
+import type express from 'express';
+import type { Request } from 'firebase-functions/v2/https';
+import { canonicalOrigin } from './getPagePreview.js';
+import {
+    buildSitemapXml,
+    documentIdFromName,
+    ExampleGalleries,
+    ExamplePrefix,
+    getBooleanField,
+    StaticSitemapPaths,
+    type FirestoreRestDocument,
+} from './preview/shared.js';
+
+/**
+ * Serves /sitemap.xml (via a Firebase Hosting rewrite): the prerendered
+ * public routes, the built-in example galleries and projects, and the
+ * public projects and galleries in Firestore (#1133). Reads use the
+ * Firestore REST API with no credentials, filtered on `public == true` —
+ * the one filter the security rules provably allow for unauthenticated
+ * list queries (the same query the galleries page runs client-side) —
+ * with `listed`/`archived` narrowed in code afterward.
+ */
+
+const FETCH_TIMEOUT_MS = 10_000;
+const QUERY_LIMIT = 5000;
+
+async function queryPublicDocs(
+    collection: 'projects' | 'galleries',
+    fields: string[],
+): Promise<FirestoreRestDocument[] | undefined> {
+    const project = process.env.GCLOUD_PROJECT ?? 'demo-wordplay';
+    const emulator = process.env.FIRESTORE_EMULATOR_HOST;
+    const base = emulator
+        ? `http://${emulator}`
+        : 'https://firestore.googleapis.com';
+    try {
+        const response = await fetch(
+            `${base}/v1/projects/${project}/databases/(default)/documents:runQuery`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+                body: JSON.stringify({
+                    structuredQuery: {
+                        from: [{ collectionId: collection }],
+                        where: {
+                            fieldFilter: {
+                                field: { fieldPath: 'public' },
+                                op: 'EQUAL',
+                                value: { booleanValue: true },
+                            },
+                        },
+                        select: {
+                            fields: fields.map((fieldPath) => ({ fieldPath })),
+                        },
+                        limit: QUERY_LIMIT,
+                    },
+                }),
+            },
+        );
+        if (!response.ok) {
+            console.error(
+                `${collection} query failed: ${response.status} ${await response.text()}`,
+            );
+            return undefined;
+        }
+        const results = (await response.json()) as {
+            document?: FirestoreRestDocument;
+        }[];
+        return results
+            .map((result) => result.document)
+            .filter(
+                (doc): doc is FirestoreRestDocument =>
+                    doc !== undefined && doc.name !== undefined,
+            );
+    } catch (error) {
+        console.error(`${collection} query failed`, error);
+        return undefined;
+    }
+}
+
+export default async function getSitemap(
+    _: Request,
+    response: express.Response,
+): Promise<void> {
+    const origin = canonicalOrigin();
+    const urls = StaticSitemapPaths.map((path) =>
+        path === '/' ? origin : `${origin}${path}`,
+    );
+
+    for (const id of Object.keys(ExampleGalleries)) {
+        urls.push(`${origin}/gallery/${id}`);
+        for (const name of ExampleGalleries[id].projects)
+            urls.push(`${origin}/project/${ExamplePrefix}${name}`);
+    }
+
+    // On a Firestore failure the static portion still ships; the CDN's stale
+    // copy usually covers the gap, so a partial sitemap beats an error.
+    const projects = await queryPublicDocs('projects', ['listed', 'archived']);
+    if (projects !== undefined)
+        for (const doc of projects) {
+            if (getBooleanField(doc, 'listed') !== true) continue;
+            if (getBooleanField(doc, 'archived') === true) continue;
+            urls.push(
+                `${origin}/project/${encodeURIComponent(documentIdFromName(doc.name ?? ''))}`,
+            );
+        }
+
+    const galleries = await queryPublicDocs('galleries', ['public']);
+    if (galleries !== undefined)
+        for (const doc of galleries)
+            urls.push(
+                `${origin}/gallery/${encodeURIComponent(documentIdFromName(doc.name ?? ''))}`,
+            );
+
+    response.set('Content-Type', 'application/xml; charset=utf-8');
+    response.set('Cache-Control', 'public, max-age=3600, s-maxage=86400');
+    response.status(200).send(buildSitemapXml(urls));
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,6 +26,8 @@ import getTranslationsHandler, {
 } from './getTranslations.js';
 import getLLMTranslationsHandler from './getLLMTranslations.js';
 import analyzeLocalizationHandler from './analyzeLocalization.js';
+import getPagePreviewHandler from './getPagePreview.js';
+import getSitemapHandler from './getSitemap.js';
 import getWebpageHandler from './getWebpage.js';
 import postFeedbackHandler from './postFeedback.js';
 import purgeArchivedProjectsHandler from './purgeArchivedProjects.js';
@@ -94,6 +96,12 @@ export const analyzeLocalization = onCall<AnalyzeLocalizationInputs>(
 
 /** Given a URL that should refer to an HTML document, sends a GET request to the URL to try to get the document's text. */
 export const getWebpage = onRequest(cors, getWebpageHandler);
+
+/** Serves project/gallery URLs (hosting rewrite) as the SPA shell with injected title/og metadata for public docs (#1133). */
+export const getPagePreview = onRequest(cors, getPagePreviewHandler);
+
+/** Serves /sitemap.xml (hosting rewrite): static routes, examples, and public Firestore projects/galleries (#1133). */
+export const getSitemap = onRequest(cors, getSitemapHandler);
 
 /** Every day, delete projects that were archived more than 30 days ago. */
 export const purgeArchivedProjects = onSchedule(

--- a/functions/src/preview/shared.ts
+++ b/functions/src/preview/shared.ts
@@ -1,0 +1,402 @@
+/**
+ * Pure logic shared by the page-preview and sitemap functions (#1133).
+ *
+ * This module must stay dependency-free: it is compiled by the functions
+ * tsconfig for deployment AND imported directly by the root test suite
+ * (src/examples/previewShared.test.ts, src/examples/exampleManifestSync.test.ts),
+ * which runs it under the app's tsconfig. The example manifest below duplicates
+ * data from src/examples/examples.ts and src/locale/en-US.json on purpose —
+ * functions/ cannot import src/ — and the sync test fails `npm test` if they
+ * drift.
+ */
+
+/** Mirrors ExamplePrefix in src/examples/examples.ts. */
+export const ExamplePrefix = 'example-';
+
+export type ExampleGalleryInfo = {
+    /** The key under `gallery` in each locale's JSON file. */
+    localeKey: string;
+    /** en-US name/description fallbacks; en-US.json is not served as a static asset. */
+    name: string;
+    description: string;
+    /** Example project names; ids are ExamplePrefix + name. */
+    projects: string[];
+};
+
+export const ExampleGalleries: Record<string, ExampleGalleryInfo> = {
+    Games: {
+        localeKey: 'games',
+        name: 'Games',
+        description: 'Interactive games with words and symbols.',
+        projects: [
+            'HeartAttack',
+            'ShowAndTell',
+            'BuildingBlocks',
+            'Adventure',
+            'BasketballStar',
+            'HummingBird',
+            'Maze',
+            'WhatWord',
+            'Catch',
+            'Madlib',
+            'WheresWaldough',
+            'KatakanaGuess',
+            'FrenchNumbers',
+        ],
+    },
+    Visualizations: {
+        localeKey: 'visualizations',
+        name: 'Visualizations',
+        description: 'Visualizations of and via text.',
+        projects: [
+            'Amplitude',
+            'PointerTrail',
+            'CodeGap',
+            'Garden',
+            'Letters',
+            'Poem',
+            'Questions',
+            'RainingKitties',
+            'RotatingBinary',
+            'FontMachine',
+            'Pumpkin',
+            'Size',
+            'FloatingFoods',
+            'AnimatedName',
+            'WordplayTrace',
+        ],
+    },
+    Motion: {
+        localeKey: 'motion',
+        name: 'Motion',
+        description: 'Examples of movement and collisions.',
+        projects: [
+            'Hira',
+            'Layers',
+            'Chamber',
+            'Pounce',
+            'FootBall',
+            'Christmas',
+            'Easing',
+            'Echo',
+        ],
+    },
+    Music: {
+        localeKey: 'music',
+        name: 'Music',
+        description:
+            'Songs, instruments, and typography that moves to the beat.',
+        projects: [
+            'Instruments',
+            'Birthday',
+            'Conductor',
+            'RowYourBoat',
+            'CatScat',
+            'Chimes',
+            'Fireworks',
+            'Lyrics',
+        ],
+    },
+    AV: {
+        localeKey: 'av',
+        name: 'Audio/Video',
+        description:
+            'Using volume, pitch, and video as input, and speech as output.',
+        projects: [
+            'Listen',
+            'Talk',
+            'SpokenWords',
+            'RainingLetters',
+            'Video',
+            'PitchNotes',
+            'Hand',
+            'Face',
+            'FaceTalk',
+        ],
+    },
+    Stories: {
+        localeKey: 'stories',
+        name: 'Stories',
+        description: 'Interactive stories and narratives.',
+        projects: ['Pears', 'JapaneseClass', 'PersonalMap', 'SlideShow'],
+    },
+    Tools: {
+        localeKey: 'tools',
+        name: 'Tools',
+        description: 'Simple utilities and applications.',
+        projects: [
+            'Calculator',
+            'Clock',
+            'Literacy',
+            'Timer',
+            'Headlines',
+            'SentenceLength',
+            'StudyModeMeter',
+            'Patterns',
+            'Chatterbox',
+        ],
+    },
+};
+
+export function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+/** Mirrors src/locale/withoutAnnotations.ts (markers from src/locale/Annotations.ts). */
+export function withoutAnnotations(text: string): string {
+    return text
+        .replace(/\$\?/g, '')
+        .replace(/\$!/g, '')
+        .replace(/\$~/g, '')
+        .trim();
+}
+
+export type PreviewTarget = {
+    kind: 'project' | 'gallery';
+    id: string;
+    /** Locales from the URL's optional `+`-joined locale segment, e.g. ['en-US','es-MX']. */
+    locales: string[];
+};
+
+/**
+ * Parse a `/project/<id>`, `/gallery/<id>`, or locale-prefixed variant.
+ * Returns undefined for anything else, in which case the caller serves the
+ * shell untouched — the hosting rewrite regex should make that unreachable,
+ * but the function must not trust it.
+ */
+export function parsePreviewPath(path: string): PreviewTarget | undefined {
+    let segments;
+    try {
+        segments = path
+            .split('/')
+            .filter((segment) => segment.length > 0)
+            .map(decodeURIComponent);
+    } catch {
+        return undefined;
+    }
+    const locales =
+        segments.length === 3 ? segments[0].split('+').filter(Boolean) : [];
+    const rest = segments.length === 3 ? segments.slice(1) : segments;
+    if (rest.length !== 2) return undefined;
+    const [kind, id] = rest;
+    if (kind !== 'project' && kind !== 'gallery') return undefined;
+    if (id.length === 0) return undefined;
+    return { kind, id, locales };
+}
+
+/** Mirrors TextCloseByTextOpen in src/parser/Tokenizer.ts. */
+const TextCloseByTextOpen: Record<string, string> = {
+    '"': '"',
+    '“': '”',
+    '„': '“',
+    "'": "'",
+    '‘': '’',
+    '‹': '›',
+    '«': '»',
+    '「': '」',
+    '『': '』',
+    '`': '`',
+};
+
+/**
+ * Resolve a project name that may be a multilingual Wordplay TextLiteral,
+ * e.g. `"project"/en"proyecto"/es` — a simplified mirror of
+ * src/db/projects/getLocalizedProjectName.ts, matching its contract: only a
+ * string that parses cleanly end-to-end as language-tagged translations is
+ * treated as multilingual; anything else renders raw.
+ */
+export function resolveMultilingualName(
+    raw: string,
+    languages: string[],
+): string {
+    if (raw.length === 0) return raw;
+    const close = TextCloseByTextOpen[raw[0]];
+    if (close === undefined) return raw;
+
+    const translations: { text: string; language: string }[] = [];
+    let position = 0;
+    while (position < raw.length) {
+        const open = raw[position];
+        const closer = TextCloseByTextOpen[open];
+        if (closer === undefined) return raw;
+        const end = raw.indexOf(closer, position + 1);
+        if (end < 0) return raw;
+        const text = raw.substring(position + 1, end);
+        position = end + 1;
+        if (raw[position] !== '/') return raw;
+        position++;
+        const language = /^[a-zA-Z]+/.exec(raw.substring(position))?.[0];
+        if (language === undefined || language.length === 0) return raw;
+        position += language.length;
+        translations.push({ text, language });
+    }
+    if (translations.length === 0) return raw;
+    const preferred = translations.find((translation) =>
+        languages.includes(translation.language),
+    );
+    return (preferred ?? translations[0]).text;
+}
+
+/** Grapheme count, matching UnicodeString semantics for the preview-glyph check. */
+function graphemeCount(text: string): number {
+    const segmenter =
+        typeof Intl !== 'undefined' && 'Segmenter' in Intl
+            ? new Intl.Segmenter()
+            : undefined;
+    if (segmenter === undefined) return Array.from(text).length;
+    return Array.from(segmenter.segment(text)).length;
+}
+
+/**
+ * The project name from a `.wp` example file: an optional single-grapheme
+ * preview-glyph first line is peeled, then the next line is the (possibly
+ * multilingual) name — mirroring parseSerializedProject in
+ * src/examples/examples.ts.
+ */
+export function parseWpProjectName(wp: string): string | undefined {
+    let lines = wp.split('\n');
+    const first = (lines[0] ?? '').trim();
+    if (first.length > 0 && graphemeCount(first) === 1) lines = lines.slice(1);
+    const name = (lines[0] ?? '').trim();
+    return name.length > 0 ? name : undefined;
+}
+
+/**
+ * The best string from a locale-keyed record: exact locale match, then
+ * language match, then en-US, then anything — skipping entries that are
+ * empty once localization annotations are stripped.
+ */
+export function pickLocalizedText(
+    record: Record<string, string> | undefined,
+    locales: string[],
+): string | undefined {
+    if (record === undefined) return undefined;
+    const candidates: string[] = [];
+    for (const locale of locales) {
+        if (record[locale] !== undefined) candidates.push(record[locale]);
+        const language = locale.split('-')[0];
+        for (const key of Object.keys(record))
+            if (key.split('-')[0] === language) candidates.push(record[key]);
+    }
+    if (record['en-US'] !== undefined) candidates.push(record['en-US']);
+    candidates.push(...Object.values(record));
+    for (const candidate of candidates) {
+        const cleaned = withoutAnnotations(candidate);
+        if (cleaned.length > 0) return cleaned;
+    }
+    return undefined;
+}
+
+export type PreviewMeta = {
+    title: string;
+    description?: string;
+    url: string;
+};
+
+/**
+ * Inject preview metadata into the SPA shell: set/insert <title> and replace
+ * the content of the og:title / og:description / og:url tags app.html already
+ * carries. Plain string surgery — the shell's head is our own app.html, whose
+ * meta tags never contain a literal `>`.
+ */
+export function injectPreviewHead(shell: string, meta: PreviewMeta): string {
+    const title = escapeHtml(meta.title);
+    const url = escapeHtml(meta.url);
+    let html = shell;
+
+    const titleTag = `<title>${title}</title>`;
+    if (/<title>[^<]*<\/title>/.test(html))
+        html = html.replace(/<title>[^<]*<\/title>/, titleTag);
+    else html = html.replace('</head>', `${titleTag}\n    </head>`);
+
+    html = html.replace(
+        /<meta[^>]*property="og:title"[^>]*>/,
+        `<meta name="title" property="og:title" content="${title}" />`,
+    );
+    html = html.replace(
+        /<meta[^>]*property="og:url"[^>]*>/,
+        `<meta property="og:url" content="${url}" />`,
+    );
+    if (meta.description !== undefined) {
+        const description = escapeHtml(meta.description);
+        html = html.replace(
+            /<meta[^>]*property="og:description"[^>]*>/,
+            `<meta name="description" property="og:description" content="${description}" />`,
+        );
+    }
+    return html;
+}
+
+/** A Firestore REST API value; only the shapes the preview reads. */
+type FirestoreRestValue = {
+    stringValue?: string;
+    booleanValue?: boolean;
+    mapValue?: { fields?: Record<string, FirestoreRestValue> };
+};
+
+export type FirestoreRestDocument = {
+    name?: string;
+    fields?: Record<string, FirestoreRestValue>;
+};
+
+export function getStringField(
+    doc: FirestoreRestDocument,
+    field: string,
+): string | undefined {
+    return doc.fields?.[field]?.stringValue;
+}
+
+export function getBooleanField(
+    doc: FirestoreRestDocument,
+    field: string,
+): boolean | undefined {
+    return doc.fields?.[field]?.booleanValue;
+}
+
+export function getStringMapField(
+    doc: FirestoreRestDocument,
+    field: string,
+): Record<string, string> | undefined {
+    const fields = doc.fields?.[field]?.mapValue?.fields;
+    if (fields === undefined) return undefined;
+    const record: Record<string, string> = {};
+    for (const key of Object.keys(fields)) {
+        const value = fields[key].stringValue;
+        if (value !== undefined) record[key] = value;
+    }
+    return record;
+}
+
+/** The document id from a REST document resource name, e.g. ".../documents/projects/abc" → "abc". */
+export function documentIdFromName(name: string): string {
+    const segments = name.split('/');
+    return segments[segments.length - 1];
+}
+
+/**
+ * Routes worth listing in the sitemap: the prerendered public pages. Login,
+ * localize, and the logged-in surfaces are deliberately absent.
+ */
+export const StaticSitemapPaths = [
+    '/',
+    '/about',
+    '/learn',
+    '/guide',
+    '/galleries',
+    '/characters',
+    '/donate',
+    '/join',
+    '/rights',
+];
+
+export function buildSitemapXml(urls: string[]): string {
+    const entries = urls
+        .map((url) => `    <url><loc>${escapeHtml(url)}</loc></url>`)
+        .join('\n');
+    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+}

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,6 +8,7 @@
         "sourceMap": true,
         "strict": true,
         "target": "es2017",
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
         "rootDir": "src"
     },
     "compileOnSave": true,

--- a/src/examples/exampleManifestSync.test.ts
+++ b/src/examples/exampleManifestSync.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { expect, test } from 'vitest';
+import DefaultLocales from '@locale/DefaultLocales';
+import {
+    ExampleGalleries,
+    ExamplePrefix,
+} from '../../functions/src/preview/shared';
+import {
+    ExamplePrefix as SrcExamplePrefix,
+    getExampleGalleries,
+} from './examples';
+
+/**
+ * The preview/sitemap functions cannot import src/, so
+ * functions/src/preview/shared.ts carries a copy of the example-gallery
+ * manifest. These tests fail when the copy drifts from the source of truth
+ * here and in en-US.json.
+ */
+
+test('the functions example manifest matches examples.ts', () => {
+    expect(ExamplePrefix).toBe(SrcExamplePrefix);
+
+    const galleries = getExampleGalleries(DefaultLocales);
+    expect(Object.keys(ExampleGalleries).sort()).toEqual(
+        galleries.map((gallery) => gallery.getID()).sort(),
+    );
+    for (const gallery of galleries) {
+        const info = ExampleGalleries[gallery.getID()];
+        expect(info, `manifest entry for ${gallery.getID()}`).toBeDefined();
+        expect(
+            gallery
+                .getProjects()
+                .map((id) => id.substring(ExamplePrefix.length)),
+        ).toEqual(info.projects);
+        expect(info.name).toBe(gallery.data.name['en-US']);
+        expect(info.description).toBe(gallery.data.description['en-US']);
+    }
+});
+
+test('the functions example manifest locale keys match en-US.json', () => {
+    const enUS = JSON.parse(
+        readFileSync(path.join('src', 'locale', 'en-US.json'), 'utf8'),
+    ) as { gallery: Record<string, { name: string; description: string }> };
+    for (const id of Object.keys(ExampleGalleries)) {
+        const info = ExampleGalleries[id];
+        const text = enUS.gallery[info.localeKey];
+        expect(text, `en-US gallery text for ${info.localeKey}`).toBeDefined();
+        expect(info.name).toBe(text.name);
+        expect(info.description).toBe(text.description);
+    }
+});

--- a/src/examples/previewShared.test.ts
+++ b/src/examples/previewShared.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { expect, test } from 'vitest';
+import {
+    buildSitemapXml,
+    injectPreviewHead,
+    parsePreviewPath,
+    parseWpProjectName,
+    pickLocalizedText,
+    resolveMultilingualName,
+} from '../../functions/src/preview/shared';
+
+/** The real shell head shapes: if app.html's meta tags change form, the
+ *  preview function's string surgery must be revisited, so test against it. */
+const shell = readFileSync(path.join('src', 'app.html'), 'utf8');
+
+test('injectPreviewHead inserts a title and replaces og tags', () => {
+    const html = injectPreviewHead(shell, {
+        title: 'Heart Attack',
+        description: 'A game about love.',
+        url: 'https://wordplay.dev/project/example-HeartAttack',
+    });
+    expect(html).toContain('<title>Heart Attack</title>');
+    expect(html).toContain(
+        '<meta name="title" property="og:title" content="Heart Attack" />',
+    );
+    expect(html).toContain(
+        '<meta name="description" property="og:description" content="A game about love." />',
+    );
+    expect(html).toContain(
+        '<meta property="og:url" content="https://wordplay.dev/project/example-HeartAttack" />',
+    );
+    // The original title/description/url contents are gone.
+    expect(html).not.toContain(
+        'Accessible, Multilingual, Programmable Typography',
+    );
+    // One tag each, not duplicates a scraper could pick arbitrarily.
+    expect(html.match(/property="og:title"/g)).toHaveLength(1);
+    expect(html.match(/property="og:description"/g)).toHaveLength(1);
+});
+
+test('injectPreviewHead escapes hostile names', () => {
+    const html = injectPreviewHead(shell, {
+        title: '</title><script>alert(1)</script>',
+        description: '"/><script>alert(2)</script>',
+        url: 'https://wordplay.dev/project/x',
+    });
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;/title&gt;');
+});
+
+test('injectPreviewHead replaces an existing title', () => {
+    const withTitle = shell.replace(
+        '</head>',
+        '<title>Wordplay</title></head>',
+    );
+    const html = injectPreviewHead(withTitle, {
+        title: 'Games',
+        url: 'https://wordplay.dev/gallery/Games',
+    });
+    expect(html).toContain('<title>Games</title>');
+    expect(html).not.toContain('<title>Wordplay</title>');
+});
+
+test('parsePreviewPath handles locale prefixes and rejects other routes', () => {
+    expect(parsePreviewPath('/project/abc')).toEqual({
+        kind: 'project',
+        id: 'abc',
+        locales: [],
+    });
+    expect(parsePreviewPath('/en-US+es-MX/gallery/Games')).toEqual({
+        kind: 'gallery',
+        id: 'Games',
+        locales: ['en-US', 'es-MX'],
+    });
+    expect(parsePreviewPath('/gallery/G%C3%A9nial')?.id).toBe('Génial');
+    expect(parsePreviewPath('/projects')).toBeUndefined();
+    expect(parsePreviewPath('/en-US/projects')).toBeUndefined();
+    expect(parsePreviewPath('/project/')).toBeUndefined();
+    expect(parsePreviewPath('/a/b/c/d')).toBeUndefined();
+    expect(parsePreviewPath('/project/%E0%A4%A')).toBeUndefined();
+});
+
+test('resolveMultilingualName picks the preferred translation', () => {
+    expect(resolveMultilingualName('"Heart Attack"/en', ['en'])).toBe(
+        'Heart Attack',
+    );
+    expect(resolveMultilingualName('"project"/en"proyecto"/es', ['es'])).toBe(
+        'proyecto',
+    );
+    expect(resolveMultilingualName('"project"/en"proyecto"/es', ['fr'])).toBe(
+        'project',
+    );
+    // Anything that isn't a clean end-to-end multilingual literal renders raw.
+    expect(resolveMultilingualName('Adventure', ['en'])).toBe('Adventure');
+    expect(resolveMultilingualName('"unterminated', ['en'])).toBe(
+        '"unterminated',
+    );
+    expect(resolveMultilingualName('"a"/en trailing', ['en'])).toBe(
+        '"a"/en trailing',
+    );
+    expect(resolveMultilingualName('"a"/en"b"', ['en'])).toBe('"a"/en"b"');
+});
+
+test('parseWpProjectName peels a preview glyph line', () => {
+    expect(parseWpProjectName('🧟\n"Heart Attack"/en\n=== start/en')).toBe(
+        '"Heart Attack"/en',
+    );
+    // A keycap glyph is multiple code points but one grapheme.
+    expect(parseWpProjectName('0⃣\nCalculator\n=== main')).toBe('Calculator');
+    // Legacy files have no glyph line.
+    expect(parseWpProjectName('Maze\n=== main')).toBe('Maze');
+    expect(parseWpProjectName('')).toBeUndefined();
+});
+
+test('pickLocalizedText falls back by language, then en-US, skipping unwritten strings', () => {
+    const record = {
+        'en-US': 'Games',
+        'es-MX': 'Juegos',
+        'fr-FR': '$?',
+    };
+    expect(pickLocalizedText(record, ['es-MX'])).toBe('Juegos');
+    expect(pickLocalizedText(record, ['es-ES'])).toBe('Juegos');
+    expect(pickLocalizedText(record, ['fr-FR'])).toBe('Games');
+    expect(pickLocalizedText(record, [])).toBe('Games');
+    expect(pickLocalizedText({ 'fr-FR': '$?' }, ['fr-FR'])).toBeUndefined();
+    expect(pickLocalizedText(undefined, ['en-US'])).toBeUndefined();
+});
+
+test('buildSitemapXml escapes URLs', () => {
+    const xml = buildSitemapXml(['https://wordplay.dev/project/a&b']);
+    expect(xml).toContain('<loc>https://wordplay.dev/project/a&amp;b</loc>');
+    expect(xml).toContain('<urlset');
+});

--- a/src/routes/[[locale]]/characters/+page.ts
+++ b/src/routes/[[locale]]/characters/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/src/routes/[[locale]]/learn/+page.ts
+++ b/src/routes/[[locale]]/learn/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://wordplay.dev/sitemap.xml

--- a/tests/end2end/page-preview.spec.ts
+++ b/tests/end2end/page-preview.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { getTestFirestore } from '../helpers/firestore';
+
+/**
+ * The getPagePreview/getSitemap functions (#1133): project and gallery URLs
+ * are rewritten by hosting to a function that injects <title>/og:* metadata
+ * for public docs into the SPA shell, reading Firestore over REST with no
+ * credentials so security rules decide visibility. These tests run through
+ * the hosting emulator, exercising the rewrite, the function, and the rules.
+ */
+
+const PUBLIC_ID = 'e2epreviewpublic00000000000001';
+const PRIVATE_ID = 'e2epreviewprivate0000000000001';
+const HOSTILE_ID = 'e2epreviewhostile0000000000001';
+const GALLERY_ID = 'e2epreviewgallery0000000000001';
+const PRIVATE_NAME = 'Extremely Secret Preview Project';
+
+test.beforeAll(async () => {
+    const firestore = getTestFirestore();
+    await firestore.collection('projects').doc(PUBLIC_ID).set({
+        name: 'E2E Preview Project',
+        public: true,
+        listed: true,
+        archived: false,
+    });
+    await firestore.collection('projects').doc(PRIVATE_ID).set({
+        name: PRIVATE_NAME,
+        public: false,
+        listed: true,
+        archived: false,
+    });
+    await firestore.collection('projects').doc(HOSTILE_ID).set({
+        name: '</title><script>window.hacked=true</script>',
+        public: true,
+        listed: true,
+        archived: false,
+    });
+    await firestore
+        .collection('galleries')
+        .doc(GALLERY_ID)
+        .set({
+            public: true,
+            name: { 'en-US': 'E2E Preview Gallery', 'es-MX': 'Galería E2E' },
+            description: { 'en-US': 'A gallery for preview tests.' },
+        });
+});
+
+test('a public project URL serves its name in title and og tags', async ({
+    request,
+}) => {
+    const response = await request.get(`/project/${PUBLIC_ID}`);
+    expect(response.status()).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('<title>E2E Preview Project</title>');
+    expect(html).toContain(
+        '<meta name="title" property="og:title" content="E2E Preview Project" />',
+    );
+    expect(html).toContain(`/project/${PUBLIC_ID}`);
+});
+
+test('a private project URL leaks nothing', async ({ request }) => {
+    const response = await request.get(`/project/${PRIVATE_ID}`);
+    // Same status and shell as before this feature existed.
+    expect(response.status()).toBe(200);
+    const html = await response.text();
+    expect(html).not.toContain(PRIVATE_NAME);
+    expect(html).not.toContain('<title>');
+});
+
+test('a hostile project name is escaped', async ({ request }) => {
+    const html = await (await request.get(`/project/${HOSTILE_ID}`)).text();
+    expect(html).not.toContain('<script>window.hacked');
+    expect(html).toContain('&lt;script&gt;');
+});
+
+test('a public gallery serves localized name and description', async ({
+    request,
+}) => {
+    const english = await (await request.get(`/gallery/${GALLERY_ID}`)).text();
+    expect(english).toContain('<title>E2E Preview Gallery</title>');
+    expect(english).toContain('A gallery for preview tests.');
+
+    const spanish = await (
+        await request.get(`/es-MX/gallery/${GALLERY_ID}`)
+    ).text();
+    expect(spanish).toContain('<title>Galería E2E</title>');
+});
+
+test('a built-in example project serves its .wp name', async ({ request }) => {
+    const html = await (
+        await request.get('/project/example-HeartAttack')
+    ).text();
+    expect(html).toContain('<title>Heart Attack</title>');
+});
+
+test('a built-in example gallery serves locale-JSON names', async ({
+    request,
+}) => {
+    // en-US text ships inside the function; sync-tested against en-US.json.
+    const english = await (await request.get('/gallery/Games')).text();
+    expect(english).toContain('<title>Games</title>');
+    expect(english).toContain('Interactive games with words and symbols.');
+
+    // Other locales come from hosting's own static locale JSON.
+    const esMX = JSON.parse(
+        readFileSync(
+            path.join('static', 'locales', 'es-MX', 'es-MX.json'),
+            'utf8',
+        ),
+    ) as { gallery: { games: { name: string } } };
+    const expected = esMX.gallery.games.name
+        .replace(/\$\?|\$!|\$~/g, '')
+        .trim();
+    const spanish = await (await request.get('/es-MX/gallery/Games')).text();
+    expect(spanish).toContain(`<title>${expected}</title>`);
+});
+
+test('non-preview routes still serve the untouched static shell', async ({
+    request,
+}) => {
+    const html = await (await request.get('/guide')).text();
+    expect(html).not.toContain('<title>');
+    expect(html).toContain(
+        'content="Wordplay: Accessible, Multilingual, Programmable Typography"',
+    );
+});
+
+test('the sitemap lists public content and omits private content', async ({
+    request,
+}) => {
+    const response = await request.get('/sitemap.xml');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('application/xml');
+    const xml = await response.text();
+    expect(xml).toContain(`/project/${PUBLIC_ID}`);
+    expect(xml).toContain(`/gallery/${GALLERY_ID}`);
+    expect(xml).toContain('/gallery/Games');
+    expect(xml).toContain('/project/example-HeartAttack');
+    expect(xml).toContain('/guide');
+    expect(xml).not.toContain(PRIVATE_ID);
+});


### PR DESCRIPTION
# Context

Resolves #1133 with the assessed lighter-weight path: instead of migrating to App Hosting/SSR, a small `getPagePreview` Cloud Function behind Firebase Hosting rewrites serves project and gallery URLs as the existing SPA shell with server-injected `<title>`/`og:*` metadata, so shared links unfurl in chat/social apps and search engines can index public content by name. A companion `getSitemap` function serves `/sitemap.xml` (static routes, built-in examples, public listed projects, public galleries), referenced from a new `robots.txt`. The `learn` and `characters` pages now prerender like `about`/`guide` (`galleries` deliberately not: it reads `?tab=` during server rendering by design, which prerendering forbids).

Design notes:

- **Rules decide visibility, not this code.** Firestore is read over unauthenticated REST, which evaluates security rules as a signed-out user — a bug in the function cannot leak private content. Verified against production that unauthenticated REST doc reads and `public == true` queries work (the client already runs the same query shape).
- **Built-in examples get previews too**: `example-*` project names come from the `.wp` files hosting already serves (including multilingual names), and the seven example galleries use each locale's JSON, with en-US carried in a manifest that `exampleManifestSync.test.ts` keeps in sync with `examples.ts`/`en-US.json`.
- The rewrites use the `function:` form (not `run:` like getwebpage) because the hosting emulator routes those to the local functions emulator, which is what makes the e2e coverage possible.
- Private/missing docs serve the untouched shell with the same 200 as before; responses are CDN-cached (`s-maxage=300`, sitemap 1 day).

## Related issues

- Closes #1133

## Verification

- `npm run check:now` clean; `npm test` passes (5588 tests), including new unit tests for head injection and escaping (hostile `</title><script>` names), path/locale parsing, multilingual name resolution, and the example-manifest sync test.
- New e2e spec `tests/end2end/page-preview.spec.ts` runs through the hosting emulator → function rewrite → functions emulator → Firestore emulator with rules: public project/gallery titles injected (including `es-MX` localized picks), private project leaks nothing, hostile names escaped, built-in example project and gallery served, non-preview routes untouched, sitemap includes public and omits private content.
- Manually verified the full chain in a local emulator suite with curl for every case above, plus cache headers and content types.
- Accessibility: no UI change — responses are the same shell with head-only metadata differences; the injected `<title>` gives previously title-less SPA routes a document title before hydration. No screen reader/keyboard/color surface changed.
- Remaining post-deploy step: on wordplay-dev, check a public project URL in a link-card validator (Discord/Slack) and confirm a private project URL shows nothing.

## Checklist

- [x] Preview function with rules-enforced Firestore REST reads
- [x] Sitemap + robots.txt
- [x] Prerender learn/characters
- [x] Unit + sync + e2e tests
- [ ] Post-deploy card-validator check on wordplay-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)