### PR TITLE
Fix the two CI failures on main: per-test timeouts and a virtualized-tile read

### DIFF
--- a/src/basis/faces/fontsSync.test.ts
+++ b/src/basis/faces/fontsSync.test.ts
@@ -39,7 +39,14 @@ describe('font artifacts are in sync with the manifest + font files', () => {
         expect(problems).toEqual([]);
     });
 
-    test('metrics.generated.ts matches what the font files measure', async () => {
-        expect(await checkMetrics(FaceMetrics)).toEqual([]);
-    });
+    // Explicit timeout because this one re-measures every font file rather than
+    // comparing hashes: ~0.6s on a dev machine, but CI runs it alongside three
+    // other workers and it reached 5.7s, tripping the 5s default.
+    test(
+        'metrics.generated.ts matches what the font files measure',
+        { timeout: 30_000 },
+        async () => {
+            expect(await checkMetrics(FaceMetrics)).toEqual([]);
+        },
+    );
 });

--- a/src/examples/localizedExamples.test.ts
+++ b/src/examples/localizedExamples.test.ts
@@ -43,6 +43,14 @@ const localized = readdirSync(dir, { withFileTypes: true })
  *  data-dump example costs seconds to analyze and covers nothing new. */
 const MaxTestableLength = 50_000;
 
+/**
+ * Enough for `FrenchNumbers.wp`, the slowest example here: it spends about 2s
+ * per locale on a dev machine, and CI runs several times slower under the
+ * suite's four workers — 8.1s when it first tripped the 5s default. The rest
+ * of the examples finish in well under 300ms.
+ */
+const SlowestExample = 30_000;
+
 const localeTexts = new Map<string, LocaleText>();
 function localeText(code: string): LocaleText {
     let text = localeTexts.get(code);
@@ -126,6 +134,7 @@ test.each(localized)(
             `Conflicts beyond the master's own in this locale: ${conflicts.join(', ')}`,
         ).toBeLessThanOrEqual(baseline);
     },
+    SlowestExample,
 );
 
 /**

--- a/tests/end2end/howto-form.spec.ts
+++ b/tests/end2end/howto-form.spec.ts
@@ -85,20 +85,27 @@ test.describe('how-to editor form', () => {
         await createViaForm(page, galleryId, 'A Draggable Draft', true);
 
         await page.goto(`/en-US/gallery/${galleryId}/howto`);
-        // Attached, not visible: canvas tiles are virtualized to the camera's
-        // viewport, and a computed style reads fine off an unrendered tile.
+        // Canvas tiles are virtualized to the camera's viewport, so a tile can
+        // mount and unmount as the camera and the canvas size settle — and
+        // getComputedStyle on a node that unmounted between resolving the
+        // locator and reading it answers '' for every property. Poll rather
+        // than read once, so the assertion is about the rendered tile.
         const title = page.locator('.howto .markup').first();
         await title.waitFor({ state: 'attached' });
-        // WebKit exposes only the prefixed property on the computed style.
-        expect(
-            await title.evaluate((e) => {
-                const style = getComputedStyle(e);
-                return (
-                    style.userSelect ||
-                    style.getPropertyValue('-webkit-user-select')
-                );
-            }),
-        ).toBe('none');
+        await expect
+            .poll(async () =>
+                title
+                    // WebKit exposes only the prefixed property.
+                    .evaluate((e) => {
+                        const style = getComputedStyle(e);
+                        return (
+                            style.userSelect ||
+                            style.getPropertyValue('-webkit-user-select')
+                        );
+                    })
+                    .catch(() => undefined),
+            )
+            .toBe('none');
     });
 
     test('editing a draft autosaves the new title to the cloud', async ({


### PR DESCRIPTION
# Context

`Verify and deploy to Firebase` has been red on main, blocking the deploy. Two independent failures.

**`unit / vitest` — red on both of the last two pushes to main**, a different test each time and the same cause each time: a test that legitimately takes seconds crossed vitest's 5s per-test default under CI's four workers.

- 3b40438: `fontsSync.test.ts` › "metrics.generated.ts matches what the font files measure" — 5,690 ms.
- 76b78ed: `localizedExamples.test.ts` › `ne-NP/FrenchNumbers.wp` — 8,136 ms (the other locales ran 2.2–2.4 s in the same run).

Neither declared a timeout, while every other corpus-scale test here does — `Project.analysis.test.ts` documents this exact class of outlier ("CI runs roughly three times slower — 8.2s when it first tripped the 5s default"), as do `creatable`, `Parser`, `Basis`, `analyzeProjectKeys`, and `exampleNamesSync`. Both now declare one, with the measurement behind it in the comment: FrenchNumbers is 1.7–3.0 s per locale on a dev machine, the font metrics ~0.6 s.

**`playwright / test (chromium 3/3)` — flaky, and not new** (it also failed on run 715 and passed on rerun). `a how-to tile is unselectable even though its title renders as markup` reads `getComputedStyle` off a canvas tile that is virtualized to the camera's viewport, so the tile mounts and unmounts as the camera and canvas size settle. A node that unmounted between resolving the locator and reading it answers `''` for every property — which the assertion reported as a missing selection rule rather than as a tile that isn't rendered. It now polls, asserting the same thing about the rendered tile.

## Related issues

- Related Issue #
- Closes #

## Verification

No user-visible change: this is test-only (two `.test.ts` files and one `.spec.ts`), so no screen-reader, keyboard, or color verification applies.

- `npm test` — 494 files, 10,909 passed, 7 skipped.
- `npm run check:now` — 3400 files, 0 errors, 0 warnings.
- `howto-form.spec.ts` — 12/12 (3 repeats × 4 tests) under chromium, 4 workers, on a deliberately loaded machine. The `''` failure reproduced locally before the change.

## Checklist

Also found while investigating, and deliberately **not** fixed here: the drafts list and canvas read the gallery's `howTos` array, which `addHowTo` updates only in the cloud (`arrayUnion`), so it reaches the client solely through the galleries listener — and that listener skips any gallery with an unsaved local edit (`GalleryDatabase.svelte.ts`, "Skip galleries with unsaved local edits"). That can leave a just-created how-to invisible until some later write to the gallery happens to arrive, and a `flushUnsaved` replay of the stale local copy would write back a `howTos` array missing what the batch just added. It is a plausible cause of the other how-to timeout in run 717, which I could not reproduce locally even at 4× CPU oversubscription. A local-mirror prototype broke the offline-replay test in 2 of 3 runs (the gallery advertised a how-to whose document didn't exist yet), so it was reverted rather than landed unverified. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXreitD9VZZNfnj5XPX97C

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXreitD9VZZNfnj5XPX97C)_