### PR TITLE
Automated tests for how-to permissions, and four defects they caught (#907)

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,7 +5,7 @@ on:
 permissions:
     contents: read
 
-# Split into six independent jobs that run concurrently. This work used to run
+# Split into seven independent jobs that run concurrently. This work used to run
 # as sequential steps in one job; as parallel jobs the wall-clock collapses
 # to the longest single job instead of their sum. Each job repeats the
 # checkout/setup-node/npm-ci preamble (cheap with the npm cache).
@@ -43,6 +43,39 @@ jobs:
               name: Install dependencies
             - run: npm run test:sweep
               name: Run the corpus sweeps
+
+    # The Firestore security rules (tests/rules/**), which decide who may read and
+    # write every collection and had run in no workflow at all until #907 — they
+    # were a script someone had to remember. Its own job rather than a step in
+    # `vitest` because it needs a JVM and the Firestore emulator, and as a
+    # sibling it costs no wall clock: it finishes well inside the playwright gate.
+    rules:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-node@v5
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+            - run: npm ci
+              name: Install dependencies
+            - name: Set up JDK 21 # Firebase emulator requires >=21
+              uses: actions/setup-java@v5
+              with:
+                  java-version: '21'
+                  distribution: 'temurin'
+            - name: Cache Firebase emulators
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/firebase/emulators
+                  # Lockfile hash included so a firebase-tools bump invalidates
+                  # the cached jars instead of reusing stale ones.
+                  key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('package-lock.json') }}
+                  restore-keys: ${{ runner.os }}-firebase-emulators-
+            # Only the Firestore emulator: these tests evaluate firestore.rules
+            # over its REST API and need nothing else the suite starts.
+            - run: npm run test:rules
+              name: Run the security rules tests
 
     svelte-check:
         runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 - 🐛 We fixed a sentence in the sharing box that stopped halfway and said only "The curators of". It now says who reviews what you share, and sits after the rules instead of splitting them in two.
 - 🎨 We fixed the space around a list of rules in the sharing box, which used to leave more room after the list than before it.
 - 🐛 A gallery's page now says the gallery's name in your browser tab.
+- 🤝 When a curator opens a gallery's how-tos to people in their other galleries, those people can now read them, react to them, and join the chat. Before, the setting looked like it worked but showed them nothing. (#907)
+- 🔒 A how-to you're still writing now stays yours until you post it. Anyone could read your unfinished how-tos in a gallery everyone can see, and people in the gallery could move them around and react to them. (#907)
+- 💾 Bookmarks and reactions on a how-to now save when you were invited to a gallery's how-tos, or you make things in that gallery. They looked like they worked and then quietly didn't. (#907)
+- 🔒 We fixed a hole that let anyone with an account change any how-to, even ones in galleries they had nothing to do with. (#907)
 
 ## 0.34.1 - 2026-09-02
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -181,8 +181,8 @@
                     "order": "ASCENDING"
                 },
                 {
-                    "fieldPath": "viewersFlat",
-                    "arrayConfig": "CONTAINS"
+                    "fieldPath": "galleryId",
+                    "order": "ASCENDING"
                 }
             ]
         },

--- a/firestore.rules
+++ b/firestore.rules
@@ -558,61 +558,83 @@ service cloud.firestore {
         return gallery != null && "curators" in gallery && uid in gallery.curators;
       }
 
-      function isRequestorViewer(uid) {
+      // Expanded access is a grant the curator makes on the *gallery*, so it is
+      // read from the gallery. It used to be read from a `viewersFlat` on the
+      // how-to that nothing anywhere ever wrote, so this branch was always false
+      // and expanded access did not work at all (#907). Reading through costs no
+      // document access: every other branch here already get()s this same
+      // gallery, and repeat access to one document is cached and free.
+      function isRequestorViewer(uid, galleryID) {
+        let gallery = get(/databases/$(database)/documents/galleries/$(galleryID)).data;
         return 
           "scopeOverwrite" in resource.data &&
           !resource.data.scopeOverwrite &&
-          "viewersFlat" in resource.data && 
-          uid in resource.data.viewersFlat;
+          gallery != null &&
+          "howToExpandedVisibility" in gallery &&
+          gallery.howToExpandedVisibility &&
+          "howToViewersFlat" in gallery &&
+          uid in gallery.howToViewersFlat;
       }
 
       allow create: if request.auth != null && "galleryId" in request.resource.data && isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId);
-      // Published how-tos are readable if:
-      // 1) the gallery the how-to is in is public
-      // 2) the requestor is the owner or a collaborator
-      // 3) the requestor is a curator or collaborator of the gallery the how-to is in
-      // 4) the requestor is a viewer of the gallery the how-to is in
-      // Unpublished how-tos (drafts) are only readable by the creator and collaborators
+      // A draft belongs to its creator and collaborators, full stop. Everything
+      // else — the how-to's own `isPublic`, a public gallery, gallery membership,
+      // expanded access — sits under `published`, because each of those used to
+      // be tested before it and so exposed every draft in a public gallery to
+      // anyone at all (#907).
       allow read: 
         if resource.data != null && (
           (request.auth != null && "mod" in request.auth.token && request.auth.token.mod) ||
-          ('isPublic' in resource.data && resource.data.isPublic) ||
-          isRequestorOwnerCollaborator(request.auth.uid) ||
-          ('galleryId' in resource.data && isGalleryPublic(resource.data.galleryId)) ||
+          (request.auth != null && isRequestorOwnerCollaborator(request.auth.uid)) ||
           ("published" in resource.data && resource.data.published && (
-            ('galleryId' in resource.data && isRequestorCuratorCollaborator(request.auth.uid, resource.data.galleryId)) ||
-            isRequestorViewer(request.auth.uid)
+            ('isPublic' in resource.data && resource.data.isPublic) ||
+            ('galleryId' in resource.data && isGalleryPublic(resource.data.galleryId)) ||
+            (request.auth != null && 'galleryId' in resource.data && (
+              isRequestorCuratorCollaborator(request.auth.uid, resource.data.galleryId) ||
+              isRequestorViewer(request.auth.uid, resource.data.galleryId)
+            ))
           ))
         );
 
+      // How-tos can be updated by a moderator, by the owner or a collaborator,
+      // or by a curator of the gallery they are in; and through two narrow
+      // openings — placement and social — by people who may see them but not
+      // edit them.
+      //
+      // Every branch authorizes from `resource.data.galleryId`, the *stored*
+      // gallery, and the gallery is immutable. Authorizing from
+      // `request.resource.data.galleryId` — the incoming document, which the
+      // client writes — meant that any signed-in account could edit any how-to
+      // in the database by naming a gallery it had just made, since creating a
+      // gallery makes you its curator (#907). Nothing in the product moves a
+      // how-to between galleries, and a move that did would have to rewrite two
+      // galleries' `howTos` arrays atomically, which is a callable's job.
       allow update: 
-      // How-tos can be updated if:
-      // 0) a moderator
-      // 1) owner or collaborator
-      // 2) curator of the gallery the how-to is in
-      // we also allow updating the social interactions of a how-to as long as the user can view it (viewer, owner, collaborator, gallery curator or collaborator)
-      // and updating xcoord, ycoord by how-to owner/collaborator and gallery curator/collaborator
         if request.auth != null && 
+          "galleryId" in resource.data &&
+          "galleryId" in request.resource.data &&
+          request.resource.data.galleryId == resource.data.galleryId &&
           (
             ("mod" in request.auth.token && request.auth.token.mod) ||
             isRequestorOwnerCollaborator(request.auth.uid) ||
-            ("galleryId" in request.resource.data && isRequestorCurator(request.auth.uid, request.resource.data.galleryId)) ||
-            ('galleryId' in request.resource.data && 
+            isRequestorCurator(request.auth.uid, resource.data.galleryId) ||
+            // Both openings require the how-to to be published, for the reason
+            // the read rule gives: moving or reacting to a draft you cannot
+            // read is not something to permit.
+            ("published" in resource.data && resource.data.published &&
               (
                 (
-                  isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || 
-                  isRequestorOwnerCollaborator(request.auth.uid)
-                ) && 
-                request.resource.data.diff(resource.data).affectedKeys().hasOnly(["xcoord", "ycoord"])
-              ) ||
-              (
-                request.resource.data.diff(resource.data).affectedKeys().hasOnly(["social"]) && 
+                  request.resource.data.diff(resource.data).affectedKeys().hasOnly(["xcoord", "ycoord"]) &&
+                  isRequestorCuratorCollaborator(request.auth.uid, resource.data.galleryId)
+                ) ||
                 (
-                  isRequestorViewer(request.auth.uid) || 
-                  isRequestorCuratorCollaborator(request.auth.uid, request.resource.data.galleryId) || 
-                  isRequestorOwnerCollaborator(request.auth.uid)
+                  request.resource.data.diff(resource.data).affectedKeys().hasOnly(["social"]) && 
+                  (
+                    isRequestorViewer(request.auth.uid, resource.data.galleryId) || 
+                    isRequestorCuratorCollaborator(request.auth.uid, resource.data.galleryId)
+                  )
                 )
-              )  
+              )
             )
           );
       allow delete: if request.auth != null && (resource.data.creator == request.auth.uid || isRequestorCurator(request.auth.uid, resource.data.galleryId));

--- a/functions/src/subject.ts
+++ b/functions/src/subject.ts
@@ -133,16 +133,23 @@ export default async function describeSubject(
             owner,
         },
         author: owner,
-        // Every list is checked with Array.isArray first: a how-to's `viewers`
-        // is a map of gallery id to uids, not an array, so a bare `.includes`
-        // would throw on exactly the kind we most need to read.
+        // Every list is checked with Array.isArray first, since these come
+        // straight off a stored document.
+        //
+        // A how-to's expanded-access viewers are read from the *gallery*. They
+        // used to be read from `viewersFlat` on the how-to, which nothing
+        // anywhere ever wrote — so a viewer was invisible here too, and a report
+        // about a how-to they could see routed as though they could not (#907).
         visibleTo: (who) =>
             isPublic ||
             who === owner ||
             listed(thing.collaborators, who) ||
             listed(thing.commenters, who) ||
-            listed(thing.viewers, who) ||
-            listed(thing.viewersFlat, who) ||
+            (kind === 'howto' &&
+                thing.published === true &&
+                thing.scopeOverwrite !== true &&
+                gallery?.howToExpandedVisibility === true &&
+                listed(gallery?.howToViewersFlat, who)) ||
             members.includes(who),
         title:
             typeof thing.title === 'string' ? thing.title : (thing.name ?? ''),

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -432,6 +432,51 @@ const HOWTO_REACTIONS: Record<string, string> = {
     '❓': 'have a question',
 };
 
+/** The published how-to in the first public gallery, which needs no account. */
+const PUBLIC_HOWTO_ID = 'seed-public-howto-00';
+
+/** A published how-to in the shape the schema expects, for the seeds that only
+ *  need one. Multi-locale text is one string with `¶text¶/locale` markers. */
+function makeSeededHowTo(opts: {
+    id: string;
+    galleryId: string;
+    creator: string;
+    title: string;
+    text: string;
+}) {
+    return {
+        v: 2,
+        id: opts.id,
+        galleryId: opts.galleryId,
+        published: true,
+        publishedAt: Date.now(),
+        xcoord: 0,
+        ycoord: 0,
+        title: `¶${opts.title}¶/en-US`,
+        guidingQuestions: HOWTO_GUIDING_QUESTIONS,
+        text: [`¶${opts.text}¶/en-US`],
+        creator: opts.creator,
+        collaborators: [],
+        scopeOverwrite: false,
+        locales: ['en-US'],
+        isPublic: false,
+        social: {
+            v: 1,
+            notifySubscribers: true,
+            reactionOptions: HOWTO_REACTIONS,
+            reactions: Object.fromEntries(
+                Object.keys(HOWTO_REACTIONS).map((e) => [e, []]),
+            ),
+            usedByProjects: [],
+            chat: null,
+            bookmarkers: [],
+            submittedToGuide: false,
+            seenByUsers: [],
+            viewCount: 0,
+        },
+    };
+}
+
 /**
  * Seed a class + gallery + many how-tos all owned by `creator`. The class
  * lists `creator` as the sole teacher; the gallery has `creator` as both
@@ -524,8 +569,6 @@ async function seedCreatorHowTos(): Promise<void> {
             ),
             creator: creator.uid,
             collaborators: [],
-            viewers: {},
-            viewersFlat: [],
             scopeOverwrite: false,
             locales: ['en-US'],
             isPublic: false,
@@ -569,6 +612,22 @@ async function seedPublicProjectsAndGalleries(): Promise<void> {
         // them get a project, leaving the rest empty on purpose.
         const seed = SEED_PROJECTS[i];
         const gallery = makePublicGallery(i, creator.uid, seed?.id);
+        // The first public gallery gets a published how-to, so there is a
+        // public how-to space for a signed-out visitor to open.
+        if (i === 0) {
+            const howToId = PUBLIC_HOWTO_ID;
+            gallery.howTos = [howToId];
+            batch.set(
+                firestore.collection('howtos').doc(howToId),
+                makeSeededHowTo({
+                    id: howToId,
+                    galleryId: gallery.id,
+                    creator: creator.uid,
+                    title: 'A how-to anyone can read',
+                    text: 'Seeded in a public gallery, so it needs no account.',
+                }),
+            );
+        }
         batch.set(firestore.collection('galleries').doc(gallery.id), gallery);
         if (seed !== undefined) {
             const project = makePublicProject(seed, i, creator.uid, gallery.id);
@@ -827,8 +886,6 @@ async function seedOtherUserHowTos(): Promise<void> {
             ],
             creator: authors[i].uid,
             collaborators: [],
-            viewers: {},
-            viewersFlat: [],
             scopeOverwrite: false,
             locales: ['en-US'],
             isPublic: false,
@@ -883,7 +940,13 @@ async function seedExpandedScopeGallery(): Promise<void> {
         {
             howTos: [howToId],
             howToExpandedVisibility: true,
-            howToViewers: { [SEEDED_EXPANDED_GALLERY_ID]: [creator.uid] },
+            // Keyed by the gallery the access comes *from* — `creator`'s own
+            // workshop — and declared in `howToExpandedGalleries`, which is the
+            // shape `galleryEdited` maintains. Keyed by this gallery itself, the
+            // flat list still worked but described a state the trigger could
+            // never produce, so the fixture tested nothing about production.
+            howToExpandedGalleries: [SEEDED_HOWTO_GALLERY_ID],
+            howToViewers: { [SEEDED_HOWTO_GALLERY_ID]: [creator.uid] },
             howToViewersFlat: [creator.uid],
         },
     ).data;
@@ -908,8 +971,6 @@ async function seedExpandedScopeGallery(): Promise<void> {
             text: ['¶Visible to creator via expanded scope.¶/en-US'],
             creator: teacher.uid,
             collaborators: [],
-            viewers: {},
-            viewersFlat: [],
             scopeOverwrite: false,
             locales: ['en-US'],
             isPublic: false,

--- a/src/db/chats/ChatDatabase.svelte.ts
+++ b/src/db/chats/ChatDatabase.svelte.ts
@@ -9,6 +9,7 @@ import { Domain } from '@db/Domains';
 import SaveTracker, { type RePush } from '@db/SaveTracker.svelte';
 import { firestore } from '@db/firebase';
 import type Gallery from '@db/galleries/Gallery';
+import { expandedViewersOf } from '@db/howtos/howToAccess';
 import HowTo from '@db/howtos/HowToDatabase.svelte';
 import isQuotaError from '@db/isQuotaError';
 import { ChatWritableFields, HowToFields } from '@db/rulesFields';
@@ -1292,7 +1293,7 @@ export class ChatDatabase {
             participants: Array.from(
                 new Set([
                     ...howTo.getCollaborators(),
-                    ...howTo.getViewers(),
+                    ...expandedViewersOf(howTo, gallery),
                     howTo.getCreator(),
                     ...(gallery ? gallery.getCurators() : []),
                     ...(gallery ? gallery.getCreators() : []),
@@ -1409,7 +1410,7 @@ export class ChatDatabase {
         const intendedChatParticipants = [
             ...new Set([
                 ...howTo.getCollaborators(),
-                ...howTo.getViewers(),
+                ...expandedViewersOf(howTo, gallery),
                 howTo.getCreator(),
                 ...(gallery ? gallery.getCurators() : []),
                 ...(gallery ? gallery.getCreators() : []),

--- a/src/db/galleries/GalleryDatabase.svelte.ts
+++ b/src/db/galleries/GalleryDatabase.svelte.ts
@@ -259,6 +259,10 @@ export default class GalleryDatabase {
                 this.accessibleGalleries.delete(id);
             }
         }
+        // The cold-start path fills these maps too, and the how-to listeners are
+        // built from both of them. Gated inside, so a hydration that changes no
+        // membership re-subscribes nothing.
+        this.database.HowTos.galleriesChanged();
     }
 
     /** Mirror authoritative galleries into the local cache for cold-start
@@ -443,6 +447,16 @@ export default class GalleryDatabase {
                         // chunk listeners depend on the same set.
                         this.database.Characters.galleriesChanged();
                     }
+
+                    // How-tos are filtered by gallery too, and unlike projects and
+                    // characters they also follow `expandedScopeGalleries` — a
+                    // viewer's read access is a grant on the gallery (#907). That
+                    // set is deliberately outside the guard above: widening
+                    // `watchedKey` to cover it would churn every project and
+                    // character listener whenever a curator changes who a gallery
+                    // is open to. `galleriesChanged` keeps its own gate over both
+                    // maps, so this is a no-op unless the set it watches moved.
+                    this.database.HowTos.galleriesChanged();
 
                     // Mark the database loaded.
                     this.status = 'loaded';

--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -96,12 +96,6 @@ const HowToSchemaV1 = z.object({
     creator: z.string(),
     /** The list of users who can collaborate with the creator on a how-to */
     collaborators: z.array(z.string()),
-    /** The list of users who can view a how-to and interact with its social features
-     * Organized as a map from gallery ID to list of user IDs, where the gallery ID is the gallery that grants the viewer access since it is a gallery by the same curator
-     */
-    viewers: z.record(z.string(), z.array(z.string())),
-    /** Flat version of viewers, calculated in a firestore function, for firestore rule queries */
-    viewersFlat: z.array(z.string()),
     /** True if the user restricts access to the how-to to only those who have direct access to the gallery
      * I.e., overwrites the gallery curator "expanding" how-to viewing permissions
      */
@@ -124,6 +118,19 @@ const HowToSchemaV2 = HowToSchemaV1.extend({
 const HowToPreviewSchema = PreviewContentSchema;
 export type HowToPreview = z.infer<typeof HowToPreviewSchema>;
 
+/**
+ * `viewers`/`viewersFlat` are gone: they claimed to be maintained by a cloud
+ * function and nothing anywhere ever wrote them, so the rule and the query that
+ * read them matched nobody and expanded access did not work (#907). Who may view
+ * a how-to through expanded scope is a grant on the *gallery*, and is read from
+ * there now.
+ *
+ * No version bump is needed to drop them, and none of the three versions
+ * declares them any more. `HowToSchema.parse` runs in zod's default strip mode
+ * and its result is discarded — `new HowTo()` takes the pre-parse object — so a
+ * stored document still carrying the fields validates, and nothing re-persists a
+ * stripped value.
+ */
 const HowToSchemaV3 = HowToSchemaV2.extend({
     v: z.literal(3),
     /** Cached preview computed by the author's browser on save, so readers skip evaluation */
@@ -322,14 +329,6 @@ export default class HowTo {
         );
     }
 
-    getViewers() {
-        return this.data.viewersFlat;
-    }
-
-    hasViewer(userId: string) {
-        return this.data.viewersFlat.includes(userId);
-    }
-
     getLocales(): string[] {
         return this.data.locales;
     }
@@ -415,6 +414,14 @@ export default class HowTo {
 
 export const HowTosCollection = Domain.HowTos;
 
+/** Gallery IDs split into `where('galleryId','in',...)`-sized batches. */
+function chunkGalleries(ids: string[]): string[][] {
+    const chunks: string[][] = [];
+    for (let i = 0; i < ids.length; i += GALLERY_CHUNK_SIZE)
+        chunks.push(ids.slice(i, i + GALLERY_CHUNK_SIZE));
+    return chunks;
+}
+
 export class HowToDatabase {
     private readonly db: Database;
 
@@ -447,6 +454,15 @@ export class HowToDatabase {
      *  Key is the listener identity ("own", "scope", or `gallery:<chunkIndex>`).
      *  Used to garbage-collect cache entries that no listener sees anymore. */
     private listenerDocIds: Map<string, Set<string>> = new Map();
+
+    /** The gallery IDs the current listeners were built from, sorted and joined,
+     *  so a gallery edit that changes no membership re-subscribes nothing. */
+    private watchedGalleryKey: string | undefined = undefined;
+
+    /** How many listeners must have reported before the cache GC may run. Without
+     *  it, a re-subscribe empties `listenerDocIds` while the cache is still full,
+     *  and whichever listener answers first evicts everything the others hold. */
+    private expectedHowToListeners = 0;
 
     /** Dedup set so a how-to surfaced by multiple listeners only notifies once. */
 
@@ -770,8 +786,6 @@ export class HowToDatabase {
             text: text,
             creator: user as string,
             collaborators: collaborators,
-            viewers: {} as Record<string, string[]>,
-            viewersFlat: [] as string[],
             scopeOverwrite: overwriteAccessScope,
             locales: locales,
             isPublic: isPublic,
@@ -876,6 +890,8 @@ export class HowToDatabase {
         this.unsubscribes.forEach((u) => u());
         this.unsubscribes = [];
         this.listenerDocIds.clear();
+        this.watchedGalleryKey = undefined;
+        this.expectedHowToListeners = 0;
     }
 
     listen(firestore: Firestore, userId: string) {
@@ -893,6 +909,7 @@ export class HowToDatabase {
 
     private startListening(firestore: Firestore, userId: string) {
         this.db.markSyncing(Domain.HowTos);
+        this.watchedGalleryKey = this.galleryKey();
 
         // Notifications only fire for how-tos published after this point in time.
 
@@ -925,9 +942,9 @@ export class HowToDatabase {
         const editorGalleryIds = Array.from(
             this.db.Galleries.accessibleGalleries.keys(),
         );
-        for (let i = 0; i < editorGalleryIds.length; i += GALLERY_CHUNK_SIZE) {
-            const chunk = editorGalleryIds.slice(i, i + GALLERY_CHUNK_SIZE);
-            const key = `gallery:${i / GALLERY_CHUNK_SIZE}`;
+        const editorChunks = chunkGalleries(editorGalleryIds);
+        for (const [index, chunk] of editorChunks.entries()) {
+            const key = `gallery:${index}`;
             const galleryQuery = query(
                 collection(firestore, HowTosCollection),
                 where('galleryId', 'in', chunk),
@@ -942,22 +959,70 @@ export class HowToDatabase {
             );
         }
 
-        // Listener 3: published how-tos visible via expanded scope.
-        const scopeQuery = query(
-            collection(firestore, HowTosCollection),
-            and(
-                where('published', '==', true),
-                where('scopeOverwrite', '==', false),
-                where('viewersFlat', 'array-contains', userId),
-            ),
+        // Listener 3: published how-tos visible via expanded scope — the galleries
+        // a curator has opened to members of their other galleries. Selected by
+        // gallery, exactly like Listener 2, because expanded access is a grant on
+        // the gallery: it used to select on a `viewersFlat` field of the how-to
+        // that nothing ever wrote, so it matched nothing and the whole feature was
+        // dead (#907).
+        //
+        // `scopeOverwrite == false` is load-bearing for the same reason
+        // `published == true` is above — the rule's viewer branch requires it, and
+        // Firestore rejects the entire query if any matched doc would be denied.
+        const scopeChunks = chunkGalleries(
+            Array.from(this.db.Galleries.expandedScopeGalleries.keys()),
         );
-        this.unsubscribes.push(
-            onSnapshot(
-                scopeQuery,
-                (snapshot) => this.handleSnapshot('scope', snapshot),
-                (error) => this.logFirebaseError(error),
-            ),
-        );
+        for (const [index, chunk] of scopeChunks.entries()) {
+            const key = `scope:${index}`;
+            const scopeQuery = query(
+                collection(firestore, HowTosCollection),
+                and(
+                    where('galleryId', 'in', chunk),
+                    where('published', '==', true),
+                    where('scopeOverwrite', '==', false),
+                ),
+            );
+            this.unsubscribes.push(
+                onSnapshot(
+                    scopeQuery,
+                    (snapshot) => this.handleSnapshot(key, snapshot),
+                    (error) => this.logFirebaseError(error),
+                ),
+            );
+        }
+
+        this.expectedHowToListeners =
+            1 + editorChunks.length + scopeChunks.length;
+    }
+
+    /**
+     * Re-subscribe when the set of galleries the user can reach changes, since
+     * both chunked listeners' filters are built from it. A no-op when the set is
+     * the same, so a gallery edit — a rename, a project added — churns nothing.
+     *
+     * This is not only for mid-session changes. `expandedScopeGalleries` is
+     * filled by one of three gallery listeners, and `domainSettled` resolves on
+     * the first of them to report, so on a cold load the set can still be empty
+     * when the how-tos first subscribe. A warm load fills it from IndexedDB
+     * first, which is why that gap shows up for a new account and not on a
+     * machine that has run the app before.
+     */
+    galleriesChanged() {
+        if (firestore === undefined) return;
+        const user = this.db.getUser();
+        if (!user) return;
+        if (this.galleryKey() === this.watchedGalleryKey) return;
+        this.listen(firestore, user.uid);
+    }
+
+    /** Every gallery whose how-tos this user may see, as a stable string. */
+    private galleryKey() {
+        return [
+            ...this.db.Galleries.accessibleGalleries.keys(),
+            ...this.db.Galleries.expandedScopeGalleries.keys(),
+        ]
+            .sort()
+            .join(',');
     }
 
     private handleSnapshot(key: string, snapshot: QuerySnapshot<DocumentData>) {
@@ -997,18 +1062,28 @@ export class HowToDatabase {
         snapshot.docChanges().forEach((change) => {});
 
         // (c) Cache GC: a doc should remain cached iff at least one listener still sees it.
-        //     Safe on initial load — listeners that haven't fired yet have no entry in
-        //     listenerDocIds, so the union only includes IDs we've actually loaded.
-        const union = new Set<string>();
-        for (const ids of this.listenerDocIds.values())
-            for (const id of ids) union.add(id);
+        //     Only once every listener has reported, and only against server-fresh
+        //     data. The old "listeners that haven't fired have no entry" reasoning
+        //     held only on a cold start, when the cache is empty too; on a
+        //     re-subscribe — which `galleriesChanged` now makes routine — the cache
+        //     is full while `listenerDocIds` is empty, so whichever listener answers
+        //     first would evict everything the others hold and the canvas would
+        //     blank and refill on every membership change.
+        if (
+            !snapshot.metadata.fromCache &&
+            this.listenerDocIds.size === this.expectedHowToListeners
+        ) {
+            const union = new Set<string>();
+            for (const ids of this.listenerDocIds.values())
+                for (const id of ids) union.add(id);
 
-        for (const cachedId of this.howtos.keys()) {
-            // Keep how-tos with unsaved local edits even if no listener sees
-            // them (they aren't on the server yet) — pruning them would drop the
-            // only copy and leave nothing for flushUnsaved to replay.
-            if (!union.has(cachedId) && !this.unsavedIDs.has(cachedId))
-                this.howtos.delete(cachedId);
+            for (const cachedId of this.howtos.keys()) {
+                // Keep how-tos with unsaved local edits even if no listener sees
+                // them (they aren't on the server yet) — pruning them would drop the
+                // only copy and leave nothing for flushUnsaved to replay.
+                if (!union.has(cachedId) && !this.unsavedIDs.has(cachedId))
+                    this.howtos.delete(cachedId);
+            }
         }
 
         this.db.markSynced(Domain.HowTos, this.howtos.size);

--- a/src/db/howtos/howToAccess.test.ts
+++ b/src/db/howtos/howToAccess.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// `HowToDatabase.svelte.ts` reaches `@db/Database` for the singleton, which
+// constructs every domain database at import — the same circular import
+// `HowToDatabase.test.ts` mocks around. Only the `HowTo` wrapper class is under
+// test here, and it needs none of it.
+vi.mock('@db/firebase', () => ({ firestore: undefined }));
+vi.mock('@db/Database', () => ({}));
+
+import Gallery from '@db/galleries/Gallery';
+import HowTo, { type HowToDocument } from './HowToDatabase.svelte';
+import {
+    canConfigureHowToSpace,
+    canCreateHowTo,
+    canDeleteHowTo,
+    canEditHowTo,
+    canInteractSocially,
+    canMoveHowTo,
+} from './howToAccess';
+import {
+    Actions,
+    Actors,
+    GalleryPermissions,
+    permits,
+    Scenarios,
+    ServerOnlyActions,
+    ServerOnlyActors,
+    type Action,
+    type Actor,
+    type Scenario,
+} from './howToAccessScenarios';
+
+/**
+ * The client half of #907's permission matrix. `tests/rules/howToRules.test.ts`
+ * drives the same table against the emulator, so an affordance the interface
+ * offers that the server would refuse — the silent-refusal class of #1348-#1350
+ * — fails here rather than in someone's browser.
+ */
+
+const Uid: Record<Exclude<Actor, 'anon'>, string> = {
+    owner: 'owner-uid',
+    collaborator: 'collaborator-uid',
+    curator: 'curator-uid',
+    galleryCreator: 'gallerycreator-uid',
+    viewer: 'viewer-uid',
+    stranger: 'stranger-uid',
+    mod: 'mod-uid',
+};
+
+function galleryFor(scenario: Scenario): Gallery {
+    return Gallery.make(
+        'gallery',
+        { 'en-US': 'Gallery' },
+        { 'en-US': '' },
+        [Uid.curator],
+        [Uid.galleryCreator],
+        {
+            howTos: ['howto'],
+            public: scenario.gallery.public,
+            howToExpandedVisibility: scenario.gallery.expandedVisibility,
+            howToViewers: { source: [Uid.viewer] },
+            howToViewersFlat: [Uid.viewer],
+        },
+    );
+}
+
+function howToFor(scenario: Scenario): HowTo {
+    const data: HowToDocument = {
+        v: 3,
+        id: 'howto',
+        galleryId: 'gallery',
+        published: scenario.howTo.published,
+        publishedAt: scenario.howTo.published ? 1 : null,
+        xcoord: 0,
+        ycoord: 0,
+        title: '¶How-to¶/en-US',
+        guidingQuestions: [],
+        text: ['¶Body¶/en-US'],
+        creator: Uid.owner,
+        collaborators: [Uid.collaborator],
+        scopeOverwrite: scenario.howTo.scopeOverwrite,
+        locales: ['en-US'],
+        isPublic: scenario.howTo.isPublic,
+        social: {
+            v: 1,
+            notifySubscribers: true,
+            reactionOptions: {},
+            reactions: {},
+            usedByProjects: [],
+            chat: null,
+            bookmarkers: [],
+            submittedToGuide: false,
+            seenByUsers: [],
+            viewCount: 0,
+        },
+    };
+    return new HowTo(data);
+}
+
+/** The predicate behind each action the client actually gates on. */
+function ask(
+    action: Exclude<Action, 'read'>,
+    howTo: HowTo,
+    gallery: Gallery,
+    uid: string | undefined,
+): boolean {
+    switch (action) {
+        case 'edit':
+            return canEditHowTo(howTo, gallery, uid);
+        case 'delete':
+            return canDeleteHowTo(howTo, gallery, uid);
+        case 'move':
+            return canMoveHowTo(howTo, gallery, uid);
+        case 'social':
+            return canInteractSocially(howTo, gallery, uid);
+    }
+}
+
+const clientActors = Actors.filter((a) => !ServerOnlyActors.includes(a));
+const clientActions = Actions.filter(
+    (a): a is Exclude<Action, 'read'> => !ServerOnlyActions.includes(a),
+);
+
+describe.each(Scenarios)('$name', (scenario) => {
+    const howTo = howToFor(scenario);
+    const gallery = galleryFor(scenario);
+
+    test.each(clientActors)('%s', (actor) => {
+        const uid = actor === 'anon' ? undefined : Uid[actor];
+        const verdicts = clientActions.map(
+            (action) => `${action}: ${ask(action, howTo, gallery, uid)}`,
+        );
+        expect(verdicts).toEqual(
+            clientActions.map(
+                (action) => `${action}: ${permits(scenario, actor, action)}`,
+            ),
+        );
+    });
+});
+
+describe('creating a how-to and configuring the space', () => {
+    const gallery = galleryFor(Scenarios[0]);
+
+    test.each(clientActors)('%s', (actor) => {
+        const uid = actor === 'anon' ? undefined : Uid[actor];
+        const allowed = GalleryPermissions[actor] ?? [];
+        expect({
+            create: canCreateHowTo(gallery, uid),
+            configure: canConfigureHowToSpace(gallery, uid),
+        }).toEqual({
+            create: allowed.includes('create'),
+            configure: allowed.includes('configure'),
+        });
+    });
+
+    test('nobody at all when the gallery has not loaded', () => {
+        expect(canCreateHowTo(undefined, Uid.curator)).toBe(false);
+        expect(canConfigureHowToSpace(undefined, Uid.curator)).toBe(false);
+    });
+});

--- a/src/db/howtos/howToAccess.ts
+++ b/src/db/howtos/howToAccess.ts
@@ -1,0 +1,128 @@
+import type Gallery from '@db/galleries/Gallery';
+import type HowTo from './HowToDatabase.svelte';
+
+/**
+ * Who may do what with a how-to, in one place. These mirror the `match /howtos`
+ * branches in `firestore.rules` and are held to the same table the rules tests
+ * use (`howToAccessScenarios.ts`), so an affordance the interface offers and a
+ * write the server will actually accept cannot drift apart — the silent-refusal
+ * class of #1348-#1350, where a refused write leaves a document permanently
+ * unsaved and says nothing.
+ *
+ * They were four `$derived` expressions spread across the how-to route's
+ * components, one of which — `isCreatorCollaboratorViewer` — did not check the
+ * how-to's own collaborators despite its name. As pure functions over documents
+ * rather than component state they are testable in milliseconds, and they
+ * outlive any redesign of the markup around them.
+ */
+
+/** `null` is a gallery still loading or out of reach; `undefined` is none. */
+type MaybeGallery = Gallery | null | undefined;
+
+/** A uid of `undefined` is a signed-out viewer, who may do none of this. */
+type MaybeUser = string | undefined;
+
+/** Curating the gallery — the widest gallery role. */
+function curates(gallery: MaybeGallery, uid: MaybeUser): boolean {
+    return uid !== undefined && !!gallery && gallery.hasCurator(uid);
+}
+
+/** Belonging to the gallery at all: curating it, or creating in it. */
+function belongs(gallery: MaybeGallery, uid: MaybeUser): boolean {
+    return (
+        uid !== undefined &&
+        !!gallery &&
+        (gallery.hasCurator(uid) || gallery.hasCreator(uid))
+    );
+}
+
+/**
+ * The people a curator has opened this gallery's how-tos to. Empty unless the
+ * curator switched expanded visibility on and this how-to's creator left the
+ * gallery-wide scope in place.
+ *
+ * The list lives on the *gallery*, which is the only place it is ever written
+ * (`galleryEdited` maintains it). It used to be read from a `viewersFlat` on the
+ * how-to that nothing anywhere wrote, so expanded access did nothing at all
+ * (#907).
+ */
+export function expandedViewersOf(
+    howTo: HowTo,
+    gallery: MaybeGallery,
+): string[] {
+    if (!gallery) return [];
+    if (!gallery.getHowToExpandedVisibility()) return [];
+    if (howTo.getScopeOverwrite()) return [];
+    return gallery.getHowToViewers();
+}
+
+/** Posting a how-to is open to everyone the gallery belongs to. */
+export function canCreateHowTo(gallery: MaybeGallery, uid: MaybeUser): boolean {
+    return belongs(gallery, uid);
+}
+
+/**
+ * The space's guiding questions and reaction set are the curator's decision and
+ * not every creator's — one shared prompt is the point of them.
+ */
+export function canConfigureHowToSpace(
+    gallery: MaybeGallery,
+    uid: MaybeUser,
+): boolean {
+    return curates(gallery, uid);
+}
+
+/** Editing the words: the creator, a collaborator, or the gallery's curator. */
+export function canEditHowTo(
+    howTo: HowTo,
+    gallery: MaybeGallery,
+    uid: MaybeUser,
+): boolean {
+    if (uid === undefined) return false;
+    return howTo.isCreatorCollaborator(uid) || curates(gallery, uid);
+}
+
+/**
+ * Deleting is narrower than editing: the how-to's own creator, or the gallery's
+ * curator. A collaborator may rewrite it but not destroy it.
+ */
+export function canDeleteHowTo(
+    howTo: HowTo,
+    gallery: MaybeGallery,
+    uid: MaybeUser,
+): boolean {
+    if (uid === undefined) return false;
+    return howTo.getCreator() === uid || curates(gallery, uid);
+}
+
+/**
+ * Moving a tile is arranging the shared space, so it is open to everyone the
+ * gallery belongs to — but not to an expanded-access viewer, who is a guest
+ * here, and never on a draft, which nobody outside it can see to arrange.
+ */
+export function canMoveHowTo(
+    howTo: HowTo,
+    gallery: MaybeGallery,
+    uid: MaybeUser,
+): boolean {
+    if (canEditHowTo(howTo, gallery, uid)) return true;
+    return howTo.isPublished() && belongs(gallery, uid);
+}
+
+/**
+ * Bookmarking, reacting, citing and chatting — everything in the social pane,
+ * and so also who may be added as a collaborator. The widest of these: anyone
+ * who can reach a published how-to may take part in it, an expanded-access
+ * viewer included, which is what expanded access is for.
+ */
+export function canInteractSocially(
+    howTo: HowTo,
+    gallery: MaybeGallery,
+    uid: MaybeUser,
+): boolean {
+    if (canEditHowTo(howTo, gallery, uid)) return true;
+    if (uid === undefined || !howTo.isPublished()) return false;
+    return (
+        belongs(gallery, uid) || expandedViewersOf(howTo, gallery).includes(uid)
+    );
+}

--- a/src/db/howtos/howToAccessScenarios.ts
+++ b/src/db/howtos/howToAccessScenarios.ts
@@ -1,0 +1,251 @@
+/**
+ * #907's permission checklist, written down once so that both enforcement points
+ * are held to it: `tests/rules/howToRules.test.ts` drives this table against the
+ * Firestore emulator, and `howToAccess.test.ts` drives it against the pure
+ * predicates the UI gates on. A row is the statement; neither suite gets to
+ * disagree with it quietly.
+ *
+ * Deliberately import-free plain TypeScript. `vitest.rules.config.ts` declares no
+ * `resolve.alias`, so `tests/rules/**` reaches this file by relative path and
+ * cannot follow a `@db/...` import out of it.
+ */
+
+/** Who is asking. `anon` is signed out; `mod` carries the moderator claim. */
+export type Actor =
+    | 'owner'
+    | 'collaborator'
+    | 'curator'
+    | 'galleryCreator'
+    | 'viewer'
+    | 'stranger'
+    | 'anon'
+    | 'mod';
+
+export const Actors: Actor[] = [
+    'owner',
+    'collaborator',
+    'curator',
+    'galleryCreator',
+    'viewer',
+    'stranger',
+    'anon',
+    'mod',
+];
+
+/**
+ * What they are asking to do. `edit` is a whole-document write; `move` is the
+ * `xcoord`/`ycoord` opening and `social` the `social` one, which are the two
+ * narrow branches the rules admit for people who may not edit.
+ */
+export type Action = 'read' | 'edit' | 'delete' | 'move' | 'social';
+
+/**
+ * `delete` is last on purpose: a suite that probes every action against one
+ * fixture must not remove the document before the probes that follow it.
+ */
+export const Actions: Action[] = ['read', 'edit', 'move', 'social', 'delete'];
+
+/**
+ * `read` is server-only: the client has no `canReadHowTo`, because what a
+ * creator may read is decided by the three listener queries rather than by a
+ * predicate, and adding one with no call site would be a claim nothing tests.
+ */
+export const ServerOnlyActions: Action[] = ['read'];
+
+/**
+ * `mod` is server-only: the claim lives on the auth token and the client's
+ * predicates take only `(howTo, gallery, uid)`. A moderator's reach is the
+ * moderation surfaces, not the how-to space's own affordances.
+ */
+export const ServerOnlyActors: Actor[] = ['mod'];
+
+/** The how-to under test. */
+export type HowToState = {
+    published: boolean;
+    /** Public independent of the gallery's permissions (schema v2). */
+    isPublic: boolean;
+    /** The creator's opt-out of the gallery-wide expanded scope. */
+    scopeOverwrite: boolean;
+};
+
+/** The gallery it sits in. */
+export type GalleryState = {
+    public: boolean;
+    /** Whether the curator has switched expanded how-to access on at all. */
+    expandedVisibility: boolean;
+};
+
+export type Scenario = {
+    /** Reads as the test name, so it should say what is being claimed. */
+    name: string;
+    howTo: HowToState;
+    gallery: GalleryState;
+    /** Everything not listed for an actor is denied. */
+    allowed: Partial<Record<Actor, Action[]>>;
+};
+
+const Published = { published: true, isPublic: false, scopeOverwrite: false };
+const Draft = { published: false, isPublic: false, scopeOverwrite: false };
+const Private = { public: false, expandedVisibility: false };
+const Expanded = { public: false, expandedVisibility: true };
+
+/**
+ * A collaborator may not delete: the delete rule reads the how-to's `creator`
+ * and the gallery's curators, and nothing else. A gallery creator may not edit
+ * the body but may move and react, which is what "can move any how-to" in #907
+ * amounts to. A moderator may read and write but not delete — there is no mod
+ * branch on delete, and taking a how-to down is `moderate.ts` setting
+ * `published: false`, not a deletion.
+ */
+const OwnerAll: Action[] = ['read', 'edit', 'delete', 'move', 'social'];
+const CollaboratorAll: Action[] = ['read', 'edit', 'move', 'social'];
+const GalleryCreatorPublished: Action[] = ['read', 'move', 'social'];
+const ModPublished: Action[] = ['read', 'edit', 'move', 'social'];
+
+export const Scenarios: Scenario[] = [
+    {
+        name: 'a published how-to in a private gallery',
+        howTo: Published,
+        gallery: Private,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: OwnerAll,
+            galleryCreator: GalleryCreatorPublished,
+            mod: ModPublished,
+            // No expanded visibility, so a viewer is a stranger here.
+        },
+    },
+    {
+        name: 'a draft in a private gallery',
+        howTo: Draft,
+        gallery: Private,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            // A curator may write a draft they may not read. That asymmetry is
+            // #907's, not an oversight: "can edit any how-to in the gallery"
+            // and "cannot see another creator's drafts" are both on the list.
+            curator: ['edit', 'delete', 'move', 'social'],
+            mod: ModPublished,
+        },
+    },
+    {
+        name: 'a published how-to in a public gallery',
+        howTo: Published,
+        gallery: { public: true, expandedVisibility: false },
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: OwnerAll,
+            galleryCreator: GalleryCreatorPublished,
+            mod: ModPublished,
+            // Anyone may read a public gallery's published how-tos, and no one
+            // outside it may touch them — #907's "the entire social pane should
+            // be removed".
+            viewer: ['read'],
+            stranger: ['read'],
+            anon: ['read'],
+        },
+    },
+    {
+        name: 'a draft in a public gallery (a public gallery must not expose drafts)',
+        howTo: Draft,
+        gallery: { public: true, expandedVisibility: false },
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: ['edit', 'delete', 'move', 'social'],
+            mod: ModPublished,
+        },
+    },
+    {
+        name: 'a published how-to visible through expanded access',
+        howTo: Published,
+        gallery: Expanded,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: OwnerAll,
+            galleryCreator: GalleryCreatorPublished,
+            mod: ModPublished,
+            // The whole point of expanded access: read and take part, but not
+            // edit, delete, or move. #907: "cannot move any how-to, unless
+            // added specifically as a collaborator".
+            viewer: ['read', 'social'],
+        },
+    },
+    {
+        name: 'a published how-to whose creator opted out of expanded scope',
+        howTo: { ...Published, scopeOverwrite: true },
+        gallery: Expanded,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: OwnerAll,
+            galleryCreator: GalleryCreatorPublished,
+            mod: ModPublished,
+        },
+    },
+    {
+        name: 'a draft in a gallery with expanded access on',
+        howTo: Draft,
+        gallery: Expanded,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: ['edit', 'delete', 'move', 'social'],
+            mod: ModPublished,
+        },
+    },
+    {
+        name: 'a how-to published publicly on its own, in a private gallery',
+        howTo: { ...Published, isPublic: true },
+        gallery: Private,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: OwnerAll,
+            galleryCreator: GalleryCreatorPublished,
+            mod: ModPublished,
+            viewer: ['read'],
+            stranger: ['read'],
+            anon: ['read'],
+        },
+    },
+    {
+        name: 'an unpublished how-to marked public (a draft is never public)',
+        howTo: { ...Draft, isPublic: true },
+        gallery: Private,
+        allowed: {
+            owner: OwnerAll,
+            collaborator: CollaboratorAll,
+            curator: ['edit', 'delete', 'move', 'social'],
+            mod: ModPublished,
+        },
+    },
+];
+
+/** Whether `actor` may do `action` in `scenario`. */
+export function permits(
+    scenario: Scenario,
+    actor: Actor,
+    action: Action,
+): boolean {
+    return (scenario.allowed[actor] ?? []).includes(action);
+}
+
+/**
+ * Creating a how-to and configuring the space are decided by the gallery alone,
+ * so they are their own small table rather than a column above.
+ */
+export const GalleryActions = ['create', 'configure'] as const;
+export type GalleryAction = (typeof GalleryActions)[number];
+
+/** Everything not listed is denied. A moderator has no create branch. */
+export const GalleryPermissions: Partial<Record<Actor, GalleryAction[]>> = {
+    curator: ['create', 'configure'],
+    // A gallery creator posts how-tos but does not set the space's guiding
+    // questions or reaction set — that is the curator's decision.
+    galleryCreator: ['create'],
+};

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -26,6 +26,10 @@
         Locales,
         locales,
     } from '@db/Database';
+    import {
+        canConfigureHowToSpace,
+        canCreateHowTo,
+    } from '@db/howtos/howToAccess';
     import type Gallery from '@db/galleries/Gallery';
     import HowTo from '@db/howtos/HowToDatabase.svelte';
     import Project from '@db/projects/Project';
@@ -117,17 +121,18 @@
     // the component-creation cost is paid off-screen, not on first visibility.
     let PRELOAD_MARGIN = $derived(Math.max(canvasWidth, canvasHeight) / 2);
 
-    // determine if the user can add a new how-to
+    // Whether this creator may post a how-to here, which also gates the drafts
+    // sidebar; and whether they may set the space's guiding questions and
+    // reactions, which is the curator's alone.
     let canUserEdit = $derived(
-        gallery
-            ? isAuthenticated($user) &&
-                  (gallery.hasCurator($user.uid) ||
-                      gallery.hasCreator($user.uid))
-            : false,
+        canCreateHowTo(gallery, isAuthenticated($user) ? $user.uid : undefined),
     );
 
     let isUserCurator = $derived(
-        gallery && $user && gallery.hasCurator($user.uid),
+        canConfigureHowToSpace(
+            gallery,
+            isAuthenticated($user) ? $user.uid : undefined,
+        ),
     );
 
     let usersBookmarks: HowTo[] = $derived(
@@ -566,11 +571,7 @@
                                     {canvasHeight}
                                     bind:whichMoving
                                     bind:notPermittedAreas
-                                    galleryCuratorCollaborators={gallery
-                                        ? gallery
-                                              .getCurators()
-                                              .concat(gallery.getCreators())
-                                        : []}
+                                    {gallery}
                                     bind:whichDialogOpen
                                 />
                             {/if}

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToForm.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToForm.svelte
@@ -29,7 +29,13 @@
         Locales,
         locales,
     } from '@db/Database';
+    import {
+        canDeleteHowTo,
+        canEditHowTo,
+        canInteractSocially,
+    } from '@db/howtos/howToAccess';
     import { enqueuePreviewCompute } from '@db/projects/previewQueue';
+    import { HowToFields } from '@db/rulesFields';
     import Project from '@db/projects/Project';
     import Source from '@nodes/Source';
     import { toMarkup } from '@parser/toMarkup';
@@ -554,7 +560,11 @@
             social: { bookmarkers: newBookmarkers },
         });
 
-        await HowTos.updateHowTo(howTo, true);
+        // Only `social`: an expanded-access viewer and a gallery creator hold
+        // that opening and no other, and a whole-document write is refused
+        // outright — silently, leaving the how-to permanently unsaved on that
+        // device (#1348-#1350, same class).
+        await HowTos.updateHowTo(howTo, true, HowToFields.Social);
     }
 
     function addRemoveReaction(reactionLabel: string) {
@@ -581,15 +591,13 @@
 
         howTo = howTo.withFields({ social: { reactions: newReactions } });
 
-        HowTos.updateHowTo(howTo, true);
+        HowTos.updateHowTo(howTo, true, HowToFields.Social);
     }
 
+    /** Who may take part in this how-to's social pane, and so who may be added
+     *  as a collaborator on it. */
     function isCreatorCollaboratorViewer(uid: string) {
-        return (
-            howTo?.hasViewer(uid) ||
-            gallery?.hasCurator(uid) ||
-            gallery?.hasCreator(uid)
-        );
+        return howTo !== undefined && canInteractSocially(howTo, gallery, uid);
     }
 
     function updateCollaborators(toChangeID: string, add: boolean) {
@@ -922,7 +930,7 @@
             <HowToUsedBy bind:howTo compact />
         </div>
         <div class="toolbar">
-            {#if howTo.isCreatorCollaborator($user.uid) || gallery?.hasCurator($user.uid)}
+            {#if canEditHowTo(howTo, gallery, $user.uid) || canDeleteHowTo(howTo, gallery, $user.uid)}
                 <Button
                     tip={(l) => l.ui.howto.viewer.edit.tip}
                     label={(l) => l.ui.howto.viewer.edit.label}

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToPreview.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToPreview.svelte
@@ -11,6 +11,8 @@
     import { pickPreviewExample } from '@concepts/pickPreviewExample';
     import { DB, HowTos, locales } from '@db/Database';
     import HowTo from '@db/howtos/HowToDatabase.svelte';
+    import type Gallery from '@db/galleries/Gallery';
+    import { canMoveHowTo } from '@db/howtos/howToAccess';
     import { HowToFields } from '@db/rulesFields';
     import { enqueuePreviewCompute } from '@db/projects/previewQueue';
     import Project from '@db/projects/Project';
@@ -37,7 +39,7 @@
         canvasHeight: number;
         whichMoving: string | undefined;
         notPermittedAreas: SvelteMap<string, [number, number, number, number]>;
-        galleryCuratorCollaborators: string[];
+        gallery: Gallery | undefined;
         whichDialogOpen: string | undefined;
     }
 
@@ -49,7 +51,7 @@
         canvasHeight,
         whichMoving = $bindable(),
         notPermittedAreas = $bindable(),
-        galleryCuratorCollaborators,
+        gallery,
         whichDialogOpen = $bindable(),
     }: Props = $props();
 
@@ -148,16 +150,16 @@
 
     // code that enables drag and drop functionality
 
-    // don't allow the user to move the how-to if they don't have write permission to the db
-    // currently, only the creator, collaborators of the how-to + the curators, collaborators of the gallery can write
-    let allWriters: string[] = $derived([
-        ...howTo.getCollaborators(),
-        howTo.getCreator(),
-        ...galleryCuratorCollaborators,
-    ]);
+    // Arranging the shared space is open to everyone the gallery belongs to, but
+    // not to an expanded-access viewer, who is a guest here — and never on a
+    // draft, which nobody outside it can see to arrange.
     let user = getUser();
     let canEdit: boolean = $derived(
-        isAuthenticated($user) && allWriters.includes($user.uid),
+        canMoveHowTo(
+            howTo,
+            gallery,
+            isAuthenticated($user) ? $user.uid : undefined,
+        ),
     );
 
     /** Anchor recorded at drag start: the viewport-space cursor position

--- a/src/util/importGraph.test.ts
+++ b/src/util/importGraph.test.ts
@@ -597,13 +597,26 @@ test('resolving a color needs no basis', () => {
  * refresh beside `ensureAuth`. Every byte budget moves by a hundredth, and the
  * landing page's by two: that is the module, the new save-failure message, and
  * its translation into every locale.
+ *
+ * Stating who may read and write a how-to once (#907) is **+1 file**, and the
+ * same move for the same reason. `howToAccess.ts` is a leaf that imports only
+ * types, holding the predicates the interface gates on so they can be checked
+ * against `firestore.rules` — by the same table the emulator tests use — without
+ * standing up Firebase. It reaches these entries through `ChatDatabase`, which
+ * needs it to decide a how-to chat's participants: expanded-access viewers are
+ * part of that conversation, and reading them from the wrong document is what
+ * made the whole feature inert. A file rather than four `$derived` expressions
+ * in Svelte components, because a component's gate cannot be tested at all and
+ * dies with the next redesign. Every byte budget moves by a hundredth, which is
+ * the module itself — it is mostly comment, and pulls in nothing that was not
+ * already here.
  */
 test.each([
-    ['src/routes/+layout.svelte', 507, 3.77],
-    ['src/components/app/Page.svelte', 530, 4.02],
-    ['src/routes/[[locale]]/+page.svelte', 545, 4.11],
-    ['src/routes/[[locale]]/galleries/+page.svelte', 549, 4.12],
-    ['src/routes/[[locale]]/projects/+page.svelte', 556, 4.14],
+    ['src/routes/+layout.svelte', 508, 3.78],
+    ['src/components/app/Page.svelte', 531, 4.03],
+    ['src/routes/[[locale]]/+page.svelte', 546, 4.11],
+    ['src/routes/[[locale]]/galleries/+page.svelte', 550, 4.13],
+    ['src/routes/[[locale]]/projects/+page.svelte', 557, 4.15],
 ])('%s stays within its import budget', (entry, maxFiles, maxMB) => {
     const reach = reachFrom(entry, Root);
     expect(

--- a/src/util/isolatedTests.ts
+++ b/src/util/isolatedTests.ts
@@ -19,6 +19,7 @@ export const MockingTests = [
     'src/db/galleries/GalleryDatabase.test.ts',
     'src/db/getFirebaseTranslator.test.ts',
     'src/db/howtos/HowToDatabase.test.ts',
+    'src/db/howtos/howToAccess.test.ts',
     'src/db/projects/PresenceTracker.test.ts',
     'src/db/projects/YjsFirestoreProvider.test.ts',
     'src/db/teachers/TeacherDatabase.test.ts',

--- a/tests/end2end/howto-form.spec.ts
+++ b/tests/end2end/howto-form.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '../../playwright/fixtures';
+import { enUS, text } from '../helpers/localize';
 import { createTestGallery } from '../helpers/createGallery';
 import { waitForDocumentUpdate, getTestDocument } from '../helpers/firestore';
 import {
@@ -27,15 +28,23 @@ async function createViaForm(
     post = false,
 ): Promise<void> {
     await page.goto(`/en-US/gallery/${galleryId}/howto`);
-    await page.getByRole('button', { name: 'Create a new how-to' }).click();
+    await page
+        .getByRole('button', {
+            name: text(enUS.ui.howto.editor.newForm.header),
+        })
+        .click();
     const titleField = page.locator('#howto-title');
     await titleField.waitFor();
     await titleField.fill(title);
     await page
         .getByRole('button', {
-            name: post
-                ? 'post your how-to to the space'
-                : 'save your how-to as a draft',
+            // From the locale rather than typed in English, so a reword moves
+            // the test with the app instead of breaking it.
+            name: text(
+                post
+                    ? enUS.ui.howto.editor.post.tip
+                    : enUS.ui.howto.editor.save.tip,
+            ),
         })
         .click();
 }
@@ -150,8 +159,12 @@ test.describe('how-to editor form', () => {
         // Reopen the draft, switch to edit mode, and change the title. Each
         // how-to form keeps its own #howto-title in the DOM (the closed "+"
         // form's too), so scope to the visible one — the open draft dialog.
-        await page.getByRole('button', { name: 'view your draft' }).click();
-        await page.getByRole('button', { name: 'edit this how-to' }).click();
+        await page
+            .getByRole('button', { name: text(enUS.ui.howto.drafts.tooltip) })
+            .click();
+        await page
+            .getByRole('button', { name: text(enUS.ui.howto.viewer.edit.tip) })
+            .click();
         const titleField = page.locator('#howto-title:visible');
         await titleField.waitFor();
         await titleField.fill('After Edit');
@@ -182,12 +195,16 @@ test.describe('how-to editor form', () => {
         await page.goto(`/en-US/gallery/${galleryId}/howto`);
         await cutFirestore(page);
 
-        await page.getByRole('button', { name: 'Create a new how-to' }).click();
+        await page
+            .getByRole('button', {
+                name: text(enUS.ui.howto.editor.newForm.header),
+            })
+            .click();
         const titleField = page.locator('#howto-title');
         await titleField.waitFor();
         await titleField.fill('Offline Draft');
         await page
-            .getByRole('button', { name: 'save your how-to as a draft' })
+            .getByRole('button', { name: text(enUS.ui.howto.editor.save.tip) })
             .click();
 
         // Wait until the new how-to's dirty row is durable (its id is generated

--- a/tests/end2end/seeded-load.spec.ts
+++ b/tests/end2end/seeded-load.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { enUS, text } from '../helpers/localize';
 import { loginNewContext } from '../helpers/loginNewContext';
 
 /**
@@ -106,4 +107,64 @@ test('teacher sees how-tos authored by other users in the class gallery', async 
     } finally {
         await context.close();
     }
+});
+
+test('an expanded-scope viewer reads the space but cannot add to it', async ({
+    browser,
+}) => {
+    // `creator` curates nothing in this gallery — `teacher` does — and reaches it
+    // only through `howToViewersFlat`. That grant is a field on the *gallery*, and
+    // the rules used to look for it on the how-to, where nothing ever wrote it, so
+    // this whole path was dead and the fixture it needs had sat unread since #882
+    // (#907). Read-only is the other half of the claim: a guest takes part in a
+    // how-to but does not post to someone else's space.
+    const { context, page } = await loginNewContext(
+        browser,
+        'creator',
+        'password',
+    );
+    try {
+        await page.goto(
+            '/en-US/gallery/seeded-expanded-scope-gallery-id/howto',
+        );
+        // Attached rather than visible: canvas tiles are virtualized to the
+        // camera's viewport, so presence is the "it synced" signal.
+        await expect(
+            page.getByText('Expanded-scope how-to').first(),
+        ).toBeAttached({ timeout: NO_BANNER_TIMEOUT });
+        // Names read from the locale rather than typed in English, so a reword
+        // moves the test with the app.
+        await expect(
+            page.getByRole('button', {
+                name: text(enUS.ui.howto.editor.newForm.header),
+            }),
+        ).toHaveCount(0);
+        await expect(
+            page.getByText(text(enUS.ui.howto.drafts.header)),
+        ).toHaveCount(0);
+    } finally {
+        await context.close();
+    }
+});
+
+test('a signed-out visitor reads a public space and cannot take part', async ({
+    page,
+}) => {
+    // No fixture login at all: the public branch of the read rule is the one path
+    // that must work with no account. The social pane is the other half — #907's
+    // "the entire social pane should be removed" for a passer-by.
+    await page.goto('/en-US/gallery/seed-public-gallery-00/howto');
+    await expect(
+        page.getByText('A how-to anyone can read').first(),
+    ).toBeAttached({ timeout: NO_BANNER_TIMEOUT });
+    await expect(
+        page.getByRole('button', {
+            name: text(enUS.ui.howto.bookmarks.canBookmark.label),
+        }),
+    ).toHaveCount(0);
+    await expect(
+        page.getByRole('button', {
+            name: text(enUS.ui.howto.editor.newForm.header),
+        }),
+    ).toHaveCount(0);
 });

--- a/tests/rules/howToRules.test.ts
+++ b/tests/rules/howToRules.test.ts
@@ -1,0 +1,296 @@
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment,
+    type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { readFileSync } from 'fs';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    Actions,
+    Actors,
+    GalleryPermissions,
+    permits,
+    Scenarios,
+    type Action,
+    type Actor,
+    type Scenario,
+} from '../../src/db/howtos/howToAccessScenarios';
+
+/**
+ * Security-rules tests for how-tos — the first they have ever had, and the
+ * reason #907 stayed open. The permission model shipped in #882 is a checklist
+ * of who may read, edit, move, react to and delete a how-to, and until now every
+ * line of it was enforced only by rules nothing exercised.
+ *
+ * The matrix itself lives in `src/db/howtos/howToAccessScenarios.ts` so that the
+ * client's own predicates are held to the same table (see `howToAccess.test.ts`).
+ * This file is the server half.
+ */
+
+const Users: Record<Exclude<Actor, 'anon'>, string> = {
+    owner: 'rulestest-howto-owner',
+    collaborator: 'rulestest-howto-collaborator',
+    curator: 'rulestest-howto-curator',
+    galleryCreator: 'rulestest-howto-gallerycreator',
+    viewer: 'rulestest-howto-viewer',
+    stranger: 'rulestest-howto-stranger',
+    mod: 'rulestest-howto-mod',
+};
+
+const Gallery = 'rulestest-howto-gallery';
+const HowTo = 'rulestest-howto';
+/** The document the create tests make, deleted before each of them. */
+const New = 'rulestest-howto-new';
+
+let env: RulesTestEnvironment;
+
+/** The uid `actor` acts under; `anon` has none, so a stand-in for fixture data. */
+function uidOf(actor: Actor): string {
+    return actor === 'anon' ? 'rulestest-howto-anonymous' : Users[actor];
+}
+
+/** A Firestore handle acting as `actor`, unauthenticated for `anon`. */
+function as(actor: Actor) {
+    if (actor === 'anon') return env.unauthenticatedContext().firestore();
+    if (actor === 'mod')
+        return env.authenticatedContext(Users.mod, { mod: true }).firestore();
+    return env.authenticatedContext(Users[actor]).firestore();
+}
+
+const social = (reactor: string) => ({
+    v: 1,
+    notifySubscribers: true,
+    reactionOptions: { '👍': 'like' },
+    reactions: { '👍': [reactor] },
+    usedByProjects: [],
+    chat: null,
+    bookmarkers: [reactor],
+    submittedToGuide: false,
+    seenByUsers: [],
+    viewCount: 1,
+});
+
+/** Rebuild both documents in the shape this scenario describes. */
+async function reset(scenario: Scenario) {
+    await env.withSecurityRulesDisabled(async (context) => {
+        const db = context.firestore();
+        await db.doc(`galleries/${Gallery}`).set({
+            v: 3,
+            id: Gallery,
+            path: null,
+            name: { 'en-US': 'Rules test gallery' },
+            description: { 'en-US': '' },
+            words: [],
+            curators: [Users.curator],
+            creators: [Users.galleryCreator],
+            projects: [],
+            characters: [],
+            public: scenario.gallery.public,
+            featured: false,
+            moderation: {},
+            howTos: [HowTo],
+            howToExpandedVisibility: scenario.gallery.expandedVisibility,
+            howToExpandedGalleries: [],
+            howToViewers: { 'rulestest-source-gallery': [Users.viewer] },
+            howToViewersFlat: [Users.viewer],
+            howToGuidingQuestions: [],
+            howToReactions: {},
+        });
+        await db.doc(`howtos/${HowTo}`).set({
+            v: 3,
+            id: HowTo,
+            galleryId: Gallery,
+            published: scenario.howTo.published,
+            publishedAt: scenario.howTo.published ? 1 : null,
+            xcoord: 0,
+            ycoord: 0,
+            title: '¶Rules test how-to¶/en-US',
+            guidingQuestions: [],
+            text: ['¶Body¶/en-US'],
+            creator: Users.owner,
+            collaborators: [Users.collaborator],
+            scopeOverwrite: scenario.howTo.scopeOverwrite,
+            locales: ['en-US'],
+            isPublic: scenario.howTo.isPublic,
+            social: social(Users.owner),
+        });
+    });
+}
+
+/** The request each action makes, as the client makes it. */
+function attempt(actor: Actor, action: Action): Promise<unknown> {
+    const doc = as(actor).doc(`howtos/${HowTo}`);
+    switch (action) {
+        case 'read':
+            return doc.get();
+        // A title change touches no narrow opening, so only the full-edit
+        // branches can admit it — which is what makes it the probe for `edit`.
+        case 'edit':
+            return doc.update({ title: '¶Edited¶/en-US' });
+        case 'move':
+            return doc.update({ xcoord: 5, ycoord: 5 });
+        case 'social':
+            return doc.update({ social: social(uidOf(actor)) });
+        case 'delete':
+            return doc.delete();
+    }
+}
+
+beforeAll(async () => {
+    env = await initializeTestEnvironment({
+        projectId: 'demo-wordplay',
+        firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+    });
+});
+
+afterAll(async () => {
+    await env.cleanup();
+});
+
+describe.each(Scenarios)('$name', (scenario) => {
+    // Rebuilt per test: every actor's run writes, and a delete would otherwise
+    // leave the next actor with nothing to act on.
+    beforeEach(() => reset(scenario));
+
+    // One test per actor rather than per action: each is a fresh fixture, and
+    // 8 resets per scenario is the difference between a suite that runs in
+    // seconds and one that runs in a minute.
+    it.each(Actors)('%s', async (actor) => {
+        const failures: string[] = [];
+        for (const action of Actions) {
+            const allowed = permits(scenario, actor, action);
+            try {
+                if (allowed) await assertSucceeds(attempt(actor, action));
+                else await assertFails(attempt(actor, action));
+            } catch (error) {
+                failures.push(
+                    `${action}: expected ${allowed ? 'allowed' : 'denied'} — ${error}`,
+                );
+            }
+        }
+        expect(failures, `${actor} on ${scenario.name}`).toEqual([]);
+    });
+});
+
+describe('creating a how-to and configuring the space', () => {
+    // The new how-to has to go as well as be rebuilt: left behind by whichever
+    // actor was allowed to make it, the next actor's `set` is an *update*, and
+    // the update rule answers a different question than the create rule.
+    beforeEach(async () => {
+        await reset(Scenarios[0]);
+        await env.withSecurityRulesDisabled(async (context) => {
+            await context.firestore().doc(`howtos/${New}`).delete();
+        });
+    });
+
+    it.each(Actors)(
+        '%s creates only if the gallery admits them',
+        async (actor) => {
+            const allowed = (GalleryPermissions[actor] ?? []).includes(
+                'create',
+            );
+            const write = as(actor)
+                .doc(`howtos/${New}`)
+                .set({
+                    v: 3,
+                    id: New,
+                    galleryId: Gallery,
+                    published: false,
+                    publishedAt: null,
+                    xcoord: 0,
+                    ycoord: 0,
+                    title: '¶New¶/en-US',
+                    guidingQuestions: [],
+                    text: [],
+                    creator: uidOf(actor),
+                    collaborators: [],
+                    scopeOverwrite: false,
+                    locales: ['en-US'],
+                    isPublic: false,
+                    social: social('nobody'),
+                });
+            if (allowed) await assertSucceeds(write);
+            else await assertFails(write);
+        },
+    );
+
+    it('a create naming a gallery the caller does not belong to fails', async () => {
+        await assertFails(
+            as('stranger')
+                .doc('howtos/rulestest-howto-elsewhere')
+                .set({ galleryId: Gallery, creator: Users.stranger }),
+        );
+    });
+});
+
+describe('expanded access is a grant on the gallery, and it can be withdrawn', () => {
+    it('a viewer may read the gallery while expanded visibility is on', async () => {
+        await reset(Scenarios[4]);
+        await assertSucceeds(as('viewer').doc(`galleries/${Gallery}`).get());
+    });
+
+    it('and may not once the curator switches it off', async () => {
+        await reset(Scenarios[0]);
+        await assertFails(as('viewer').doc(`galleries/${Gallery}`).get());
+    });
+
+    it('someone not on the list never may', async () => {
+        await reset(Scenarios[4]);
+        await assertFails(as('stranger').doc(`galleries/${Gallery}`).get());
+    });
+});
+
+describe('a how-to cannot be captured by renaming its gallery', () => {
+    // The escalation this closes: creating a gallery makes you its curator and
+    // the gallery create rule is only `request.auth != null`, so authorizing an
+    // update from `request.resource.data.galleryId` let any signed-in account
+    // edit any how-to in the database by naming a gallery they had just made.
+    beforeEach(async () => {
+        await reset(Scenarios[0]);
+        await env.withSecurityRulesDisabled(async (context) => {
+            await context
+                .firestore()
+                .doc('galleries/rulestest-howto-stranger-gallery')
+                .set({
+                    curators: [Users.stranger],
+                    creators: [Users.stranger],
+                    public: false,
+                    howToExpandedVisibility: false,
+                    howToViewersFlat: [],
+                });
+        });
+    });
+
+    it('a stranger cannot edit by claiming their own gallery in the write', async () => {
+        await assertFails(
+            as('stranger').doc(`howtos/${HowTo}`).update({
+                galleryId: 'rulestest-howto-stranger-gallery',
+                title: '¶Captured¶/en-US',
+            }),
+        );
+    });
+
+    it('nor react to one they cannot otherwise see', async () => {
+        await assertFails(
+            as('stranger')
+                .doc(`howtos/${HowTo}`)
+                .update({
+                    galleryId: 'rulestest-howto-stranger-gallery',
+                    social: social(Users.stranger),
+                }),
+        );
+    });
+
+    it("a how-to's gallery is immutable even to its owner", async () => {
+        // Nothing moves a how-to between galleries — `HowToMovement` is canvas
+        // geometry — and a move that did would have to rewrite two galleries'
+        // `howTos` arrays atomically, which is a callable's job, not a client
+        // write's.
+        await assertFails(
+            as('owner')
+                .doc(`howtos/${HowTo}`)
+                .update({ galleryId: 'rulestest-howto-stranger-gallery' }),
+        );
+    });
+});


### PR DESCRIPTION
# Context

The how-to permission model from #882 had no automated coverage at all. There were no security-rules tests for the `howtos` collection — `tests/rules/` covered projects, chats, moderation, notices, handles and usage, and `grep -rn "howTo" tests/rules/` returned nothing — and `npm run test:rules` ran in no workflow and no git hook, so the whole of that directory was a script someone had to remember. The client's own decisions were four `$derived` expressions spread across the how-to route's components, one of which (`isCreatorCollaboratorViewer`) did not check the how-to's own collaborators despite its name.

#907 is a long checklist of "can" and "cannot" across four roles. This writes it down as a table and holds both enforcement points to it. **87 rules cases; 16 failed on the first run, and each was a real defect:**

- **Expanded access did nothing at all.** The rules' viewer branch read `viewersFlat` off the *how-to*, and nothing anywhere ever wrote that field — not the client, not a cloud function. So the branch was always false, the listener that queried on it matched nothing, and a creator given access to another gallery's how-tos saw an empty space. The `seeded-expanded-scope-gallery-id` fixture had been seeded and read by no test since #882, which is how this survived. The grant is read from the gallery now, where it is actually made and maintained by `galleryEdited`. That costs no document access: every other branch already `get()`s the same gallery, and repeat access to one document is cached and free (see `src/db/firestoreLimits.ts`).
- **A public gallery exposed every draft in it, to anyone.** The gallery-public and how-to-public branches were tested *before* the `published` guard rather than under it. #907 requires "cannot see another creator's drafts".
- **Any signed-in account could edit or react to any how-to in the database.** `allow update` authorized from `request.resource.data.galleryId` — the incoming document, which the client writes — and creating a gallery makes you its curator, so naming a gallery you had just made was enough. Every branch reads the stored gallery now, and a how-to's gallery is immutable: nothing in the product moves one between galleries.
- **The placement and social openings never checked `published`**, so a gallery creator could move and react to a draft they could not read. This one the tests found; it was not predicted.

Two related things were dead for the same reason: an expanded-access viewer was missing from a how-to's chat participants, and from `subject.ts`'s `visibleTo`, so a report about a how-to they could see routed as though they could not.

Bookmarking and reacting sent a whole-document write, which the `social` opening cannot admit for a viewer or a gallery creator — the silent-refusal class of #1348/#1349/#1350, where a refused write leaves the document permanently unsaved on that device and says nothing.

One prediction the tests **disproved**: dereferencing `request.auth.uid` while signed out does not abort the rule, so anonymous reads of public galleries worked fine already.

## Design notes

**One table, two enforcement points.** `src/db/howtos/howToAccessScenarios.ts` is #907's checklist in executable form. `tests/rules/howToRules.test.ts` drives it against the emulator; `src/db/howtos/howToAccess.test.ts` drives it against the pure predicates the interface gates on. Client and server cannot drift, and adding a role or a branch means adding a row rather than two tests. The table is import-free plain TypeScript because `vitest.rules.config.ts` declares no path aliases.

**Tolerant to a redesign.** Rules tests touch no DOM, the predicates are pure functions over documents, and the few e2e selectors read their accessible names out of `src/locale/en-US.json` through the existing `tests/helpers/localize.ts` instead of hard-coded English.

**Cheap.** A Playwright test costs ~5s against a unit test's ~30ms, so the matrix went where it is deterministic: +~18s for a rules suite that ran nowhere before, +~50ms on `test:run`, **2** new e2e tests, and one new parallel CI job that finishes well inside the Playwright gate — roughly zero added wall clock to the merge gate.

**Two consequences of reading the grant from the gallery**, both handled: the expanded-scope listener now depends on a set that moves mid-session, so it needs a re-subscribe hook; and re-subscribing exposed a latent GC bug where `ignore()` clears the per-listener ID sets while the cache stays full, so the first listener to answer would evict everything the others hold. Both follow `CharacterDatabase`'s existing pattern. The hook is not only for mid-session changes — `expandedScopeGalleries` is filled by one of three gallery listeners and `domainSettled` resolves on the first to report, so on a cold load the set can still be empty when the how-tos subscribe. A warm load fills it from IndexedDB first, which is why that gap would show up for a new account and never on a machine that had run the app before.

## Related issues

- Closes #907
- Related Issue #882, #825

## Verification

- `npm run check:now` — clean (3449 files, 0 errors, 0 warnings).
- `npm run test:run` — 508 files, 8771 passed, 7 skipped.
- `npm run test:rules` — 7 files, 228 passed (was 6 files before this branch; the `howtos` suite is new). The six pre-existing suites are unregressed.
- `npm run format:check` — clean.
- Playwright, chromium: both new tests in `seeded-load.spec.ts` pass — the expanded-scope viewer reading a space read-only, and a signed-out visitor on a public space.

**Not verified here, and why.** `howto-form.spec.ts` and one pre-existing `seeded-load` test could not run in this environment: the worker fixture creates an account through the join flow, which needs network that this container blocks, and the available Chromium is a different build from the pinned one. Both were confirmed to fail identically on an unmodified tree, so neither is a regression — but CI is the real check for them. For `howto-form.spec.ts` the only change is swapping hard-coded English for locale lookups, and each lookup was verified to resolve to exactly the string it replaced.

**Accessibility:** no new UI. The change is permission logic plus tests; the only user-visible difference is that controls now appear for people who may use them and not for people whose writes the server would refuse. No new colors, no new focus targets, no new markup. Screen-reader and keyboard passes are therefore unchanged from `main`, and I have not run them.

## Checklist

Two follow-ups deliberately left out of this change, both noted in the code:

- [ ] A curator can still self-grant gallery read by writing `howToViewersFlat` directly — `galleryServerFieldsUnchanged()` does not cover it. Pre-existing; reading through widens its reach. Closing it means moving `Gallery.withExpandedGallery`'s flattening into `galleryEdited` so the client sends only `howToExpandedGalleries`.
- [ ] A how-to's chat can never be deleted: `ownsChatsProject()` does `get(/projects/<chat id>)`, and a how-to chat's id is a how-to id. Already recorded in `chatRules.test.ts`'s `Orphan` fixture.
- [ ] `/gallery/<id>/howto` is not in the axe scan list. Worth adding, but a separate concern from #907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2)_