### PR TITLE
Ask the database for a how-to space rather than concluding from silence

### DIFF
--- a/src/basis/faces/fontsSync.test.ts
+++ b/src/basis/faces/fontsSync.test.ts
@@ -21,32 +21,33 @@ import { FallbackFaces } from './faces.fallback.generated';
 
 const lock = readLock();
 
-describe('font artifacts are in sync with the manifest + font files', () => {
-    test('every font file matches its lockfile hash', () => {
-        expect(checkHashes(lock)).toEqual([]);
-    });
+// Every check here reads or measures each of the font files, so all of them are
+// I/O-bound in a way the 5s default doesn't survive on a loaded machine: the
+// metrics check reached 5.7s in CI and hashing every file blew it under a
+// parallel local run, though both are well under a second idle.
+describe(
+    'font artifacts are in sync with the manifest + font files',
+    { timeout: 30_000 },
+    () => {
+        test('every font file matches its lockfile hash', () => {
+            expect(checkHashes(lock)).toEqual([]);
+        });
 
-    test('the committed CSS ranges match the lockfile', async () => {
-        expect(await checkCssConsistency(lock)).toEqual([]);
-    });
+        test('the committed CSS ranges match the lockfile', async () => {
+            expect(await checkCssConsistency(lock)).toEqual([]);
+        });
 
-    test('faces.generated.ts matches the manifest + lockfile', async () => {
-        const problems = await checkRegistryConsistency(
-            lock,
-            { Faces, FallbackFaces },
-            await emojiRanges(),
-        );
-        expect(problems).toEqual([]);
-    });
+        test('faces.generated.ts matches the manifest + lockfile', async () => {
+            const problems = await checkRegistryConsistency(
+                lock,
+                { Faces, FallbackFaces },
+                await emojiRanges(),
+            );
+            expect(problems).toEqual([]);
+        });
 
-    // Explicit timeout because this one re-measures every font file rather than
-    // comparing hashes: ~0.6s on a dev machine, but CI runs it alongside three
-    // other workers and it reached 5.7s, tripping the 5s default.
-    test(
-        'metrics.generated.ts matches what the font files measure',
-        { timeout: 30_000 },
-        async () => {
+        test('metrics.generated.ts matches what the font files measure', async () => {
             expect(await checkMetrics(FaceMetrics)).toEqual([]);
-        },
-    );
-});
+        });
+    },
+);

--- a/src/db/galleries/GalleryDatabase.svelte.ts
+++ b/src/db/galleries/GalleryDatabase.svelte.ts
@@ -609,6 +609,28 @@ export default class GalleryDatabase {
         }
     }
 
+    /** Reflect a how-to's addition or removal in the local copy of its gallery,
+     *  once the write it mirrors has landed. The gallery half of the batch is an
+     *  arrayUnion/arrayRemove, so it otherwise reaches this client only through
+     *  the listener — which skips a gallery with an unsaved local edit, leaving
+     *  the drafts list waiting on a snapshot that may never come. Never mirror
+     *  before the ack: offline that would advertise a how-to with no document. */
+    mirrorHowToMembership(gallery: Gallery, howToID: string, added: boolean) {
+        const id = gallery.getID();
+        const revised = added
+            ? gallery.withHowTo(howToID)
+            : gallery.withoutHowTo(howToID);
+        // Wherever we hold it, including the by-ID cache a direct read fills.
+        if (this.accessibleGalleries.has(id))
+            this.accessibleGalleries.set(id, revised);
+        else if (this.expandedScopeGalleries.has(id))
+            this.expandedScopeGalleries.set(id, revised);
+        else if (this.publicGalleries.has(id))
+            this.publicGalleries.set(id, revised);
+        else return; // Hold no copy? Nothing to keep in sync.
+        void this.cacheGalleriesLocally([revised]);
+    }
+
     async delete(gallery: Gallery) {
         if (firestore === undefined) return undefined;
         const user = this.database.getUser();

--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -682,6 +682,8 @@ export class HowToDatabase {
         // firestore): now remove locally.
         this.howtos.delete(howToId);
         this.saves.forget(howToId);
+        // Confirmed above, so the arrayRemove has landed.
+        this.db.Galleries.mirrorHowToMembership(gallery, howToId, false);
         if (this.IndexedDBSupported) void this.db.localDB.deleteHowTo(howToId);
         return true;
     }
@@ -790,7 +792,20 @@ export class HowToDatabase {
             // connection (a Firestore write promise resolves only on server
             // ack, never while offline). Matches projects/characters, whose
             // editors never block on the cloud write.
-            void this.trackSave(newHowTo.id, howTo.getTitle(), batch.commit());
+            void this.trackSave(
+                newHowTo.id,
+                howTo.getTitle(),
+                batch.commit(),
+            ).then((saved) => {
+                // Once it lands, so the drafts list doesn't wait on a snapshot
+                // for a membership we already wrote.
+                if (saved)
+                    this.db.Galleries.mirrorHowToMembership(
+                        gallery,
+                        newHowTo.id,
+                        true,
+                    );
+            });
         } catch (error) {
             console.error(error);
             return undefined;

--- a/src/db/howtos/HowToDatabase.test.ts
+++ b/src/db/howtos/HowToDatabase.test.ts
@@ -6,6 +6,8 @@ type BatchOp = {
     data?: unknown;
 };
 let lastBatchOps: BatchOp[] = [];
+/** What `batch.commit()` returns; a test can hold it unresolved. */
+let commitResult: Promise<void> = Promise.resolve();
 
 vi.mock('firebase/firestore', () => ({
     and: vi.fn(),
@@ -35,7 +37,9 @@ vi.mock('firebase/firestore', () => ({
             delete: vi.fn((ref: unknown) => {
                 ops.push({ kind: 'delete', ref });
             }),
-            commit: vi.fn(async () => {}),
+            // Resolves immediately by default; a test that needs to hold the
+            // write in flight (an offline create) replaces `commitResult`.
+            commit: vi.fn(() => commitResult),
         };
     }),
     onSnapshot: vi.fn(() => () => {}),
@@ -123,12 +127,14 @@ describe('HowToDatabase atomic how-to + gallery updates', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         lastBatchOps = [];
+        commitResult = Promise.resolve();
 
         mockDatabase = {
             getUser: vi.fn(() => ({ uid: 'user-1' })),
             track: vi.fn(<T>(p: Promise<T>) => p),
             write: vi.fn(<T>(p: Promise<T>) => p),
             reportBanner: vi.fn(),
+            Galleries: { mirrorHowToMembership: vi.fn() },
         };
 
         db = new HowToDatabase(mockDatabase);
@@ -174,6 +180,78 @@ describe('HowToDatabase atomic how-to + gallery updates', () => {
             expect(elements).toHaveLength(1);
             expect(typeof elements[0]).toBe('string');
         });
+
+        // The gallery half of the batch is a cloud-only arrayUnion, so the
+        // membership reaches this client only through the galleries listener —
+        // which skips a gallery with an unsaved local edit. Without the local
+        // mirror the drafts list can sit empty until some later write to the
+        // gallery happens to arrive.
+        it('mirrors the new membership once the write lands', async () => {
+            const gallery = makeGallery('g1');
+
+            await db.addHowTo(
+                gallery,
+                false,
+                0,
+                0,
+                [],
+                'title',
+                [],
+                [''],
+                ['en-US'],
+                {},
+                false,
+                false,
+                false,
+            );
+
+            const galleryUpdate = lastBatchOps.find((o) => o.kind === 'update');
+            const { elements } = (galleryUpdate!.data as { howTos: unknown })
+                .howTos as { elements: string[] };
+            await vi.waitFor(() =>
+                expect(
+                    mockDatabase.Galleries.mirrorHowToMembership,
+                ).toHaveBeenCalledWith(gallery, elements[0], true),
+            );
+        });
+
+        // Offline, the commit doesn't resolve until reconnect. Mirroring before
+        // it lands would leave the gallery listing a how-to whose document
+        // isn't there — and `flushUnsaved` would replay the gallery that way.
+        it('does not mirror while the write is still in flight', async () => {
+            const gallery = makeGallery('g1');
+            let land: (() => void) | undefined;
+            commitResult = new Promise<void>((resolve) => {
+                land = resolve;
+            });
+
+            await db.addHowTo(
+                gallery,
+                false,
+                0,
+                0,
+                [],
+                'title',
+                [],
+                [''],
+                ['en-US'],
+                {},
+                false,
+                false,
+                false,
+            );
+
+            expect(
+                mockDatabase.Galleries.mirrorHowToMembership,
+            ).not.toHaveBeenCalled();
+
+            land?.();
+            await vi.waitFor(() =>
+                expect(
+                    mockDatabase.Galleries.mirrorHowToMembership,
+                ).toHaveBeenCalled(),
+            );
+        });
     });
 
     describe('deleteHowTo', () => {
@@ -208,6 +286,9 @@ describe('HowToDatabase atomic how-to + gallery updates', () => {
 
             expect(db['howtos'].has('ht-1')).toBe(false);
             expect(mockDatabase.reportBanner).not.toHaveBeenCalled();
+            expect(
+                mockDatabase.Galleries.mirrorHowToMembership,
+            ).toHaveBeenCalledWith(gallery, 'ht-1', false);
         });
 
         it('keeps the how-to locally and reports a banner when the cloud delete fails', async () => {
@@ -222,6 +303,11 @@ describe('HowToDatabase atomic how-to + gallery updates', () => {
 
             expect(db['howtos'].has('ht-1')).toBe(true);
             expect(mockDatabase.reportBanner).toHaveBeenCalledTimes(1);
+            // A refused delete leaves the membership alone too, or the how-to
+            // would vanish from the gallery while still in the cloud.
+            expect(
+                mockDatabase.Galleries.mirrorHowToMembership,
+            ).not.toHaveBeenCalled();
         });
     });
 

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -36,6 +36,7 @@
     import HowToConfiguration from './HowToConfiguration.svelte';
     import HowToForm from './HowToForm.svelte';
     import HowToPreview from './HowToPreview.svelte';
+    import resolveGallery from './resolveGallery';
 
     // The current gallery being viewed. Starts at null, to represent loading state.
     let gallery = $state<Gallery | null | undefined>(null);
@@ -45,6 +46,10 @@
 
     // The component views
     let howToComponents = $state<HowToPreview[]>([]);
+
+    // Which resolution is current: an earlier lookup that resolves after a later
+    // one must not overwrite it. A plain let, so writing it can't re-run the effect.
+    let resolution = 0;
 
     // When the page changes, get the gallery store corresponding to the requested ID.
     $effect(() => {
@@ -58,30 +63,19 @@
         // query. Read `hydrated` so this effect re-runs once the cache loads, and
         // `authAttempted` so it re-runs once Firebase Auth resolves: the gallery
         // database is constructed before auth, so the maps are empty until the
-        // user is known.
-        const hydrated = Galleries.hydrated;
-        const authResolved = $authAttempted;
-
-        // check if the user has permission to read the gallery. if not, don't try to get it.
-        if (
+        // user is known. Reading both maps here is also what re-runs this when a
+        // snapshot finally lands.
+        const ready = Galleries.hydrated && $authAttempted;
+        const cached =
             Galleries.accessibleGalleries.has(galleryID) ||
-            Galleries.expandedScopeGalleries.has(galleryID)
-        ) {
-            Galleries.get(galleryID).then((gal) => {
-                // Found a store? Subscribe to it, updating the gallery when it changes.
-                if (gal) gallery = gal;
-                // Not found? No gallery.
-                else gallery = undefined;
-            });
-        } else if (!authResolved || !hydrated) {
-            // Auth hasn't resolved yet, or the local cache hasn't hydrated —
-            // stay in the loading state rather than flashing "this how-to space
-            // doesn't exist" before we know who the user is and what they can
-            // access. This resolves offline (hydration doesn't need a network).
-            gallery = null;
-        } else {
-            gallery = undefined;
-        }
+            Galleries.expandedScopeGalleries.has(galleryID);
+
+        const generation = ++resolution;
+        resolveGallery(galleryID, cached, ready, (id) =>
+            Galleries.find(id),
+        ).then((resolved) => {
+            if (generation === resolution) gallery = resolved;
+        });
     });
 
     let galleryName: string = $derived(

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/resolveGallery.test.ts
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/resolveGallery.test.ts
@@ -1,0 +1,52 @@
+import type Gallery from '@db/galleries/Gallery';
+import type { GalleryResult } from '@db/galleries/GalleryDatabase.svelte';
+import { expect, test, vi } from 'vitest';
+import resolveGallery from './resolveGallery';
+
+/** Only identity matters here, so a stand-in beats building a real Gallery. */
+const gallery = { id: 'g1' } as unknown as Gallery;
+
+function lookup(result: GalleryResult) {
+    return vi.fn(() => Promise.resolve(result));
+}
+
+test('nothing local and nothing settled yet is still loading, and asks no one', async () => {
+    const find = lookup({ kind: 'missing' });
+    expect(await resolveGallery('g1', false, false, find)).toBe(null);
+    // Answering "doesn't exist" before the user is known was the old bug; not
+    // reading at all before then is what keeps the page on its spinner.
+    expect(find).not.toHaveBeenCalled();
+});
+
+test('a gallery the maps already hold resolves without waiting to settle', async () => {
+    const find = lookup({ kind: 'found', gallery });
+    expect(await resolveGallery('g1', true, false, find)).toBe(gallery);
+});
+
+// The point of the change: settled with nothing local is a question for the
+// database, not a conclusion. The listener may be slow, or gone.
+test('settled with nothing local asks the database rather than concluding', async () => {
+    const find = lookup({ kind: 'found', gallery });
+    expect(await resolveGallery('g1', false, true, find)).toBe(gallery);
+    expect(find).toHaveBeenCalledWith('g1');
+});
+
+test('a gallery that really is missing reports missing', async () => {
+    expect(
+        await resolveGallery('g1', false, true, lookup({ kind: 'missing' })),
+    ).toBeUndefined();
+});
+
+// "We couldn't go look" is not "it isn't there": a timed-out read must not tell
+// a curator their own space is gone. The caller re-runs this when the maps
+// change, so a recovered connection resolves it.
+test('an unreachable lookup keeps loading rather than claiming it is gone', async () => {
+    expect(
+        await resolveGallery(
+            'g1',
+            false,
+            true,
+            lookup({ kind: 'unreachable' }),
+        ),
+    ).toBe(null);
+});

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/resolveGallery.ts
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/resolveGallery.ts
@@ -1,0 +1,43 @@
+import type Gallery from '@db/galleries/Gallery';
+import type { GalleryResult } from '@db/galleries/GalleryDatabase.svelte';
+
+/**
+ * What the how-to page should show for a gallery ID: the gallery, `null` for
+ * "still finding out", or `undefined` for "there isn't one".
+ *
+ * The page used to answer from the local maps alone — the realtime listener's
+ * `accessibleGalleries`/`expandedScopeGalleries` and the hydrated cache — and
+ * to conclude "this space doesn't exist" the moment auth and hydration had both
+ * settled without one. But those maps are fed by a snapshot, and a snapshot can
+ * be slow, or lost with the listener that would have delivered it (a Firestore
+ * listener ends on error and nothing re-subscribes it). A curator landing on
+ * their own space then read that it did not exist, with no way back but a
+ * reload, and every test locator on the page waited out its timeout.
+ *
+ * So ask the database instead of concluding from silence: `find` answers from
+ * those same maps when they have it — no network — and otherwise reads the
+ * document directly, which is authoritative and doesn't depend on the listener
+ * being alive. That is also why 'unreachable' stays `null` rather than becoming
+ * `undefined`: "we couldn't go look" is not "it isn't there", and the caller
+ * re-runs this whenever the maps change, so a recovered connection resolves it.
+ */
+export default async function resolveGallery(
+    galleryID: string,
+    /** Whether either role-split map already holds it. */
+    cached: boolean,
+    /** Whether the user and the local cache have both settled. */
+    ready: boolean,
+    lookup: (id: string) => Promise<GalleryResult>,
+): Promise<Gallery | null | undefined> {
+    // Nothing local, and we don't yet know who the viewer is or what the cache
+    // holds: keep loading rather than flashing "doesn't exist" at someone whose
+    // own gallery is about to arrive.
+    if (!cached && !ready) return null;
+
+    const result = await lookup(galleryID);
+    return result.kind === 'found'
+        ? result.gallery
+        : result.kind === 'missing'
+          ? undefined
+          : null;
+}


### PR DESCRIPTION
# Context

The chromium shard's how-to tests are the one recurring CI failure — runs 715, 717 and 718 all failed the same way, and 718 blocked the deploy until a re-run. Each time a locator on the how-to page waits out its full 90 s, and each time on a *different* locator: the "+" button, the drafts button, a canvas tile. That's the signature of the page, not of any one test.

**The page concluded a gallery didn't exist instead of asking.** It answered "which gallery is this?" from the local maps alone — `accessibleGalleries` / `expandedScopeGalleries` — and the moment auth and hydration had both settled without one, set `gallery = undefined`, which renders "this how-to space doesn't exist". But those maps are fed by the galleries realtime snapshot, and a snapshot can be late, or lost with the listener that would have delivered it: a Firestore listener ends on error and `reportListenerError` only logs and marks the domain failed, so nothing re-subscribes. A curator then reads that their own space doesn't exist, with no way back but a reload — and every locator on the page waits out its timeout.

`GalleryDatabase.find` already exists for exactly this question, and the page never used it: it answers from those same maps when they have it (no network), and otherwise reads the document directly, which is authoritative and doesn't need the listener alive. It also separates "isn't there" from "couldn't go look", so an unreachable read now keeps the page loading rather than claiming the gallery is gone — the distinction `find`'s own docstring was written for. The branch is extracted to `resolveGallery` so its four cases are unit-tested rather than reasoned about.

**The drafts list had its own version of the same dependency**, which is how run 718's retry failed. `addHowTo` writes the gallery half of its batch as an `arrayUnion`, so the new membership only ever came back through that same snapshot. The local copy is now updated once the write is acknowledged — after the ack, never before: mirroring earlier makes the gallery advertise a how-to whose document doesn't exist yet, which offline lasts until reconnect and which `flushUnsaved` would then replay. An earlier attempt that mirrored eagerly broke the offline-replay test in 2 of 3 runs; both timings are now covered by tests.

Also moves `fontsSync`'s timeout from the metrics test to the describe block: hashing every font file blew the 5 s default under a parallel local run, the same way measuring them did in CI. Every check in that guard is file-bound, so the guard carries the timeout.

## Related issues

- Related Issue #
- Closes #

## Verification

- `npm test` — 500 files, 10,967 passed, 7 skipped.
- `npm run check:now` — 3402 files, 0 errors, 0 warnings.
- `howto-form` + `seeded-load` e2e under chromium, 3 repeats, 2 workers: 12/12 for the how-to spec. `seeded-load.spec.ts:39` fails in this container both with and without the change (verified against unmodified `main`), so it is environmental here, not a regression.
- New unit tests: `resolveGallery.test.ts` covers cached, unsettled, found-by-direct-read, missing and unreachable; `HowToDatabase.test.ts` covers mirroring after the ack and *not* mirroring while the write is in flight.

**The CI flake itself could not be reproduced locally**, even running CI's exact shard-3 command under 4× CPU oversubscription — the how-to tests passed there while 20 unrelated tests failed from container load. So the page fix is reasoned from the code path rather than demonstrated against a reproduction, and the real test is whether the shard stays green.

No user-visible surface changed, so no screen-reader, keyboard or color verification applies — though the same fix means a creator whose snapshot is late now sees their space load instead of being told it doesn't exist.

## Checklist

Left for a follow-up, deliberately: nothing re-subscribes a Firestore listener after an error, in this database or the others. That is the deeper cause this change routes around rather than fixes, and it deserves its own change with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXreitD9VZZNfnj5XPX97C

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXreitD9VZZNfnj5XPX97C)_