### PR TITLE
Let a how-to's conversation be deleted, and delete it with the how-to (#1353)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -407,6 +407,30 @@ service cloud.firestore {
           && "owner" in project.data
           && project.data.owner == request.auth.uid;
       }
+      // A how-to's chat has the same shape — its id is its how-to's id — but the
+      // id named a project here, so the get() found nothing and no uid could
+      // ever delete one. Deleting the how-to did not take it either, so the
+      // conversation and the `translations` subcollection the `chatDeleted`
+      // trigger exists to collect were both stranded for good (#1353).
+      //
+      // Who may delete it is who may delete the how-to: its creator, or a
+      // curator of the gallery it is in — the same pair `match /howtos` states.
+      // A collaborator may rewrite a how-to and not destroy it, and that holds
+      // for the conversation about it too.
+      function mayDeleteHowTosChat() {
+        let howTo = get(/databases/$(database)/documents/howtos/$(chat)).data;
+        return howTo != null
+          && (
+            ("creator" in howTo && howTo.creator == request.auth.uid)
+            || ("galleryId" in howTo && curatesGallery(howTo.galleryId))
+          );
+      }
+      function curatesGallery(galleryID) {
+        let gallery = get(/databases/$(database)/documents/galleries/$(galleryID)).data;
+        return gallery != null
+          && "curators" in gallery
+          && request.auth.uid in gallery.curators;
+      }
       // Anyone logged in can create chats
       allow create: if request.auth != null;
       allow read: if request.auth != null && (resource == null || (resource.data != null && request.auth.uid in resource.data.participants));
@@ -435,7 +459,20 @@ service cloud.firestore {
         && request.resource.data.diff(resource.data).affectedKeys()
              .hasOnly(['messages', 'unread', 'participants'])
         && request.resource.data.messages.size() >= resource.data.messages.size();
-      allow delete: if request.auth != null && ownsChatsProject();
+      // Which subject to ask about is the chat's own `type`. A pre-v2 document
+      // has none and is a project's, and a document that is already gone has no
+      // type to read — deleting a project whose chat never existed goes through
+      // this path, so it has to stay allowed rather than start reporting a
+      // failure.
+      allow delete: if request.auth != null && (
+        (
+          (resource == null || !("type" in resource.data) || resource.data.type == 'project')
+          && ownsChatsProject()
+        ) || (
+          resource != null && "type" in resource.data && resource.data.type == 'howto'
+          && mayDeleteHowTosChat()
+        )
+      );
 
       // Cached machine translations of this conversation, one document per
       // target language holding {messageID: translated text} (#1214).

--- a/src/db/chats/ChatDatabase.svelte.ts
+++ b/src/db/chats/ChatDatabase.svelte.ts
@@ -1157,7 +1157,9 @@ export class ChatDatabase {
         this.saves.forget(projectID);
     }
 
-    async deleteChat(projectID: string) {
+    /** Whether the chat is gone, so a caller deleting its subject can stop
+     *  rather than stranding the conversation it could no longer reach. */
+    async deleteChat(projectID: string): Promise<boolean> {
         // Confirm-then-remove: delete the cloud doc FIRST and only forget local
         // state (memory + durable dirty row) once it lands. Forgetting first —
         // as this used to — meant a failed/offline delete cleared the dirty row
@@ -1170,7 +1172,7 @@ export class ChatDatabase {
                 );
             } catch (err) {
                 this.db.reportBanner((l) => l.ui.banner.deleteFailed, err);
-                return;
+                return false;
             }
         }
         // Nothing to do about the translations subcollection here. Firestore
@@ -1180,6 +1182,7 @@ export class ChatDatabase {
         // silently leak from every other way a chat dies (a project deleted, an
         // account closed), so the `chatDeleted` trigger owns it instead.
         this.forgetChat(projectID);
+        return true;
     }
 
     syncUser() {

--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -691,6 +691,17 @@ export class HowToDatabase {
      *  failed/offline delete left a stranded cloud copy with the dirty row
      *  already cleared, so nothing could retry it. write() fails fast. */
     async deleteHowTo(howToId: string, gallery: Gallery): Promise<boolean> {
+        // The conversation about it goes first, and awaited, for the reason the
+        // project delete path gives: the chat rules read the how-to to check
+        // that whoever is deleting may, so deleting the how-to first leaves
+        // nothing to check against and strands the chat — and with it the
+        // `translations` subcollection only the `chatDeleted` trigger collects
+        // (#1353). Stop if it fails rather than deleting the how-to anyway,
+        // which is the state that has no way back.
+        if (this.howtos.get(howToId)?.getChatId() != null) {
+            if (!(await this.db.Chats.deleteChat(howToId))) return false;
+        }
+
         if (firestore) {
             try {
                 // Atomic batch: delete the how-to doc AND remove its ID from

--- a/src/db/howtos/HowToDatabase.test.ts
+++ b/src/db/howtos/HowToDatabase.test.ts
@@ -137,6 +137,7 @@ describe('HowToDatabase atomic how-to + gallery updates', () => {
             write: vi.fn(<T>(p: Promise<T>) => p),
             reportBanner: vi.fn(),
             Galleries: { mirrorHowToMembership: vi.fn() },
+            Chats: { deleteChat: vi.fn(async () => true) },
         };
 
         db = new HowToDatabase(mockDatabase);
@@ -278,6 +279,55 @@ describe('HowToDatabase atomic how-to + gallery updates', () => {
             expect(galleryUpdate!.data).toMatchObject({
                 howTos: { _op: 'arrayRemove', elements: ['ht-1'] },
             });
+        });
+
+        it('deletes the conversation about it first, and only when there is one', async () => {
+            // Before the how-to, because the chat rules read the how-to to
+            // decide who may delete its chat — deleting the how-to first strands
+            // the conversation for good (#1353).
+            const gallery = makeGallery('g1', ['ht-1']);
+            db['howtos'].set(
+                'ht-1',
+                new HowTo(
+                    makeHowToDoc({
+                        id: 'ht-1',
+                        social: { ...baseSocial, chat: 'ht-1' },
+                    }),
+                ),
+            );
+
+            await db.deleteHowTo('ht-1', gallery);
+
+            expect(mockDatabase.Chats.deleteChat).toHaveBeenCalledWith('ht-1');
+        });
+
+        it('does not ask to delete a conversation that was never started', async () => {
+            const gallery = makeGallery('g1', ['ht-1']);
+            db['howtos'].set('ht-1', new HowTo(makeHowToDoc({ id: 'ht-1' })));
+
+            await db.deleteHowTo('ht-1', gallery);
+
+            expect(mockDatabase.Chats.deleteChat).not.toHaveBeenCalled();
+        });
+
+        it('keeps the how-to when its conversation could not be deleted', async () => {
+            // The alternative is the one state with no way back: the how-to gone
+            // and the chat left behind, which no client can then reach.
+            mockDatabase.Chats.deleteChat = vi.fn(async () => false);
+            const gallery = makeGallery('g1', ['ht-1']);
+            db['howtos'].set(
+                'ht-1',
+                new HowTo(
+                    makeHowToDoc({
+                        id: 'ht-1',
+                        social: { ...baseSocial, chat: 'ht-1' },
+                    }),
+                ),
+            );
+
+            expect(await db.deleteHowTo('ht-1', gallery)).toBe(false);
+            expect(lastBatchOps).toHaveLength(0);
+            expect(db['howtos'].has('ht-1')).toBe(true);
         });
 
         it('removes the how-to from the local cache only after the cloud delete succeeds', async () => {

--- a/tests/rules/chatRules.test.ts
+++ b/tests/rules/chatRules.test.ts
@@ -21,12 +21,18 @@ const Users = {
     Collaborator: 'rulestest-chat-collaborator',
     Stranger: 'rulestest-chat-stranger',
     Mod: 'rulestest-chat-mod',
+    /** Curates the gallery the how-to below is in. */
+    Curator: 'rulestest-chat-curator',
 };
 
 /** A chat's document id is its project's id, which is what the rule relies on. */
 const Chat = 'rulestest-chat-project';
-/** A chat whose project doesn't exist, standing in for a how-to's chat. */
+/** A chat whose subject doesn't exist at all. */
 const Orphan = 'rulestest-chat-orphan';
+/** A how-to's chat: same shape, but its id names a how-to (#1353). */
+const HowToChat = 'rulestest-chat-howto';
+/** The gallery that how-to is in. */
+const HowToGallery = 'rulestest-chat-howto-gallery';
 /** A cache whose conversation has been deleted, which is what the client can
  *  never clean up and the `chatDeleted` trigger exists for. */
 const Gone = 'rulestest-chat-gone';
@@ -72,6 +78,31 @@ beforeEach(async () => {
                 moderation: {},
                 unread: [],
             });
+        // A how-to, its gallery, and the conversation about it. The chat's id is
+        // the how-to's, which is what made it unreachable by the project-shaped
+        // rule (#1353).
+        await db.doc(`galleries/${HowToGallery}`).set({
+            curators: [Users.Curator],
+            creators: [Users.Collaborator],
+            public: false,
+        });
+        await db.doc(`howtos/${HowToChat}`).set({
+            galleryId: HowToGallery,
+            creator: Users.Owner,
+            collaborators: [Users.Collaborator],
+            published: true,
+            scopeOverwrite: false,
+            isPublic: false,
+        });
+        await db.doc(`chats/${HowToChat}`).set({
+            v: 3,
+            project: HowToChat,
+            type: 'howto',
+            participants,
+            messages: [{ id: 'm1', time: 1, creator: Users.Owner, text: 'hi' }],
+            moderation: {},
+            unread: [],
+        });
         // A cached translation for each, plus one whose conversation is gone.
         for (const id of [Chat, Orphan, Gone])
             await db.doc(`chats/${id}/translations/es-MX`).set({ m1: 'hola' });
@@ -365,13 +396,62 @@ describe('chats: participants take part, the project owner disposes', () => {
         );
     });
 
-    it('a chat whose project is gone cannot be deleted by anyone', async () => {
+    it('a chat whose subject is gone cannot be deleted by anyone', async () => {
         // get() answers null for a missing document, so the rule denies rather
-        // than erroring. This is also today's behavior for a how-to's chat,
-        // whose id names a how-to and never a project.
+        // than erroring. Deleting the subject first is what keeps this from
+        // being reachable — which is why both delete paths do it in that order.
         await assertFails(as(Users.Owner).doc(`chats/${Orphan}`).delete());
         await assertFails(
             as(Users.Collaborator).doc(`chats/${Orphan}`).delete(),
+        );
+    });
+
+    it("a how-to's creator can delete the conversation about it", async () => {
+        // The whole of #1353: this used to be denied for everyone, because the
+        // rule read the chat's id as a project's and found nothing.
+        await assertSucceeds(
+            as(Users.Owner).doc(`chats/${HowToChat}`).delete(),
+        );
+    });
+
+    it('so can a curator of the gallery it is in, who can delete the how-to', async () => {
+        await assertSucceeds(
+            as(Users.Curator).doc(`chats/${HowToChat}`).delete(),
+        );
+    });
+
+    it('a collaborator on the how-to cannot, as on a project', async () => {
+        // A collaborator may rewrite a how-to and not destroy it, and that holds
+        // for the conversation about it — the same asymmetry the how-to delete
+        // rule states.
+        await assertFails(
+            as(Users.Collaborator).doc(`chats/${HowToChat}`).delete(),
+        );
+    });
+
+    it('nor a stranger, nor a moderator', async () => {
+        // A moderator takes a how-to down by unpublishing it, which is what
+        // `moderate.ts` does; a conversation is not public content.
+        await assertFails(
+            as(Users.Stranger).doc(`chats/${HowToChat}`).delete(),
+        );
+        await assertFails(
+            as(Users.Mod, { mod: true }).doc(`chats/${HowToChat}`).delete(),
+        );
+    });
+
+    it("a how-to's chat is not deletable by its project's owner", async () => {
+        // The branch is on the chat's own `type`, so a how-to's chat is never
+        // answered by the project question — there is no project with this id to
+        // own, and inventing one must not open it.
+        await env.withSecurityRulesDisabled(async (context) => {
+            await context
+                .firestore()
+                .doc(`projects/${HowToChat}`)
+                .set({ owner: Users.Stranger, collaborators: [] });
+        });
+        await assertFails(
+            as(Users.Stranger).doc(`chats/${HowToChat}`).delete(),
         );
     });
 });


### PR DESCRIPTION
# Context

A chat's document id is its subject's id, and the delete rule read that id as a *project's*. A how-to's chat is created at its how-to's id, so the `get()` looked up a project that does not exist, found nothing, and denied — for everyone, always. Deleting the how-to did not take the chat either, so the conversation and the `translations` subcollection the `chatDeleted` trigger exists to collect were both stranded, unreachable by exactly the argument that trigger's own comment makes.

**Writing the test turned up something worse than the issue described.** Project ids are client-chosen and `allow create` constrains none of them, so a stranger could create `projects/<a how-to's id>` naming themselves owner, and then delete that how-to's chat — destroying someone else's conversation. So this was not only "can never be deleted"; it was also "can be deleted by the wrong person". The branch is on the chat's own `type` now, so a how-to's chat never consults the project question and a planted project cannot answer for it.

Three of the five new tests fail against `main`, that one among them. The other two pass there trivially — everything was denied — and are here to guard the new rule against being too permissive.

**The issue's open question, answered: projects were already fine.** `ProjectsDatabase.delete` deletes the chat first and awaited, with a comment giving exactly the reason — the chat rules read the project to check that whoever is deleting owns it, so deleting the project first would leave nothing to check against. That is the pattern this mirrors.

## Design notes

**Who may delete it is who may delete the how-to**: its creator, or a curator of the gallery it is in — the same pair `match /howtos` states. A collaborator may rewrite a how-to and not destroy it, and that holds for the conversation about it too. A moderator gets no special access, as on a project chat: taking a how-to down is `moderate.ts` unpublishing it, and a conversation is not public content.

**The rule has to keep answering for a chat document that is not there.** `ProjectsDatabase.delete` calls `deleteChat` unconditionally, so deleting a project whose chat was never started goes through this path — a null resource therefore falls to the project branch rather than erroring on a `type` it cannot read. Without that, every project deletion without a chat would start reporting a failed delete.

**No new cloud function.** `deleteHowTo` is the only path that deletes a how-to — the editor and gallery deletion both route through it — so a trigger on `howtos/{id}` would be guarding a path that does not exist. It deletes the conversation first and awaited, mirroring the project path, and **stops if that fails** rather than deleting the how-to anyway: a how-to gone with its chat left behind is the one state with no way back. `deleteChat` reports whether it succeeded so the caller can make that choice; the project path ignores the new return value and is unchanged.

## Related issues

- Closes #1353
- Related Issue #907, #1351, #1352

## Verification

- `npm run test:rules` — 243 passed (238 before this branch). The five new cases; three of them fail on `main`, which I confirmed by running them against the unmodified rules.
- `npm run test:run` — 508 files, 8792 passed, 7 skipped, including three new `HowToDatabase` cases (the chat is deleted first, only when one exists, and the how-to survives a failed chat delete).
- `npm run check:now` and `npm run format:check` — clean.
- Playwright, chromium: the five `seeded-load` tests that can run in my environment pass.

**Not verified here.** Nine e2e tests failed for two container limitations I have already confirmed are pre-existing on an unmodified tree: `#project-name` never resolving on `/project/seed-collab-project` (`seeded-load`'s project test and `chat-translation`, same locator on the same page), and the worker fixture's account signup, which needs blocked network (the seven `chat.spec.ts` tests, each failing in 1–3ms before any assertion). Those all passed in CI on the previous PR, so CI is the check on them.

**Accessibility:** no UI change — a security rule and a deletion path. No new markup, colors or focus targets, so screen-reader and keyboard passes are unchanged from `main` and I have not run them.

## Checklist

- [ ] Worth a reviewer's eye: this makes a how-to's chat deletable, which it never was. If any conversation is currently stranded on a deleted how-to in production, this change does not collect it — the rule needs the how-to to exist to authorize the delete, and those how-tos are gone. Those documents would need an admin sweep; I have not written one, and it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2)_