### PR TITLE
Fixed #1315: a replaced body no longer lands in a freed physics world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 ### Fixed
 
 - 🧲 Writing a strange number like `!#` or `∞` for the @Stage's `gravity` used to freeze everything on the stage that moves. Wordplay now uses ordinary gravity instead. (#1305)
+- 🧲 A @Phrase with @Matter crashed the program the first time it changed size, if it was the only thing physics was moving — like a score that counts up. (#1315)
 - 🐛 Formatted text with a language on it never matched the same formatted text without one, so `` `hi` `` and `` `hi`/en `` looked like different things. Plain text was fixed for this before; now formatted text is too.
 - 🐛 Reversing a list changed the list you started with, instead of leaving it alone and handing you a new one.
 - 🐛 Sorting a list could jumble items that had nothing wrong with them, if any one item's sorting number wasn't a number. Those items go last now, and everything else keeps its order.

--- a/src/output/physics/Physics.ts
+++ b/src/output/physics/Physics.ts
@@ -367,18 +367,19 @@ export default class Physics {
                         // Get the world for this z depth
                         const world = this.getWorldAtZ(info.global.z);
 
-                        // If we already had a body, remove it so we can replace with a new one.
-                        if (shape !== undefined) {
-                            this.removeOutputBody(name);
-                        }
-
-                        // Make a new body for this new output.
+                        // Make the new body before retiring the one it replaces.
+                        // removeOutputBody frees a world that empties, so
+                        // removing first would free this one out from under the
+                        // body about to be built in it, whenever the body being
+                        // replaced is the only one at its depth (#1315).
+                        const previous = shape;
                         shape = this.createOutputBody(
                             info,
                             matter,
                             detectable,
                             world,
                         );
+                        if (previous !== undefined) this.removeOutputBody(name);
 
                         // Remember the body by name and its collider handle.
                         this.bodyByName.set(name, shape);
@@ -770,6 +771,10 @@ export default class Physics {
             this.nameByColliderHandle.delete(outputBody.collider.handle);
             outputBody.world.removeRigidBody(outputBody.rigidBody);
             this.bodyByName.delete(name);
+
+            // A removed body must not still be swept: tick() finalizes every
+            // sweep, which would move a rigid body that no longer exists.
+            this.sweepingBodies.delete(outputBody);
 
             // If the world is now empty, remove it.
             if (outputBody.world.bodies.len() === 0) {

--- a/src/output/physics/worldLifetime.test.ts
+++ b/src/output/physics/worldLifetime.test.ts
@@ -1,0 +1,118 @@
+import { DB } from '@db/Database';
+import Project from '@db/projects/Project';
+import DefaultLocale from '@locale/DefaultLocale';
+import DefaultLocales from '@locale/DefaultLocales';
+import Source from '@nodes/Source';
+import type { OutputInfo, OutputInfoSet } from '@output/animation/Animator';
+import Phrase from '@output/Output/Phrase';
+import { toStage } from '@output/Output/Stage';
+import { createPlace } from '@output/Place/Place';
+import Physics, { FIXED_STEP_MS } from '@output/physics/Physics';
+import RenderContext from '@output/RenderContext';
+import Evaluator from '@runtime/Evaluator';
+import { beforeAll, expect, test, vi } from 'vitest';
+import { loadRapier, onRapierLoaded } from './rapierLoader';
+
+/**
+ * A world is freed as soon as it holds no bodies, so replacing the only body at
+ * a depth used to free the world out from under its replacement (#1315): sync()
+ * resolved the world before removing the old body, and removeOutputBody both
+ * freed it and dropped it from worldsByZ. Building into the freed world throws
+ * outright ("Cannot read properties of undefined (reading 'createRigidBody')"),
+ * so a lone Phrase with Matter — a score, a timer, a growing word — crashed the
+ * frame the first time its text changed size. Anything else at that depth, a
+ * second output or a Shape barrier, kept the world full and hid it.
+ *
+ * Only a Phrase or Group can reach that path: matter is read off those two
+ * alone, a watched Shape is deliberately left to its barrier body, and a Shape
+ * has no place input for a Motion to drive. So this measures a Phrase, which
+ * needs a canvas — mocked below, since these tests run in node.
+ */
+
+vi.mock('@output/Output/getTextMetrics', () => ({
+    default: () => ({
+        width: 10,
+        actualBoundingBoxAscent: 8,
+        actualBoundingBoxDescent: 2,
+        fontBoundingBoxAscent: 10,
+        fontBoundingBoxDescent: 3,
+    }),
+}));
+
+beforeAll(async () => {
+    loadRapier();
+    await new Promise<void>((resolve) => onRapierLoaded(resolve));
+});
+
+/** Evaluate a program and hand back its stage and a Physics to sync with it. */
+function stageAndPhysics(code: string) {
+    const source = new Source('test', code);
+    const project = Project.make(null, 'test', source, [], DefaultLocale);
+    project.analyze();
+    const evaluator = new Evaluator(
+        project,
+        DB,
+        DefaultLocales.getLocales(),
+        false,
+    );
+    const value = evaluator.getInitialValue();
+    if (value === undefined) throw new Error('expected a value');
+    const stage = toStage(evaluator, value);
+    if (stage === undefined) throw new Error('expected a stage');
+    return { evaluator, stage, physics: new Physics(evaluator) };
+}
+
+test('replacing the only body at a depth keeps its world alive', () => {
+    const { evaluator, stage, physics } = stageAndPhysics(
+        `Stage([Phrase('a' matter: Matter())])`,
+    );
+
+    const phrase = stage.content[0];
+    if (!(phrase instanceof Phrase)) throw new Error('expected a phrase');
+    const name = phrase.getName();
+
+    const context = new RenderContext(
+        'Noto Sans',
+        12,
+        DefaultLocales,
+        new Set(),
+        1,
+        'horizontal-tb',
+    );
+    const place = createPlace(evaluator, 0, 0, 0);
+
+    /** The scene entry Animator.layout would produce, at the given size. */
+    const scene = (width: number, height: number): OutputInfoSet => {
+        const info: OutputInfo = {
+            output: phrase,
+            global: place,
+            local: place,
+            rotation: undefined,
+            width,
+            height,
+            parents: [stage],
+            context,
+        };
+        return new Map([[name, info]]);
+    };
+
+    // The phrase is the only thing on stage, so its world holds only its body.
+    physics.sync(stage, scene(1, 1), new Map());
+    expect(physics.worldsByZ.get(0)?.bodies.len()).toBe(1);
+
+    // Its size changes, so sync replaces the body.
+    physics.sync(stage, scene(2, 1), new Map());
+
+    // The world it was replaced in is still the world the simulation steps.
+    const world = physics.worldsByZ.get(0);
+    expect(world).toBeDefined();
+    expect(physics.worldsByZ.size).toBe(1);
+    expect(physics.getOutputBody(name)?.world).toBe(world);
+    // And the body it replaced is gone, rather than both lingering.
+    expect(world?.bodies.len()).toBe(1);
+
+    // Stepping over the replacement is safe.
+    expect(() => physics.tick(FIXED_STEP_MS)).not.toThrow();
+
+    evaluator.stop();
+});


### PR DESCRIPTION
# Context

`Physics.sync` resolves the world for an output's depth *before* removing the body it is replacing, and `removeOutputBody` frees a world once it holds no bodies — deleting it from `worldsByZ` as it goes. So when the body being replaced is the **only** body at its depth, the new body is built in a freed wasm world.

That isn't a silent freeze: a freed Rapier world nulls its internal pointer, so `world.bodies` is `undefined` and `createRigidBody` throws.

```
TypeError: Cannot read properties of undefined (reading 'createRigidBody')
 ❯ new OutputBody src/output/physics/Physics.ts:1046:32
 ❯ Physics.sync src/output/physics/Physics.ts:376:38
```

A lone `Phrase` with `Matter` — a score, a timer, a growing word — crashed the frame the first time its text changed size. Anything else at that depth (a second output, or a `Shape` barrier, which also counts toward `world.bodies.len()`) kept the world full and hid it.

This builds the replacement body **before** retiring the old one, so the world can never empty across the swap and is never freed. That is preferable to simply resolving the world after the removal: a rebuilt world starts weightless until the next sync's `Stage` entry sets gravity, so a lone output whose size changes often would get a fresh zero-gravity world each time. Moving to a different `z` still frees the old world correctly, since only the old body leaves it.

Nothing steps between the two, so the momentary overlap is inert, and the new collider's handle is distinct from the old one while both are alive.

A second, one-line fix in the same family: `removeOutputBody` now drops the body from `sweepingBodies`. `tick()` finalizes every pending sweep, so a body removed between a sync and the next tick was having `setTranslation` called on a rigid body no longer in any world.

## Related issues

- Closes #1315

Pre-existing; not introduced by #1305, though reviewing that PR — which newly holds `RAPIER.World` references in its attractor map — is what made the lifetime worth checking.

## Verification

New regression test, `src/output/physics/worldLifetime.test.ts`: syncs a single sized output at one depth, changes its size, and steps. It fails on `main` with the `TypeError` above and passes with the fix.

Only a `Phrase` or `Group` can reach that branch — `matter` is read off those two alone, a watched `Shape` is deliberately left to its barrier body, and a `Shape` has no `place` input for a `Motion` to drive — so the shapes-only trick that keeps `watched.test.ts` DOM-free wasn't available. The test mocks the one leaf module `@output/Output/getTextMetrics` rather than faking `document`.

- `npx vitest run` — 386 files, 6770 passed, 7 skipped.
- `npm run check:now` — 0 errors, 0 warnings.
- `npx prettier --check` on all changed files — clean.

No UI surface changes, so there is no screen-reader, keyboard, or color pass to report: this is internal physics lifetime, and the user-visible effect is a crash that no longer happens.

## Checklist

- [x] Regression test that fails before the fix
- [x] `npm run check:now` and the full unit suite pass
- [x] CHANGELOG entry
- [ ] Manual check in the app with a counter-style project (not done — the unit test reproduces the crash deterministically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
