### PR TITLE
Scan the how-to space for accessibility, and give it a title (#1354)

### DIFF
--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -4,6 +4,7 @@
     import Notice from '@components/app/Notice.svelte';
     import Page from '@components/app/Page.svelte';
     import PageHeader from '@components/app/PageHeader.svelte';
+    import Title from '@components/widgets/Title.svelte';
     import Subheader from '@components/app/Subheader.svelte';
     import Writing from '@components/app/Writing.svelte';
     import MarkupHTMLView from '@components/concepts/MarkupHTMLView.svelte';
@@ -400,6 +401,16 @@
         indexContext.index = placeholderIndex;
     });
 </script>
+
+<!-- Outside the branches below, so the page is titled while it is still
+     loading and when the gallery turns out to be unreachable. axe's
+     document-title rule fails a page that has none, and this route had none in
+     any state (#1354) — it is also the one route a signed-out visitor can reach
+     that no scan covered. Named for the section plus this gallery, the way the
+     gallery page titles itself. -->
+<svelte:head>
+    <Title text={(l) => l.ui.howto.galleryView.header} subtitle={galleryName} />
+</svelte:head>
 
 {#if gallery === null || (gallery === undefined && urlID !== null && urlLoaded === null)}
     <Loading />

--- a/tests/end2end/accessibility-authed.spec.ts
+++ b/tests/end2end/accessibility-authed.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { expectNoAxeViolationsInBothSchemes } from '../helpers/checkAccessibility';
+import { enUS, text } from '../helpers/localize';
 import { createTestCharacter } from '../helpers/createCharacter';
 import { createTestGallery } from '../helpers/createGallery';
 import { editTrianglePoints } from '../helpers/drawCharacterPath';
@@ -374,6 +375,72 @@ test.describe('authed views', () => {
             await createTestCharacter(page);
             await editTrianglePoints(page);
             await expectNoAxeViolationsInBothSchemes(page);
+        } finally {
+            await context.close();
+        }
+    });
+
+    test(`a how-to space and an open how-to have no WCAG 2.2 AA violations`, async ({
+        browser,
+    }) => {
+        // Two surfaces on one sign-in, for the reason this file's header gives:
+        // restoring Firebase Auth's IndexedDB into a fresh context is the
+        // expensive part, and these differ only by a navigation.
+        //
+        // Neither had ever been scanned (#1354). The seeded workshop gallery is
+        // used rather than a fresh one so both are deterministic: `creator`
+        // curates it, so the create control, the drafts sidebar and the
+        // configuration dialog are all in the tree, and it holds both published
+        // how-tos and drafts.
+        const { context, page } = await loginNewContext(
+            browser,
+            'creator',
+            'password',
+        );
+        try {
+            await page.goto('/en-US/gallery/seeded-howto-gallery-id/howto');
+            // Attached rather than visible: canvas tiles are virtualized to the
+            // camera's viewport, so presence is what says the space has loaded.
+            await expect(
+                page.getByText('Use color to set mood').first(),
+            ).toBeAttached({ timeout: LOAD_TIMEOUT });
+            await expectNoAxeViolationsInBothSchemes(page, { verbose: true });
+
+            // An open how-to, which is where the editor, the collaborators
+            // panel and the whole social pane live. Both parameters are needed
+            // and do different things: `id` pans the camera to the how-to, which
+            // is what mounts its tile — they are virtualized to the viewport,
+            // and Dialog only reacts to the URL while it is mounted — and
+            // `dialog` is Dialog's own reopen-from-a-link mechanism.
+            // `seed-howto-01` is published and is the one the seed gives a
+            // conversation, so the chat is in the tree too.
+            await page.goto(
+                '/en-US/gallery/seeded-howto-gallery-id/howto?id=seed-howto-01&dialog=howto:seed-howto-01',
+            );
+            const howTo = page.locator('dialog[open]').first();
+            await expect(howTo).toBeVisible({ timeout: LOAD_TIMEOUT });
+            // That it is *this* how-to's dialog, and that the social pane is in
+            // it: a whole-page scan of a dialog that opened empty, or of some
+            // other dialog, would pass while checking nothing this test is for.
+            // Buttons here take their accessible name from `tip`, not the
+            // visible `label`, which is what the editor's own spec matches on.
+            await expect(
+                howTo.getByText('Use color to set mood').first(),
+            ).toBeVisible();
+            await expect(
+                howTo
+                    .getByRole('button', {
+                        name: text(enUS.ui.howto.bookmarks.canBookmark.tip),
+                    })
+                    .or(
+                        howTo.getByRole('button', {
+                            name: text(
+                                enUS.ui.howto.bookmarks.alreadyBookmarked.tip,
+                            ),
+                        }),
+                    ),
+            ).toBeVisible();
+            await expectNoAxeViolationsInBothSchemes(page, { verbose: true });
         } finally {
             await context.close();
         }

--- a/tests/end2end/accessibility.spec.ts
+++ b/tests/end2end/accessibility.spec.ts
@@ -37,6 +37,12 @@ const PUBLIC_ROUTES = [
     // Signed out is also the dimmed state of the cloud badge marking a synced
     // setting, so this covers that color in both schemes.
     '/?dialog=settings',
+    // A public gallery's how-to space, which a signed-out visitor can open
+    // (#1351) and which no scan reached until #1354 — an infinite pan canvas of
+    // virtualized tiles, and none of it had ever had an axe pass. Signed out is
+    // also the state with no social pane, so this covers the canvas and its
+    // tiles without the affordances only a member gets.
+    '/gallery/seed-public-gallery-00/howto',
 ];
 
 test.describe('public pages', () => {


### PR DESCRIPTION
# Context

The how-to space was in neither axe scan. CLAUDE.md says a new route adds a `Title` and an entry in the scan list; this one got neither when it shipped in #882, so its canvas, virtualized tiles, drafts sidebar, editor, collaborators panel and social pane had never had an axe pass. Since #1351 a signed-out visitor can open a public gallery's space, which puts it in the same category as the routes already in `PUBLIC_ROUTES`.

Two scans, mirroring the split that already exists: the public space **signed out**, which is also the state with no social pane, and a curator's space plus an **open how-to** signed in.

## What they found

**One violation, and only one**: the route rendered no `<title>`, so axe's `document-title` rule failed it in every state — both scans, both color schemes.

I said in the issue that I expected this to find real violations rather than come up green. It found one, and I was more pessimistic than the surface deserved: **the rest is clean at WCAG 2.2 AA**. The canvas and its tiles, the drafts sidebar, the dialog, the collaborators panel and the chat all pass in both color schemes, with no `exclude` and no `disableRules`.

The title is fixed the way the gallery page fixes it — outside the branches, so the page is titled while it is still loading and when the gallery turns out to be unreachable, and named for the section plus the gallery.

## Design notes

**Opening the dialog takes both URL parameters, and they do different things.** `id` pans the camera, which is what mounts the tile — tiles are virtualized to the viewport, and `Dialog` only reacts to the URL while it is mounted. `dialog` is `Dialog`'s own reopen-from-a-link mechanism. Neither alone is enough. Clicking a tile is not an option: one can unmount as the camera settles, which is the flake #1336 fixed.

**One test, two surfaces, one sign-in.** That file's header records that restoring Firebase Auth's IndexedDB into a fresh context is the expensive part of these tests, and the two surfaces differ only by a navigation — so this adds one `test()` rather than two.

**The dialog assertions are load-bearing rather than decorative.** A whole-page scan of a dialog that opened empty, or of some other dialog, would pass while checking nothing this test is for — so it asserts the how-to's own title and the social pane are present first. Writing them turned up that these buttons take their accessible name from `tip` and not the visible `label`, which is the obvious guess and is wrong.

## Related issues

- Closes #1354
- Related Issue #907, #1351

## Verification

- Playwright, chromium, the accessibility subset CLAUDE.md names (`accessibility keyboard-navigation aria-snapshots announcer`): **44 passed**, including both new scans. Both fail before the `Title` fix, which is how I know the scans are actually looking at the route.
- `npm run test:run` — 508 files, 8792 passed, 7 skipped.
- `npm run check:now` and `npm run format:check` — clean.

**The 8 failures in that subset are pre-existing and not from this change** — I confirmed it rather than assuming, by stashing the change, rebuilding and running the same specs: the same 8 fail on a clean tree. They are the two environment limitations this container has (`/project/seed-collab-project` never resolving `#project-name`, and `createTestProject`, which the four `announcer` stage tests go through). All of them pass in CI.

**Accessibility:** this change *is* the accessibility work. No behavior change beyond the document title; no new markup, colors or focus targets. Screen-reader and keyboard passes are unchanged from `main` and I have not run them — the keyboard and announcer suites in the subset above cover their own ground and pass.

## Checklist

- [ ] Worth a reviewer's eye: the scans cover the space, an open how-to, and the signed-out case, but **not** the curator's configuration dialog (guiding questions and the reaction set) or the create form with content typed into it. Both are reachable and could be added; I stopped where the issue's scope did, and a scan of each costs about 5s.
- [ ] Keyboard-moving a tile is still unscanned by axe, which cannot see it anyway — that behavior belongs in `keyboard-navigation.spec.ts` if it is worth pinning, and it is not covered today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PusW8g2Wb3JyULD93GDmJ2)_