### PR TITLE
Let the server own the gallery fields it decides, and remove one that decided nothing (#1352)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,10 +13,6 @@
                     "order": "ASCENDING"
                 },
                 {
-                    "fieldPath": "featured",
-                    "order": "DESCENDING"
-                },
-                {
                     "fieldPath": "id",
                     "order": "ASCENDING"
                 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -324,18 +324,40 @@ service cloud.firestore {
           || !('public' in request.resource.data)
           || request.resource.data.public != true;
       }
-      // A gallery's moderation state (#1311) is written by the moderateGallery
-      // function and the galleryEdited trigger, both of which use the Admin SDK
-      // and so bypass these rules. No client may write it: a curator who could
-      // approve their own gallery is the whole thing this curation prevents.
-      // `public` stays theirs to set — it's the request, not the decision.
+      // A gallery's moderation state (#1311) and its expanded how-to viewer
+      // lists (#1352) are written by the moderateGallery callable and the
+      // galleryEdited trigger, both of which use the Admin SDK and so bypass
+      // these rules. No client may write any of them: a curator who could
+      // approve their own gallery is the whole thing this curation prevents,
+      // and one who could write `howToViewersFlat` could hand the gallery — and
+      // its published how-tos — to anyone they named.
+      //
+      // `public`, `howToExpandedVisibility` and `howToExpandedGalleries` stay
+      // theirs to set. Those are the request; these are the decision.
       function galleryServerFieldsUnchanged() {
         return (!("moderation" in request.resource.data) || request.resource.data.moderation == resource.data.moderation)
           && (!("moderatedAt" in request.resource.data) || request.resource.data.moderatedAt == resource.data.moderatedAt)
           && (!("flags" in request.resource.data) || request.resource.data.flags == resource.data.flags)
-          && (!("words" in request.resource.data) || request.resource.data.words == resource.data.words);
+          && (!("words" in request.resource.data) || request.resource.data.words == resource.data.words)
+          && (!("howToViewers" in request.resource.data) || request.resource.data.howToViewers == resource.data.howToViewers)
+          && (!("howToViewersFlat" in request.resource.data) || request.resource.data.howToViewersFlat == resource.data.howToViewersFlat);
       }
-      allow create: if request.auth != null && galleryMayBePublic();
+      // The same fields on the way in. The guard above compares against what is
+      // stored, which does not exist on a create — so every rule it states could
+      // be walked around by putting the value in the new document instead, and
+      // the public listing is a plain `public == true && moderation ==
+      // 'approved'` query, so an already-approved gallery went straight into it
+      // with no moderator ever seeing it (#1352). A new gallery must therefore
+      // arrive at the initial values `GalleryDatabase.create` actually sends.
+      function galleryServerFieldsInitial() {
+        return request.resource.data.moderation == 'unrequested'
+          && request.resource.data.moderatedAt == null
+          && request.resource.data.flags.values().hasOnly([null])
+          && request.resource.data.words.size() == 0
+          && request.resource.data.howToViewers.size() == 0
+          && request.resource.data.howToViewersFlat.size() == 0;
+      }
+      allow create: if request.auth != null && galleryMayBePublic() && galleryServerFieldsInitial();
       // Public galleries can be read, as can private ones if the creator is a curator, creator, or a how to viewer.
       // Moderators can read any of them, since a gallery awaiting a decision is
       // by definition not yet public — the same access the mod claim already

--- a/functions/src/galleryEdited.test.ts
+++ b/functions/src/galleryEdited.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
     curatorsChanged,
+    deriveHowToViewers,
+    flattenHowToViewers,
     galleryContentChanged,
+    howToViewersChanged,
     nextModeration,
+    sharesCurator,
+    type HowToSource,
 } from './galleryEdited.js';
 
 /**
@@ -203,5 +208,131 @@ describe('galleryContentChanged with characters', () => {
         expect(
             galleryContentChanged(legacy, { ...legacy, characters: [] }),
         ).toBe(false);
+    });
+});
+
+/**
+ * Who may view a gallery's how-tos through expanded access. This used to be
+ * computed on the client and written straight to the document, so anyone who
+ * could edit a gallery could grant its how-tos to anyone they named (#1352).
+ * The derivation is the server's now, and these are its rules.
+ */
+describe('deriveHowToViewers', () => {
+    const Curator = 'curator';
+    const Other = 'other-curator';
+    const sources = new Map<string, HowToSource>([
+        ['shared', { curators: [Curator], creators: ['student-a'] }],
+        ['theirs', { curators: [Other], creators: ['student-b'] }],
+        ['both', { curators: [Curator, Other], creators: ['student-a'] }],
+    ]);
+
+    it('draws viewers from a gallery the same curator curates', () => {
+        expect(deriveHowToViewers(['shared'], sources, [Curator])).toEqual({
+            howToViewers: { shared: [Curator, 'student-a'] },
+            howToViewersFlat: [Curator, 'student-a'],
+        });
+    });
+
+    it('draws nothing from a gallery they have nothing to do with', () => {
+        // The disclosure this closes: `howToViewersFlat` is readable by everyone
+        // who can read the gallery, so copying a stranger's members into it
+        // publishes their membership.
+        expect(deriveHowToViewers(['theirs'], sources, [Curator])).toEqual({
+            howToViewers: {},
+            howToViewersFlat: [],
+        });
+    });
+
+    it('one curator in common is enough', () => {
+        expect(deriveHowToViewers(['both'], sources, [Curator])).toEqual({
+            howToViewers: { both: [Curator, Other, 'student-a'] },
+            howToViewersFlat: [Curator, Other, 'student-a'],
+        });
+    });
+
+    it('skips a gallery that is no longer there', () => {
+        expect(deriveHowToViewers(['gone'], sources, [Curator])).toEqual({
+            howToViewers: {},
+            howToViewersFlat: [],
+        });
+    });
+
+    it('lists someone reachable through two galleries once', () => {
+        const { howToViewersFlat } = deriveHowToViewers(
+            ['shared', 'both'],
+            sources,
+            [Curator],
+        );
+        expect(howToViewersFlat).toEqual([Curator, Other, 'student-a']);
+    });
+
+    it('gives nothing when no gallery is named', () => {
+        expect(deriveHowToViewers([], sources, [Curator])).toEqual({
+            howToViewers: {},
+            howToViewersFlat: [],
+        });
+    });
+
+    it('is deterministic, so the trigger stops rather than looping', () => {
+        // The handler diffs this against what is stored and writes only on a
+        // difference; its own write comes back through the same trigger. An
+        // answer that varied by input order — which the flat list did, before it
+        // was sorted — would be a document that rewrites itself forever.
+        const once = deriveHowToViewers(['shared', 'both'], sources, [Curator]);
+        const again = deriveHowToViewers(['both', 'shared'], sources, [
+            Curator,
+        ]);
+        expect(JSON.stringify(again)).toEqual(JSON.stringify(once));
+    });
+});
+
+describe('howToViewersChanged', () => {
+    const derived = {
+        howToViewers: { a: ['x', 'y'] },
+        howToViewersFlat: ['x', 'y'],
+    };
+
+    it('is false against a gallery that already stores the answer', () => {
+        expect(howToViewersChanged({ ...derived }, derived)).toBe(false);
+    });
+
+    it('ignores the order the map happens to be stored in', () => {
+        const stored = {
+            howToViewers: { b: ['z'], a: ['x', 'y'] },
+            howToViewersFlat: ['x', 'y', 'z'],
+        };
+        expect(
+            howToViewersChanged(stored, {
+                howToViewers: { a: ['x', 'y'], b: ['z'] },
+                howToViewersFlat: ['x', 'y', 'z'],
+            }),
+        ).toBe(false);
+    });
+
+    it('sees a viewer gained or lost', () => {
+        expect(
+            howToViewersChanged(
+                { howToViewers: { a: ['x'] }, howToViewersFlat: ['x'] },
+                derived,
+            ),
+        ).toBe(true);
+    });
+
+    it('treats a gallery stored before these fields existed as changed', () => {
+        expect(howToViewersChanged({}, derived)).toBe(true);
+    });
+});
+
+describe('sharesCurator and flattenHowToViewers', () => {
+    it('shares nothing with an empty list', () => {
+        expect(sharesCurator([], ['a'])).toBe(false);
+        expect(sharesCurator(['a'], [])).toBe(false);
+    });
+
+    it('flattens, dedupes and sorts', () => {
+        expect(flattenHowToViewers({ b: ['z', 'x'], a: ['x'] })).toEqual([
+            'x',
+            'z',
+        ]);
     });
 });

--- a/functions/src/galleryEdited.ts
+++ b/functions/src/galleryEdited.ts
@@ -44,6 +44,89 @@ function sameWords(a: string[], b: string[]): boolean {
     return a.length === b.length && a.every((word, index) => word === b[index]);
 }
 
+/** The membership of a gallery a viewer list can be drawn from. */
+export type HowToSource = { curators: string[]; creators: string[] };
+
+/** The pair a gallery stores: who may view its how-tos, and by way of what. */
+export type HowToViewers = {
+    howToViewers: Record<string, string[]>;
+    howToViewersFlat: string[];
+};
+
+/**
+ * Expanded how-to access reaches "a gallery by the same curator", and this is
+ * what makes that true rather than merely documented. Without it a curator
+ * could list any gallery id at all and the trigger would copy that gallery's
+ * member ids into a field readable by everyone who can read theirs — which,
+ * for a public gallery, discloses a private one's membership (#1352).
+ *
+ * Sharing one curator is the strongest test available here: a trigger has no
+ * actor, so "the person who added it curates both" is not a question it can ask.
+ */
+export function sharesCurator(a: string[], b: string[]): boolean {
+    return a.some((uid) => b.includes(uid));
+}
+
+/**
+ * The flat list the security rules and the client's `array-contains` query
+ * match on. Deduplicated because one person can reach a gallery through two
+ * others, and **sorted** because this value is diffed against what is stored to
+ * decide whether to write — and an unstable order there is a trigger that
+ * rewrites its own document forever.
+ */
+export function flattenHowToViewers(
+    viewers: Record<string, string[]>,
+): string[] {
+    return [...new Set(Object.values(viewers).flat())].sort();
+}
+
+/**
+ * Who may view a gallery's how-tos, derived from the galleries it draws on.
+ * A source contributes nothing if it has gone, or if it shares no curator with
+ * the gallery drawing on it. Total and deterministic: the same inputs give a
+ * byte-identical answer, which is what lets the caller diff before writing.
+ */
+export function deriveHowToViewers(
+    expandedGalleryIds: string[],
+    sources: Map<string, HowToSource>,
+    targetCurators: string[],
+): HowToViewers {
+    const howToViewers: Record<string, string[]> = {};
+    for (const id of [...expandedGalleryIds].sort()) {
+        const source = sources.get(id);
+        if (source === undefined) continue;
+        if (!sharesCurator(source.curators, targetCurators)) continue;
+        howToViewers[id] = [
+            ...new Set([...source.curators, ...source.creators]),
+        ].sort();
+    }
+    return {
+        howToViewers,
+        howToViewersFlat: flattenHowToViewers(howToViewers),
+    };
+}
+
+/** Whether a derived pair differs from what the gallery already stores. */
+export function howToViewersChanged(
+    stored: Record<string, unknown>,
+    derived: HowToViewers,
+): boolean {
+    const canonical = (viewers: Record<string, string[]>) =>
+        JSON.stringify(
+            Object.keys(viewers)
+                .sort()
+                .map((key) => [key, viewers[key]]),
+        );
+    return (
+        canonical((stored.howToViewers as Record<string, string[]>) ?? {}) !==
+            canonical(derived.howToViewers) ||
+        !sameWords(
+            (stored.howToViewersFlat as string[]) ?? [],
+            derived.howToViewersFlat,
+        )
+    );
+}
+
 /**
  * Whether a curator changed anything a decision was about. Deliberately blind
  * to the fields this function itself writes: its own write comes back through
@@ -155,18 +238,17 @@ export default async function galleryEdited(
                 otherGallery.howToExpandedGalleries.filter(
                     (id: string) => id !== before.id,
                 );
-            const howToViewers: Record<string, string[]> =
-                otherGallery.howToViewers;
+            const howToViewers: Record<string, string[]> = {
+                ...otherGallery.howToViewers,
+            };
             delete howToViewers[before.id];
-            const howToViewersFlat: string[] =
-                Object.values(howToViewers).flat();
 
             updates.push({
                 ref: galleryStore.doc(expandedGallery.id),
                 data: {
                     howToExpandedGalleries: howToExpandedGalleries,
                     howToViewers: howToViewers,
-                    howToViewersFlat: howToViewersFlat,
+                    howToViewersFlat: flattenHowToViewers(howToViewers),
                 },
             });
         });
@@ -189,18 +271,29 @@ export default async function galleryEdited(
 
         galleriesToUpdate.forEach((expandedGallery) => {
             const otherGallery = expandedGallery.data();
+            // Patching one entry rather than re-deriving the whole map, which
+            // would mean reading every gallery this one draws on. The full
+            // recompute happens on that gallery's own next write; this is here
+            // so revoking access is prompt rather than eventual.
+            //
+            // The same-curator check has to be made here too: without it this
+            // is a back door into exactly what deriveHowToViewers refuses.
             const howToViewers: Record<string, string[]> = {
                 ...otherGallery.howToViewers,
-                [after.id]: [...after.curators, ...after.creators],
             };
-            const howToViewersFlat: string[] =
-                Object.values(howToViewers).flat();
+            if (
+                sharesCurator(after.curators ?? [], otherGallery.curators ?? [])
+            )
+                howToViewers[after.id] = [
+                    ...new Set([...after.curators, ...after.creators]),
+                ].sort();
+            else delete howToViewers[after.id];
 
             updates.push({
                 ref: galleryStore.doc(expandedGallery.id),
                 data: {
                     howToViewers: howToViewers,
-                    howToViewersFlat: howToViewersFlat,
+                    howToViewersFlat: flattenHowToViewers(howToViewers),
                 },
             });
         });
@@ -211,6 +304,54 @@ export default async function galleryEdited(
     // by the security rules, and both are written here in one update.
     if (after) {
         const self: Record<string, unknown> = {};
+
+        // Who may view this gallery's how-tos, derived from the galleries it
+        // draws on. The client used to compute this and write it itself, which
+        // meant anyone who could edit a gallery could grant its how-tos to
+        // anyone they named (#1352) — so it is derived here and refused there.
+        //
+        // Recomputed on every write rather than only when the list changes: it
+        // costs nothing for the galleries that draw on none, and it means one
+        // still carrying a value a client wrote heals on its next write instead
+        // of needing a migration. Merged into `self` rather than pushed as its
+        // own update, and written only when it differs from what is stored —
+        // this document's write comes back through this same trigger, and an
+        // unconditional write here would never stop.
+        const expandedGalleryIds: string[] = after.howToExpandedGalleries ?? [];
+        if (expandedGalleryIds.length > 0) {
+            const sourceDocs = await db.getAll(
+                ...expandedGalleryIds.map((id) => galleryStore.doc(id)),
+            );
+            const sources = new Map<string, HowToSource>();
+            for (const source of sourceDocs) {
+                const data = source.data();
+                if (data === undefined) continue;
+                sources.set(source.id, {
+                    curators: data.curators ?? [],
+                    creators: data.creators ?? [],
+                });
+            }
+            const derived = deriveHowToViewers(
+                expandedGalleryIds,
+                sources,
+                after.curators ?? [],
+            );
+            if (howToViewersChanged(after, derived)) {
+                self.howToViewers = derived.howToViewers;
+                self.howToViewersFlat = derived.howToViewersFlat;
+            }
+        } else if (
+            howToViewersChanged(after, {
+                howToViewers: {},
+                howToViewersFlat: [],
+            })
+        ) {
+            // Drawing on nothing means granting nothing — including to a
+            // gallery whose list was emptied, or one whose values a client wrote
+            // before this was the server's to decide.
+            self.howToViewers = {};
+            self.howToViewersFlat = [];
+        }
 
         const contentChanged = galleryContentChanged(before, after);
         const moderation: string = after.moderation ?? 'unrequested';

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -256,7 +256,9 @@ async function seedClassAndGallery(): Promise<void> {
     const students = SEEDED_USERS.filter((u) =>
         u.username.startsWith('student'),
     );
+    const creator = SEEDED_USERS.find((u) => u.username === 'creator');
     if (!teacher) throw new Error('Teacher user missing from SEEDED_USERS');
+    if (!creator) throw new Error('Creator user missing from SEEDED_USERS');
 
     const classDoc = {
         id: SEEDED_CLASS_ID,
@@ -280,7 +282,10 @@ async function seedClassAndGallery(): Promise<void> {
         { 'en-US': 'Demo Class Gallery' },
         { 'en-US': 'Seeded gallery for the demo class.' },
         [teacher.uid],
-        students.map((s) => s.uid),
+        // `creator` alongside the students so this gallery can be the source the
+        // expanded-scope fixture below draws on: expanded access reaches only a
+        // gallery by the same curator, and the teacher curates both.
+        [...students.map((s) => s.uid), creator.uid],
     ).data;
 
     // setDoc overwrites whatever's there — fine for seeding because we want a
@@ -927,6 +932,17 @@ async function seedExpandedScopeGallery(): Promise<void> {
     if (!teacher || !creator) throw new Error('teacher/creator missing');
     const now = Date.now();
     const howToId = 'seed-expanded-howto-00';
+    // What `deriveHowToViewers` will produce for the class gallery: its curators
+    // and creators, deduped and sorted.
+    const classGalleryMembers = [
+        ...new Set([
+            teacher.uid,
+            ...SEEDED_USERS.filter((u) => u.username.startsWith('student')).map(
+                (u) => u.uid,
+            ),
+            creator.uid,
+        ]),
+    ].sort();
 
     const galleryDoc = Gallery.make(
         SEEDED_EXPANDED_GALLERY_ID,
@@ -940,14 +956,18 @@ async function seedExpandedScopeGallery(): Promise<void> {
         {
             howTos: [howToId],
             howToExpandedVisibility: true,
-            // Keyed by the gallery the access comes *from* — `creator`'s own
-            // workshop — and declared in `howToExpandedGalleries`, which is the
-            // shape `galleryEdited` maintains. Keyed by this gallery itself, the
-            // flat list still worked but described a state the trigger could
-            // never produce, so the fixture tested nothing about production.
-            howToExpandedGalleries: [SEEDED_HOWTO_GALLERY_ID],
-            howToViewers: { [SEEDED_HOWTO_GALLERY_ID]: [creator.uid] },
-            howToViewersFlat: [creator.uid],
+            // Drawn from the demo class gallery, which the same teacher curates
+            // — expanded access reaches only a gallery by the same curator, and
+            // `galleryEdited` strips a source that isn't one (#1352). Pointing
+            // this at `creator`'s own workshop described a state the trigger
+            // would undo the moment it ran.
+            //
+            // Seeded already derived, in the shape the trigger produces (deduped
+            // and sorted), so the fixture is correct before the trigger has
+            // fired as well as after.
+            howToExpandedGalleries: [SEEDED_CLASS_GALLERY_ID],
+            howToViewers: { [SEEDED_CLASS_GALLERY_ID]: classGalleryMembers },
+            howToViewersFlat: classGalleryMembers,
         },
     ).data;
     await firestore

--- a/src/db/galleries/Gallery.test.ts
+++ b/src/db/galleries/Gallery.test.ts
@@ -29,7 +29,6 @@ function makeV1() {
         curators: ['u-curator'],
         creators: ['u-creator'],
         public: true,
-        featured: false,
     };
 }
 
@@ -56,7 +55,6 @@ describe('upgradeGallery (upgrade-on-load)', () => {
         expect(upgraded.curators).toEqual(['u-curator']);
         expect(upgraded.creators).toEqual(['u-creator']);
         expect(upgraded.public).toBe(true);
-        expect(upgraded.featured).toBe(false);
     });
 
     it('upgraded doc parses against the latest schema', () => {

--- a/src/db/galleries/Gallery.test.ts
+++ b/src/db/galleries/Gallery.test.ts
@@ -197,3 +197,55 @@ describe('character membership (#822)', () => {
         expect(gallery.getCharacters()).toEqual([]);
     });
 });
+
+/**
+ * Naming a gallery to draw how-to viewers from writes the *list* and nothing
+ * else. The viewer map and its flattening are the `galleryEdited` trigger's,
+ * and the rules refuse them to clients (#1352).
+ */
+describe('expanded how-to access (#1352)', () => {
+    function gallery() {
+        return Gallery.make(
+            'g',
+            { 'en-US': 'G' },
+            { 'en-US': '' },
+            ['curator'],
+            [],
+            {
+                howToExpandedGalleries: ['first'],
+                howToViewers: { first: ['someone'] },
+                howToViewersFlat: ['someone'],
+            },
+        );
+    }
+
+    it('naming a gallery adds it to the list alone', () => {
+        const next = gallery().withExpandedGallery('second');
+        expect(next.getHowToExpandedGalleries()).toEqual(['first', 'second']);
+        expect(next.getHowToViewers()).toEqual(['someone']);
+    });
+
+    it('naming the same gallery twice lists it once', () => {
+        expect(
+            gallery().withExpandedGallery('first').getHowToExpandedGalleries(),
+        ).toEqual(['first']);
+    });
+
+    it('dropping a gallery removes it from the list alone', () => {
+        const next = gallery().withoutExpandedGallery('first');
+        expect(next.getHowToExpandedGalleries()).toEqual([]);
+        // Still stored: the trigger clears it, and until it does the gallery
+        // reports what the server last said rather than a guess.
+        expect(next.getHowToViewers()).toEqual(['someone']);
+    });
+
+    it('leaves the gallery it was called on alone', () => {
+        // The builders shallow-copy, so `howToViewers` is shared with the
+        // receiver — writing through it used to rewrite the original in place.
+        const original = gallery();
+        original.withExpandedGallery('second');
+        original.withoutExpandedGallery('first');
+        expect(original.getHowToExpandedGalleries()).toEqual(['first']);
+        expect(original.getHowToViewers()).toEqual(['someone']);
+    });
+});

--- a/src/db/galleries/Gallery.ts
+++ b/src/db/galleries/Gallery.ts
@@ -428,16 +428,22 @@ export default class Gallery {
         return this.data.howToExpandedVisibility;
     }
 
-    withExpandedGallery(galleryID: string, viewers: string[]): Gallery {
+    /**
+     * Naming a gallery to draw how-to viewers from. Only the list is written:
+     * who that actually reaches is derived by the `galleryEdited` trigger and
+     * refused to clients by the rules, because a client that could write it
+     * could hand this gallery to anyone at all (#1352).
+     *
+     * That also makes these two safe to call. They used to write
+     * `howToViewers`, which the shallow copy above shares with the receiver —
+     * so setting a key on it rewrote the Gallery being copied *from*, and the
+     * instance still held in `accessibleGalleries` changed underfoot.
+     */
+    withExpandedGallery(galleryID: string): Gallery {
         const newData = { ...this.data };
         newData.howToExpandedGalleries = [
-            ...newData.howToExpandedGalleries,
-            galleryID,
+            ...new Set([...newData.howToExpandedGalleries, galleryID]),
         ];
-        newData.howToViewers[galleryID] = viewers;
-        newData.howToViewersFlat = Array.from(
-            new Set([...newData.howToViewersFlat, ...viewers]),
-        );
         return new Gallery(newData);
     }
 
@@ -446,10 +452,6 @@ export default class Gallery {
         newData.howToExpandedGalleries = [
             ...newData.howToExpandedGalleries.filter((id) => id !== galleryID),
         ];
-        delete newData.howToViewers[galleryID];
-        newData.howToViewersFlat = Array.from(
-            new Set([...Object.values(newData.howToViewers).flat()]),
-        );
         return new Gallery(newData);
     }
 

--- a/src/db/galleries/Gallery.ts
+++ b/src/db/galleries/Gallery.ts
@@ -40,7 +40,6 @@ const SerializedGalleryV1 = z.object({
     /** If true, gallery can be viewed by anyone and appears in search results. */
     public: z.boolean(),
     /** If true, gallery is prioritized in search results */
-    featured: z.boolean(),
 });
 
 /** v2 adds configurations for the how-to space */
@@ -193,7 +192,6 @@ export default class Gallery {
             projects?: string[];
             characters?: string[];
             public?: boolean;
-            featured?: boolean;
             howTos?: string[];
             howToExpandedVisibility?: boolean;
             howToExpandedGalleries?: string[];
@@ -218,7 +216,6 @@ export default class Gallery {
             curators,
             creators,
             public: opts.public ?? false,
-            featured: opts.featured ?? false,
             howTos: opts.howTos ?? [],
             howToExpandedVisibility: opts.howToExpandedVisibility ?? false,
             howToExpandedGalleries: opts.howToExpandedGalleries ?? [],

--- a/src/db/galleries/GalleryDatabase.svelte.ts
+++ b/src/db/galleries/GalleryDatabase.svelte.ts
@@ -528,7 +528,6 @@ export default class GalleryDatabase {
             curators: curators ?? [user.uid],
             creators: creators ?? [],
             public: false,
-            featured: false,
             // Private, so nothing has been asked of the moderators yet; the
             // galleryEdited trigger moves this to 'pending' if it goes public.
             moderation: 'unrequested',

--- a/src/db/rulesFields.ts
+++ b/src/db/rulesFields.ts
@@ -29,12 +29,22 @@ export const ChatWritableFields = [
  * identical to what is stored, and the `galleryEdited` trigger rebuilds `words`
  * on every change — so a whole-document write is denied the moment the trigger
  * has moved on.
+ *
+ * `galleryServerFieldsInitial()` states the same list on a create, where there
+ * is nothing stored to compare against: every guard here was walkable around by
+ * putting the value in the new document instead (#1352).
+ *
+ * The two how-to fields are derived, not decided: a curator asks by setting
+ * `howToExpandedVisibility` and `howToExpandedGalleries`, which stay theirs, and
+ * the trigger answers with the viewer lists.
  */
 export const GalleryServerOwnedFields = [
     'moderation',
     'moderatedAt',
     'flags',
     'words',
+    'howToViewers',
+    'howToViewersFlat',
 ] as const;
 
 /**

--- a/src/db/rulesFieldsSync.test.ts
+++ b/src/db/rulesFieldsSync.test.ts
@@ -70,4 +70,26 @@ describe('the client writes exactly what firestore.rules admits', () => {
             [...GalleryServerOwnedFields].toSorted(),
         );
     });
+
+    test('and a gallery create carries each of them at its initial value', () => {
+        // The create guard names the same fields but compares against literals
+        // rather than against `resource.data`, so it reads differently and the
+        // test above cannot see it. Without this, the two guards could drift and
+        // a field would be owned on update and free on create — which is exactly
+        // the state #1352 found.
+        const block_ = block('galleries');
+        const guard = block_.slice(
+            block_.indexOf('function galleryServerFieldsInitial'),
+        );
+        const fields = new Set(
+            Array.from(
+                guard
+                    .slice(0, guard.indexOf('}'))
+                    .matchAll(/request\.resource\.data\.(\w+)/g),
+            ).map((match) => match[1]),
+        );
+        expect(Array.from(fields).toSorted()).toEqual(
+            [...GalleryServerOwnedFields].toSorted(),
+        );
+    });
 });

--- a/src/examples/examples.ts
+++ b/src/examples/examples.ts
@@ -234,7 +234,6 @@ function createGallery(
         curators: [],
         creators: [],
         public: true,
-        featured: true,
         // The developers' own galleries, so already curated. `words` stays
         // empty on purpose: their projects are searched in full rather than
         // through the prefilter it exists for.

--- a/src/routes/[[locale]]/galleries/+page.svelte
+++ b/src/routes/[[locale]]/galleries/+page.svelte
@@ -145,9 +145,9 @@
      * rather than a page at a time, because the search below runs over it in the
      * browser — paging would mean search only found what had already been
      * scrolled to. Curation (#1311) is what makes that affordable. Past this cap
-     * the featured-then-id ordering is no longer the equal visibility the
-     * shuffle gives; `Gallery.words` plus an array-contains-any query is the
-     * scaling path when it matters.
+     * the id ordering is no longer the equal visibility the shuffle gives;
+     * `Gallery.words` plus an array-contains-any query is the scaling path when
+     * it matters.
      */
     const PublicGalleryLimit = 200;
 
@@ -173,7 +173,6 @@
             // Being public is the curator's request; being approved is what
             // lists it (#1311).
             where('moderation', '==', 'approved'),
-            orderBy('featured', 'desc'),
             orderBy('id'),
             limit(PublicGalleryLimit),
         );

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToConfiguration.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/HowToConfiguration.svelte
@@ -65,19 +65,6 @@
         }
     }
 
-    function addExpansionToGallery(toModify: Gallery, toAdd: string): Gallery {
-        let toAddGalleryObject: Gallery | undefined =
-            Galleries.accessibleGalleries.get(toAdd);
-        let toAddGalleryViewers: string[] = toAddGalleryObject
-            ? [
-                  ...toAddGalleryObject.getCurators(),
-                  ...toAddGalleryObject.getCreators(),
-              ]
-            : [];
-
-        return toModify.withExpandedGallery(toAdd, toAddGalleryViewers);
-    }
-
     async function submitChanges() {
         show = false;
 
@@ -100,8 +87,12 @@
             howToReactions: reactionsObject,
         });
 
+        // Only the list of galleries: who it reaches is the server's to work
+        // out (#1352). This used to look each gallery up in the local cache and
+        // send its members, which silently sent nobody when the cache had no
+        // entry — and let anyone who could edit a gallery name any uid at all.
         galleryAddQueue.forEach((galleryId) => {
-            gallery = addExpansionToGallery(gallery, galleryId);
+            gallery = gallery.withExpandedGallery(galleryId);
         });
 
         galleryRemoveQueue.forEach((galleryId) => {

--- a/src/util/importGraph.test.ts
+++ b/src/util/importGraph.test.ts
@@ -610,11 +610,16 @@ test('resolving a color needs no basis', () => {
  * dies with the next redesign. Every byte budget moves by a hundredth, which is
  * the module itself — it is mostly comment, and pulls in nothing that was not
  * already here.
+ *
+ * Making the server own a gallery's derived viewer lists (#1352) is **+0 files**
+ * and moves one budget by two ten-thousandths: `Gallery.withExpandedGallery`
+ * gets shorter and its comment gets longer, which is the trade this rule exists
+ * to make visible rather than to prevent.
  */
 test.each([
     ['src/routes/+layout.svelte', 508, 3.78],
     ['src/components/app/Page.svelte', 531, 4.03],
-    ['src/routes/[[locale]]/+page.svelte', 546, 4.11],
+    ['src/routes/[[locale]]/+page.svelte', 546, 4.12],
     ['src/routes/[[locale]]/galleries/+page.svelte', 550, 4.13],
     ['src/routes/[[locale]]/projects/+page.svelte', 557, 4.15],
 ])('%s stays within its import budget', (entry, maxFiles, maxMB) => {

--- a/tests/end2end/curator-live-access.spec.ts
+++ b/tests/end2end/curator-live-access.spec.ts
@@ -55,7 +55,6 @@ async function seedCuratedStudentProject(
             curators: [curatorUid],
             creators: [ownerUid],
             public: false,
-            featured: false,
             howTos: [],
             howToExpandedVisibility: false,
             howToExpandedGalleries: [],

--- a/tests/rules/howToRules.test.ts
+++ b/tests/rules/howToRules.test.ts
@@ -241,6 +241,55 @@ describe('expanded access is a grant on the gallery, and it can be withdrawn', (
     });
 });
 
+/**
+ * Who may *make* the grant, as opposed to who it reaches. The switch and the
+ * list of source galleries are the curator's request; the viewer lists derived
+ * from them are the server's answer, written only by the `galleryEdited`
+ * trigger. They were client-writable, so anyone who could edit the gallery
+ * could hand it — and, since #1351, its published how-tos — to any uid they
+ * named (#1352).
+ */
+describe('expanded access is asked for by the curator and answered by the server', () => {
+    beforeEach(() => reset(Scenarios[4]));
+
+    it('a curator may ask, by naming a gallery and turning the switch on', async () => {
+        await assertSucceeds(
+            as('curator')
+                .doc(`galleries/${Gallery}`)
+                .update({
+                    howToExpandedVisibility: true,
+                    howToExpandedGalleries: ['rulestest-howto-source-gallery'],
+                }),
+        );
+    });
+
+    it('but may not write the viewer list the answer consists of', async () => {
+        await assertFails(
+            as('curator')
+                .doc(`galleries/${Gallery}`)
+                .update({ howToViewersFlat: [Users.stranger] }),
+        );
+    });
+
+    it('nor the map it is flattened from', async () => {
+        await assertFails(
+            as('curator')
+                .doc(`galleries/${Gallery}`)
+                .update({ howToViewers: { elsewhere: [Users.stranger] } }),
+        );
+    });
+
+    it('and neither may a gallery creator, who can edit everything else', async () => {
+        // A creator is barred from `public`, `curators` and `creators`, and from
+        // nothing else — so in a class gallery this was any student.
+        await assertFails(
+            as('galleryCreator')
+                .doc(`galleries/${Gallery}`)
+                .update({ howToViewersFlat: [Users.stranger] }),
+        );
+    });
+});
+
 describe('a how-to cannot be captured by renaming its gallery', () => {
     // The escalation this closes: creating a gallery makes you its curator and
     // the gallery create rule is only `request.auth != null`, so authorizing an

--- a/tests/rules/howToRules.test.ts
+++ b/tests/rules/howToRules.test.ts
@@ -87,7 +87,6 @@ async function reset(scenario: Scenario) {
             projects: [],
             characters: [],
             public: scenario.gallery.public,
-            featured: false,
             moderation: {},
             howTos: [HowTo],
             howToExpandedVisibility: scenario.gallery.expandedVisibility,

--- a/tests/rules/moderationRules.test.ts
+++ b/tests/rules/moderationRules.test.ts
@@ -5,7 +5,7 @@ import {
     type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
 import { readFileSync } from 'fs';
-import { afterAll, beforeAll, describe, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
 
 /**
  * Security-rules tests for #193: reporting public content, the moderation
@@ -473,6 +473,127 @@ describe("galleries: the moderation decision is not the curator's to write", () 
     it('but a stranger still cannot', async () => {
         await assertFails(
             as(Users.Stranger).doc(`galleries/${Galleries.Pending}`).get(),
+        );
+    });
+});
+
+/**
+ * The same fields, on the way in. `galleryServerFieldsUnchanged()` was reached
+ * only from `allow update`, so every guard above could be walked around by
+ * putting the value in the document at creation instead — and `/galleries`
+ * lists by a plain `public == true && moderation == 'approved'` query, so an
+ * already-approved gallery went straight into the public listing with no
+ * moderator ever seeing it (#1352).
+ */
+describe('galleries: a decision cannot be smuggled in at creation', () => {
+    /** What the client actually sends: private, unrequested, nothing derived. */
+    function fresh(overrides: Record<string, unknown> = {}) {
+        return {
+            v: 4,
+            id: 'rulestest-mod-created',
+            path: null,
+            name: { 'en-US': 'New' },
+            description: { 'en-US': '' },
+            words: [],
+            projects: [],
+            characters: [],
+            curators: [Users.Owner],
+            creators: [],
+            public: false,
+            featured: false,
+            moderation: 'unrequested',
+            moderatedAt: null,
+            flags: {
+                dehumanization: null,
+                violence: null,
+                disclosure: null,
+                misinformation: null,
+            },
+            howTos: [],
+            howToExpandedVisibility: false,
+            howToExpandedGalleries: [],
+            howToViewers: {},
+            howToViewersFlat: [],
+            howToGuidingQuestions: [],
+            howToReactions: {},
+            ...overrides,
+        };
+    }
+
+    const created = 'galleries/rulestest-mod-created';
+
+    beforeEach(async () => {
+        await env.withSecurityRulesDisabled(async (context) => {
+            await context.firestore().doc(created).delete();
+        });
+    });
+
+    it('a creator can make an ordinary gallery', async () => {
+        await assertSucceeds(as(Users.Owner).doc(created).set(fresh()));
+    });
+
+    it('but not one that arrives already approved', async () => {
+        await assertFails(
+            as(Users.Owner)
+                .doc(created)
+                .set(fresh({ moderation: 'approved', public: true })),
+        );
+    });
+
+    it('nor one that arrives with findings already cleared', async () => {
+        await assertFails(
+            as(Users.Owner)
+                .doc(created)
+                .set(
+                    fresh({
+                        flags: {
+                            dehumanization: false,
+                            violence: false,
+                            disclosure: false,
+                            misinformation: false,
+                        },
+                    }),
+                ),
+        );
+    });
+
+    it('nor one that arrives with a stuffed search index', async () => {
+        await assertFails(
+            as(Users.Owner)
+                .doc(created)
+                .set(fresh({ words: ['free', 'money'] })),
+        );
+    });
+
+    it('nor one that arrives already granting how-to access', async () => {
+        // The #1352 case: `howToViewersFlat` is what the gallery read rule's
+        // expanded-access branch matches on, so a populated one at creation
+        // hands the gallery to anyone named in it.
+        await assertFails(
+            as(Users.Owner)
+                .doc(created)
+                .set(
+                    fresh({
+                        howToExpandedVisibility: true,
+                        howToViewers: { elsewhere: [Users.Stranger] },
+                        howToViewersFlat: [Users.Stranger],
+                    }),
+                ),
+        );
+    });
+
+    it('asking is still theirs to do: expanded visibility alone is fine', async () => {
+        // The switch and the list of galleries are the curator's request. Only
+        // the derived viewer lists are the server's answer.
+        await assertSucceeds(
+            as(Users.Owner)
+                .doc(created)
+                .set(
+                    fresh({
+                        howToExpandedVisibility: true,
+                        howToExpandedGalleries: ['elsewhere'],
+                    }),
+                ),
         );
     });
 });

--- a/tests/rules/moderationRules.test.ts
+++ b/tests/rules/moderationRules.test.ts
@@ -500,7 +500,6 @@ describe('galleries: a decision cannot be smuggled in at creation', () => {
             curators: [Users.Owner],
             creators: [],
             public: false,
-            featured: false,
             moderation: 'unrequested',
             moderatedAt: null,
             flags: {


### PR DESCRIPTION
# Context

A gallery's `howToViewers` and `howToViewersFlat` were client-writable, so anyone who could edit a gallery could add a uid to the flat list and hand them the gallery — and, since #1351, its published how-tos. Not only a curator: a gallery **creator** is barred from `public`, `curators` and `creators` and from nothing else, so in a class gallery that was any student.

Writing the tests first showed this was one instance of a pattern, not a one-off. **Seven tests failed before the fix; all seven were real.**

- **`allow create` constrained no field at all.** `galleryServerFieldsUnchanged()` was reached only from `allow update`, so every guard it made could be walked around by putting the value in the *new* document instead. The public listing is a plain `public == true && moderation == 'approved'` query, which made an already-approved gallery **a review bypass** — live today, and four of the seven failures.
- **The trigger could not answer the question it owns.** Nothing read the edited gallery's own `howToExpandedGalleries`: naming a gallery derived nothing, and expanded access worked only because the client computed the values first. So removing the client's write without building that path would have broken the feature outright.
- **"A gallery by the same curator" was documented and unchecked.** `galleryEdited` copied *any* listed gallery's member ids into a field readable by everyone who can read yours — which, through a public gallery, publishes a private one's membership. Moving derivation server-side is what would have made that immediately reachable, so it is closed here.

One prediction the tests **disproved**: `flags.values().hasOnly([null])` has no precedent in this rules file and I expected it might not evaluate. It does.

## Design notes

**The rules state the same six fields twice** — unchanged on update, at their initial values on create. `howToExpandedVisibility` and `howToExpandedGalleries` stay the curator's: those are the request, and the viewer lists are the answer. Same split `public` already has against `moderation`.

**The derivation is a pure function** (`deriveHowToViewers`, `sharesCurator`, `flattenHowToViewers`, `howToViewersChanged`), because the handler cannot be tested at all — mocking `firebase-admin` under `functions/src` leaks into every later file in the worker, since the `fast` project runs `isolate: false` and the convention test that catches that only scans `src/`. This is the same carve-out `nextModeration` / `curatorsChanged` / `galleryContentChanged` already had, and it takes the handler from zero coverage to covering the part that can be wrong.

**Two details decide whether the trigger terminates**, and both were wrong in a way that did not matter until now. The flat list is now deduped and **sorted** — an unstable order diffed against storage is a document that rewrites itself forever — and the map is compared by content rather than key order. The derive is merged into the one self-write that already exists and diffed before it is queued.

**Recomputing on every write** rather than only on a change is deliberate: it costs nothing for the galleries that draw on none, and a gallery still carrying a client-written value heals on its next write instead of needing a migration.

**The fan-out branches stay** — they are what makes revocation prompt rather than eventual — and the one that patches a single entry gets the same-curator check, or it would be a back door into what the derivation refuses.

## Removing `featured`

Checked before removing, and it was fully dangling: nothing could ever set it (no interface, no callable, no script, no function — `GalleryDatabase.create` hard-coded `false`), so `orderBy('featured','desc')` sorted by a constant while still costing a field in the composite index. The one `featured: true` is on a built-in gallery, built in memory and never written to Firestore, so that query never saw it — and the listing shuffles per page load anyway, so the ordering could not reach the screen regardless.

No schema version bump: nothing parses a gallery on the read path (the upgrade chain returns the stored object as-is at the latest version), so a document still carrying the key keeps it as an ignored extra. Not worth a migration to delete a boolean nothing reads.

## Related issues

- Closes #1352
- Related Issue #907, #1351

## Verification

- `npm run test:rules` — 238 passed (231 before this branch). The seven new cases fail on `main` and pass here; the other six suites are unregressed.
- `npm run test:run` — 508 files, 8789 passed, 7 skipped.
- `npm run test:sweep` — 2488 passed, run because `examples.ts` changed.
- `npm run check:now` and `npm run format:check` — clean.
- Playwright, chromium: the five `seeded-load` tests that can run in my environment pass, including the expanded-scope viewer, which is the regression guard for this whole change.

**Not verified here, and the thing to watch.** The functions emulator cannot start in my environment — it makes an outbound call that is blocked — so **the trigger's handler wiring is unproven; only its extracted derivation is** (22 unit tests, including idempotence). CI is the real check on that. Separately, six e2e tests failed at `joinViaUI.ts:45`, the account-signup flow, which needs network this environment blocks; I confirmed they fail identically on an unmodified tree, so they are not regressions.

That gap caught something worth naming: the seeded expanded-scope fixture paired a **teacher**-curated gallery with **creator's** own workshop, which share no curator, so the new rule would have stripped it the moment the trigger fired — and my local run passed only because the trigger never ran. It now draws on the demo class gallery, which the same teacher curates, and `creator` was added to that gallery's creators so the grant reaches them.

**Accessibility:** no UI change. Permissions, a cloud function, and the removal of a field that rendered nothing. No new markup, colors or focus targets, so screen-reader and keyboard passes are unchanged from `main` and I have not run them.

## Checklist

- [x] Worth a reviewer's eye: the same-curator rule is a **behavior change for existing data**. Any gallery pair that does not share a curator loses expanded access the next time the trigger fires. That is the intended reading of "a gallery by the same curator", but it is not a no-op on production data, and the seed fixture needing a fix is evidence of how easy that pairing was to create.
- [x] `galleryServerFieldsInitial()` pins `moderation` to `'unrequested'` on create. If any path ever needs to create an already-`'pending'` gallery, this is where it would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2)_