### PR TITLE
Land the caret on a token's last position when clicking

### DIFF
--- a/src/components/editor/caret/CaretView.svelte
+++ b/src/components/editor/caret/CaretView.svelte
@@ -877,6 +877,7 @@
                       const rect = locateCaretRect(
                           currentTokenView,
                           Math.max(0, currentTokenOffset),
+                          axes,
                       );
                       if (rect === undefined) return undefined;
                       const extent = blockExtent(rect);
@@ -1383,7 +1384,7 @@
             // arithmetic below silently puts the caret on the first line at the
             // widest line's width. A collapsed range has no such ambiguity, and
             // it carries the correct line as well as the correct offset.
-            const caretRect = locateCaretRect(tokenView, tokenOffset);
+            const caretRect = locateCaretRect(tokenView, tokenOffset, axes);
             if (caretRect !== undefined) {
                 const box = axes.rect(caretRect);
                 // The collapsed range's own extent is the line box at that

--- a/src/components/editor/highlights/measureTokenSegment.ts
+++ b/src/components/editor/highlights/measureTokenSegment.ts
@@ -1,4 +1,8 @@
-import type { Axes, LogicalPoint } from '@components/editor/util/axes';
+import type {
+    Axes,
+    LogicalPoint,
+    LogicalRect,
+} from '@components/editor/util/axes';
 
 // Grapheme segmentation for locating an offset inside a token view's rendered
 // text. Boundaries are locale-independent, so one shared instance suffices.
@@ -103,6 +107,69 @@ export function measureTokenSegment(
     return [rect.width, rect.height];
 }
 
+/** Whether a measured rect says nothing about where anything is: a detached or
+ *  `display: none` view unions to the page origin, and Chromium reports no rects
+ *  at all for a collapsed range at the very end of a text node. */
+function isUnmeasurable(rect: DOMRect) {
+    return (
+        rect.width === 0 && rect.height === 0 && rect.x === 0 && rect.y === 0
+    );
+}
+
+/**
+ * Where the caret at a grapheme boundary sits when a collapsed range can't say:
+ * the trailing edge of everything before it.
+ *
+ * Chromium reports no rects at all for a COLLAPSED range at the very end of a
+ * text node, which is exactly a token's last position — so without this the end
+ * of a token is unmeasurable, and anything searching over offsets settles one
+ * grapheme short of it. A non-collapsed range always reports one rect per line.
+ * `CaretView`'s `edgeOfToken` works around the same thing for the caret alone.
+ *
+ * Measuring from the start of the text rather than from the preceding grapheme
+ * also answers for a substituted token, whose offset is `Infinity`.
+ *
+ * Filtering and collapsing in *logical* space is what makes this right in every
+ * writing mode: the inline axis increases in reading order, so the trailing
+ * edge is `inlineEnd` whichever way the text runs.
+ */
+function trailingEdgeRect(
+    nodes: Text[],
+    to: { index: number; codeUnit: number },
+    axes: Axes,
+    range: Range,
+): LogicalRect | undefined {
+    // Start before end: the range is reused, and setting an end that precedes
+    // the current start would silently collapse it.
+    range.setStart(nodes[0], 0);
+    range.setEnd(nodes[to.index], to.codeUnit);
+    // A line fragment with no extent along the text — a trailing empty text
+    // node, or an offset of zero — says nothing about where the caret is.
+    const boxes = Array.from(range.getClientRects())
+        .map((rect) => axes.rect(rect))
+        .filter((box) => box.inlineEnd > box.inlineStart);
+    const box = boxes[boxes.length - 1];
+    return box === undefined
+        ? undefined
+        : { ...box, inlineStart: box.inlineEnd };
+}
+
+/** A logical rect back in viewport coordinates, so a caller that projects with
+ *  its own `axes` sees exactly what was measured. */
+function clientRectOf(box: LogicalRect, axes: Axes): DOMRect {
+    const start = axes.client({
+        inline: box.inlineStart,
+        block: box.blockStart,
+    });
+    const end = axes.client({ inline: box.inlineEnd, block: box.blockEnd });
+    return new DOMRect(
+        Math.min(start.clientX, end.clientX),
+        Math.min(start.clientY, end.clientY),
+        Math.abs(end.clientX - start.clientX),
+        Math.abs(end.clientY - start.clientY),
+    );
+}
+
 /**
  * The client rect of the collapsed caret position `tokenOffset` graphemes into a
  * token view, or undefined when there is nothing to measure.
@@ -120,6 +187,7 @@ export function measureTokenSegment(
 export function locateCaretRect(
     tokenView: Element,
     tokenOffset: number,
+    axes: Axes,
 ): DOMRect | undefined {
     tokenOffset = atomicOffset(tokenView, tokenOffset);
     const nodes = getTextNodes(tokenView);
@@ -147,11 +215,14 @@ export function locateCaretRect(
         rects.length > 0
             ? rects[rects.length - 1]
             : range.getBoundingClientRect();
-    // A detached or display:none view measures as nothing; say so rather than
-    // reporting the origin, which would put the caret in the corner of the page.
-    return rect.width === 0 && rect.height === 0 && rect.x === 0 && rect.y === 0
-        ? undefined
-        : rect;
+    if (!isUnmeasurable(rect)) return rect;
+
+    // Either the token's last position, which a collapsed range can't measure,
+    // or a detached or display:none view, which measures as nothing at all —
+    // say so rather than reporting the origin, which would put the caret in the
+    // corner of the page.
+    const edge = trailingEdgeRect(nodes, found, axes, range);
+    return edge === undefined ? undefined : clientRectOf(edge, axes);
 }
 
 /**
@@ -247,11 +318,12 @@ export function graphemeOffsetAt(
             rects.length > 0
                 ? rects[rects.length - 1]
                 : range.getBoundingClientRect();
-        return rect.width === 0 &&
-            rect.height === 0 &&
-            rect.x === 0 &&
-            rect.y === 0
-            ? undefined
+        // A token's last position measures as nothing in Chromium, and without
+        // the fallback the search below can never reach it: it settles one
+        // grapheme short, so a click past the end of a line lands one character
+        // before it.
+        return isUnmeasurable(rect)
+            ? trailingEdgeRect(nodes, found, axes, range)
             : axes.rect(rect);
     };
 

--- a/src/components/editor/pointer/PointerUtilities.ts
+++ b/src/components/editor/pointer/PointerUtilities.ts
@@ -491,6 +491,7 @@ function rowRectOfIndex(
     editor: HTMLElement,
     caret: Caret,
     index: number,
+    axes: Axes,
 ): DOMRect | undefined {
     const token = caret.source.getTokenAt(index);
     if (token === undefined) return undefined;
@@ -504,7 +505,7 @@ function rowRectOfIndex(
     const at =
         start === undefined
             ? undefined
-            : locateCaretRect(view, Math.max(0, index - start));
+            : locateCaretRect(view, Math.max(0, index - start), axes);
     if (at !== undefined && isRendered(at)) return at;
     const rect = view.getBoundingClientRect();
     return isRendered(rect) ? rect : undefined;
@@ -700,11 +701,14 @@ function activeEndIndex(caret: Caret): number | undefined {
 export function caretOriginRect(
     editor: HTMLElement,
     caret: Caret,
+    axes: Axes,
 ): DOMRect | undefined {
     const bar = caretBarRect(editor);
     if (bar !== undefined) return bar;
     const end = activeEndIndex(caret);
-    return end === undefined ? undefined : rowRectOfIndex(editor, caret, end);
+    return end === undefined
+        ? undefined
+        : rowRectOfIndex(editor, caret, end, axes);
 }
 
 /** Move the text caret one visual row up (-1) or down (1), keeping its
@@ -731,7 +735,7 @@ export function moveCaretVisualVertical(
     const box =
         node !== undefined
             ? nodeViewRect(editor, node)
-            : caretOriginRect(editor, caret);
+            : caretOriginRect(editor, caret, axes);
     if (box === undefined) return undefined;
     const origin = axes.rect(box);
 
@@ -785,7 +789,7 @@ export function expandCaretVisualVertical(
     // The moving end's row: its caret bar when collapsed (a bar is rendered), or
     // the token at the moving end when it's already a range (no bar is rendered).
     const bar = caretBarRect(editor);
-    const box = bar ?? rowRectOfIndex(editor, caret, movingEnd);
+    const box = bar ?? rowRectOfIndex(editor, caret, movingEnd, axes);
     if (box === undefined) return undefined;
     const from = axes.rect(box);
 

--- a/tests/end2end/caret-vertical.spec.ts
+++ b/tests/end2end/caret-vertical.spec.ts
@@ -3,12 +3,17 @@ import { grantClipboard } from '../helpers/clipboard';
 import { createTestProject } from '../helpers/createProject';
 
 /**
- * Vertical caret movement must never silently do nothing. The rendered row
- * model is built from the DOM and only knows what it drew, so wherever it
- * disagrees with the caret's own position universe — the end of a program that
- * ends in a delimiter, a row outside a virtualized window, an unmeasurable
- * caret — a source-line step takes over. These cover what the unit tests can't:
- * the unit suite has no DOM, so every rectangle there is zero.
+ * Caret geometry the unit suite cannot see: it has no DOM, so every rectangle
+ * there is zero.
+ *
+ * Vertical movement must never silently do nothing. The rendered row model is
+ * built from the DOM and only knows what it drew, so wherever it disagrees with
+ * the caret's own position universe — the end of a program that ends in a
+ * delimiter, a row outside a virtualized window, an unmeasurable caret — a
+ * source-line step takes over.
+ *
+ * Pointer placement measures the same rectangles, and the last test covers the
+ * one position the browser refuses to measure directly.
  */
 
 /** The focused editor's hidden mirror field, which follows the caret. */
@@ -42,6 +47,16 @@ async function withCode(page: import('@playwright/test').Page, code: string) {
             message: 'source did not load into the editor',
         })
         .toBe(code);
+}
+
+/** A locator's box, failing with what was being measured rather than a null. */
+async function boxOf(
+    locator: import('@playwright/test').Locator,
+    what: string,
+) {
+    const box = await locator.boundingBox();
+    if (box === null) throw new Error(`${what} has no box to measure`);
+    return box;
 }
 
 async function useBlocksMode(page: import('@playwright/test').Page) {
@@ -126,4 +141,56 @@ test('a move with nowhere left to go says so', async ({ page }) => {
     await expect(page.locator('.announcements.immediate')).toContainText(
         "Can't move any further",
     );
+});
+
+test("a click lands on a token's last position", async ({ page }) => {
+    // The end of a token is the one caret position a COLLAPSED Range can't
+    // measure in Chromium, so the search over offsets used to settle one
+    // grapheme short of it — a click past the end of a line landed before the
+    // line's last character, and so did a click on a token's last glyph.
+    const code = 'abcde: 100\nxy: 1 + 2';
+    await withCode(page, code);
+
+    const editor = await boxOf(
+        page.getByTestId('editor').first(),
+        'the editor',
+    );
+    const rightOf = (box: { x: number; width: number }) =>
+        Math.min(box.x + box.width + 40, editor.x + editor.width - 8);
+    const middleOf = (box: { y: number; height: number }) =>
+        box.y + box.height / 2;
+    const tokenBox = (text: string) =>
+        boxOf(
+            page.locator('.token-view').filter({ hasText: text }).last(),
+            `the ${text} token`,
+        );
+
+    // Well past the end of the first line, in the empty space beside it.
+    const hundred = await tokenBox('100');
+    await page.mouse.click(rightOf(hundred), middleOf(hundred));
+    await expect
+        .poll(async () => (await mirror(page)).start, {
+            message: 'a click right of a line did not land at the line end',
+        })
+        .toBe(code.indexOf('\n'));
+
+    // Inside a token, against its far edge: the same defect, and the one that
+    // needs no geometry about empty space to reproduce.
+    const name = await tokenBox('abcde');
+    await page.mouse.click(name.x + name.width - 2, middleOf(name));
+    await expect
+        .poll(async () => (await mirror(page)).start, {
+            message: "a click on a token's last glyph did not land after it",
+        })
+        .toBe('abcde'.length);
+
+    // A line ending in a single-character token, where landing short puts the
+    // caret before the only character there is.
+    const two = await tokenBox('2');
+    await page.mouse.click(rightOf(two), middleOf(two));
+    await expect
+        .poll(async () => (await mirror(page)).start, {
+            message: 'a click right of the last line did not land at its end',
+        })
+        .toBe(code.length);
 });


### PR DESCRIPTION
# Context

Clicking in the empty space to the right of a line of code put the caret one grapheme **before** the end of that line. The same defect meant clicking a token's last glyph put the caret before that glyph — so a pointer could never reach a token's final position at all.

**Cause.** Chromium reports no client rects for a *collapsed* `Range` at the very end of a text node, and `getBoundingClientRect()` then unions to `0,0,0,0`. `graphemeTable` expresses every interior text-node boundary as the start of the *next* node, so `offset === length` is the only probe that ever lands at a text node's end. It measured as nothing, so `graphemeOffsetAt`'s search could never score it and the final sweep settled on `length - 1`.

This is a regression from #1359, which replaced `getTokenPosition`'s interpolation — whose far-edge case correctly returned the full `textLength` — with measurement. The codebase had already discovered this Chromium behavior once and worked around it locally in `CaretView`'s `edgeOfToken`, for caret *rendering* only.

**Fix.** `trailingEdgeRect` in `measureTokenSegment.ts` measures a **non-collapsed** range ending at the offset, takes the last of its per-line rects, and collapses to `inlineEnd` in *logical* space — so it holds in all four writing modes, since the inline axis increases in reading order by construction. Measuring from the start of the text rather than from the preceding grapheme also answers for a substituted (`data-synthetic`) token, whose offset is `Infinity`.

`locateCaretRect` uses the same fallback (hence the `axes` parameter threaded through `rowRectOfIndex`/`caretOriginRect` and the two `CaretView` call sites). That also stops a caret at the end of a soft-wrapped prose paragraph in the markup editor falling back to the token's union box — where it was drawn paragraph-tall, on the first line, at the widest line's width.

Deliberately **not** added: a symmetric fallback at `offset === 0`. The reported symptom proves that boundary measures fine — a click left of a line lands at 0, not 1.

## Related issues

- Related Issue #1359

## Verification

`npm run check:now` clean; `npm run test:run` 530 files / 9282 tests passing.

New e2e test in `tests/end2end/caret-vertical.spec.ts` (one page load, three assertions), reusing that file's existing `withCode`/`mirror` helpers. The unit suite cannot cover this — JSDOM has no layout, so every rect is zero and the code falls through to its (correct) interpolation fallback. It is a browser-only claim about CSS geometry.

**Proved the test is not a no-op:** with the fix stashed and rebuilt, all three assertions land exactly one index short — click right of line 1 → 9 instead of 10; click a token's last glyph → 4 instead of 5; click right of the last line, which ends in a single-character token → 19 instead of 20.

Also run green on chromium: `ime-composition` (both editors, incl. Korean/Japanese/Chinese IME), `writing-vertical`, `editor-fuzz`, `fold`, `source-views`, `phrase-text-editing`, `chrome-selection`.

Manual check: click well to the right of a line and type — the character lands at the end of the line.

**Not verified, and worth a reviewer's attention:**
- WebKit and Firefox. The fix is `axes`-projected rather than direction-branched, but Chromium is the only engine I exercised. Firefox does return a rect for a collapsed range here, so it was never affected.
- The e2e runs above used a long-lived emulator (`WORDPLAY_E2E_REUSE=1`), not a clean `npm run end2end`. CI is the backstop.
- No screen-reader pass: this changes which index a click resolves to, not any announcement, label, or focus order. Caret movement remains covered by the existing caret and echo announcements.
- No color or new UI, so nothing to check for contrast.

## Checklist

- [ ] Clean `npm run end2end`
- [ ] WebKit spot-check of clicking past a line end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
