### PR TITLE
Update dependencies

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,18 +9,17 @@
                 "shared-types"
             ],
             "dependencies": {
-                "@anthropic-ai/sdk": "^0",
+                "@anthropic-ai/sdk": "^0.125",
                 "@supercharge/promise-pool": "^3",
                 "firebase-admin": "^14",
                 "firebase-functions": "^7",
-                "nodemailer": "^9",
+                "nodemailer": "^10",
                 "prettier": "^3",
                 "resend": "^6.26.0",
                 "shared-types": "file:./src/shared",
                 "yjs": "^13"
             },
             "devDependencies": {
-                "@types/nodemailer": "^8",
                 "typescript": "^6"
             },
             "engines": {
@@ -28,9 +27,9 @@
             }
         },
         "node_modules/@anthropic-ai/sdk": {
-            "version": "0.123.0",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
-            "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
+            "version": "0.125.0",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.125.0.tgz",
+            "integrity": "sha512-Hq5wYlXupzJ9M1Fzqjqa3hObcuigEXVZJqSYDgeZGM3wF4qrNERM5Z1OOAeoT9rlod8awJ3uYyJjbQXp1ckIGg==",
             "license": "MIT",
             "dependencies": {
                 "json-schema-to-ts": "^3.1.1",
@@ -180,66 +179,198 @@
             }
         },
         "node_modules/@google-cloud/firestore": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.7.1.tgz",
-            "integrity": "sha512-Hp/WI8sH569ANitsko6RNvCUkzTCYudHoINOkQjiJq2FBG6kKnofBAW7PtS823cu6RMxHqK2RxRcspdjrRpUFA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-9.1.0.tgz",
+            "integrity": "sha512-MYh566cRZY/6/UyRIvpYynRwBBK+UFykw4EojSMt/9P74jr7FSWmupplvxPtiNA3NutyEhcEngZqdAoHgENgxA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
+                "@google-cloud/firestore-api": "^0.2.0",
                 "@opentelemetry/api": "^1.9.0",
                 "fast-deep-equal": "^3.1.3",
                 "functional-red-black-tree": "^1.0.1",
-                "google-gax": "^5.0.1",
+                "google-gax": "^6.0.1",
                 "protobufjs": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/firestore-api/-/firestore-api-0.2.0.tgz",
+            "integrity": "sha512-wfHJPZmLqzpy6FN6U+7HkkP/AKhGsbHSpEy/qL2TyI3/pKRAvpamQxZ2qvps5hMRgAjfuHCim+oeJj9RveCaqg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "google-gax": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/gaxios": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+            "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/google-auth-library": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+            "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "gaxios": "^7.0.0",
+                "gcp-metadata": "^8.0.0",
+                "google-logging-utils": "^1.0.0",
+                "gtoken": "^8.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/google-gax": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
+            "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@grpc/grpc-js": "^1.12.6",
+                "@grpc/proto-loader": "^0.8.0",
+                "duplexify": "^4.1.3",
+                "google-auth-library": "10.5.0",
+                "google-logging-utils": "1.1.3",
+                "node-fetch": "^3.3.2",
+                "object-hash": "^3.0.0",
+                "proto3-json-serializer": "3.0.4",
+                "protobufjs": "^7.5.4",
+                "retry-request": "^8.0.2",
+                "rimraf": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/proto3-json-serializer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+            "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "protobufjs": "^7.4.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/retry-request": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
+            "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "teeny-request": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api/node_modules/teeny-request": {
+            "version": "10.1.4",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
+            "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2",
+                "stream-events": "^1.0.5"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@google-cloud/paginator": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
-            "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-7.0.1.tgz",
+            "integrity": "sha512-k32cWlHAF8yTgg8rciLI8mPMI6UzuJdKp53YRxISRwMFxUl2FYplvs+Mr2UHxKn0W7rXsqZnUZy73AOJFDP8iA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "arrify": "^2.0.0",
                 "extend": "^3.0.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=22"
             }
         },
         "node_modules/@google-cloud/projectify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
-            "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-6.0.1.tgz",
+            "integrity": "sha512-zA3o4l87UJ56odT/e9PcT4n2bqVnrp6dg9vI75DoGGbl0/YJemX8Fta7454htECt07eALxxc4iaAbrX3T+QulA==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=22"
             }
         },
         "node_modules/@google-cloud/promisify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
-            "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-6.0.1.tgz",
+            "integrity": "sha512-lpN2AtoQ/iimp7jjm5zJFWbpW7OJc5qWmQdt59CI4ENeoIRIx+yf2ShSR2kanQfjFOshA74eSbimXXuRaSCUVg==",
             "license": "Apache-2.0",
             "optional": true,
             "engines": {
-                "node": ">=14"
+                "node": ">=22"
             }
         },
         "node_modules/@google-cloud/storage": {
-            "version": "7.22.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.22.0.tgz",
-            "integrity": "sha512-W98gTQOAntEeEQ7/pZxSQXxfUO5CiQcXJRsxBpUa6UU25n8YN/VtogPBi0H+MAmUrn/6bY/sBhFansoWEsr2/g==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-8.1.0.tgz",
+            "integrity": "sha512-iFDlOGBzmzTelslzcf0yTpoqloyfTUi448PxJXvjtbvGqtc2ftT8HUSl5+sKQPRz70y64ha5FqojDhABP103EA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@google-cloud/paginator": "^5.0.0",
-                "@google-cloud/projectify": "^4.0.0",
-                "@google-cloud/promisify": "<4.1.0",
+                "@google-cloud/paginator": "^7.0.1",
+                "@google-cloud/projectify": "^6.0.1",
+                "@google-cloud/promisify": "^6.0.1",
                 "abort-controller": "^3.0.0",
                 "async-retry": "^1.3.3",
                 "duplexify": "^4.1.3",
@@ -249,11 +380,11 @@
                 "html-entities": "^2.5.2",
                 "mime": "^3.0.0",
                 "p-limit": "^3.0.1",
-                "retry-request": "^7.0.0",
-                "teeny-request": "^9.0.0"
+                "retry-request": "^9.0.1",
+                "teeny-request": "^11.0.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
@@ -297,6 +428,20 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@google-cloud/storage/node_modules/gtoken": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "gaxios": "^6.0.0",
+                "jws": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -348,6 +493,91 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/@js-sdsl/ordered-map": {
@@ -466,16 +696,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@types/body-parser": {
             "version": "1.19.6",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -485,13 +705,6 @@
                 "@types/connect": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/caseless": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@types/connect": {
             "version": "3.4.38",
@@ -565,16 +778,6 @@
                 "undici-types": "~8.3.0"
             }
         },
-        "node_modules/@types/nodemailer": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
-            "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/qs": {
             "version": "6.15.1",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -586,19 +789,6 @@
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "license": "MIT"
-        },
-        "node_modules/@types/request": {
-            "version": "2.48.13",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
-            "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/caseless": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*",
-                "form-data": "^2.5.5"
-            }
         },
         "node_modules/@types/send": {
             "version": "1.2.1",
@@ -618,13 +808,6 @@
                 "@types/http-errors": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/tough-cookie": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -662,26 +845,26 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
-            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "license": "MIT",
             "optional": true,
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "license": "MIT",
             "optional": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -700,16 +883,6 @@
             "license": "MIT",
             "optional": true
         },
-        "node_modules/arrify": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/async-retry": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -719,13 +892,6 @@
             "dependencies": {
                 "retry": "0.13.1"
             }
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -869,85 +1035,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -967,19 +1054,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT",
             "optional": true
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/content-disposition": {
             "version": "1.1.0",
@@ -1079,16 +1153,6 @@
                 }
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1148,9 +1212,9 @@
             "license": "MIT"
         },
         "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT",
             "optional": true
         },
@@ -1198,22 +1262,6 @@
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1413,9 +1461,9 @@
             }
         },
         "node_modules/firebase-admin": {
-            "version": "14.3.0",
-            "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.3.0.tgz",
-            "integrity": "sha512-FUxr5HI9C0RNJW3B+CKyJOnIt5uXn/XHheyCECVTLQGSJ/MaE1Zcwf+dCaaG+xx0+VX1A4sZ1t+hc35bu73dVw==",
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.4.0.tgz",
+            "integrity": "sha512-yEx+GCsHvjH2svh4j1ATW57o8tlfjRQ0klTxvn7XCKUPXWiUQaRTHSzPSqhXtsLYSe4IwTqR7qqrh2sA45A0HA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@fastify/busboy": "^3.0.0",
@@ -1430,8 +1478,8 @@
                 "node": ">=22"
             },
             "optionalDependencies": {
-                "@google-cloud/firestore": "^8.7.1",
-                "@google-cloud/storage": "^7.22.0"
+                "@google-cloud/firestore": "^9.1.0",
+                "@google-cloud/storage": "^8.1.0"
             }
         },
         "node_modules/firebase-functions": {
@@ -1485,47 +1533,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
-            "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.4",
-                "mime-types": "^2.1.35",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
-        "node_modules/form-data/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/form-data/node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/formdata-polyfill": {
@@ -1756,26 +1763,26 @@
             }
         },
         "node_modules/google-gax": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
-            "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.3.0.tgz",
+            "integrity": "sha512-9/kD2yhNJJDAoxZMw+v/d53W6bibgHXr0uU2RRfkC2/r5uH1sBo1nzuaSUq1lKgipZ3O4HvksA7/rRBvkFHFkA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.6",
                 "@grpc/proto-loader": "^0.8.0",
+                "@opentelemetry/api": "^1.9.0",
                 "duplexify": "^4.1.3",
-                "google-auth-library": "10.5.0",
-                "google-logging-utils": "1.1.3",
+                "google-auth-library": "^11.0.0",
+                "google-logging-utils": "^2.0.0",
                 "node-fetch": "^3.3.2",
                 "object-hash": "^3.0.0",
-                "proto3-json-serializer": "3.0.4",
+                "proto3-json-serializer": "^4.0.0",
                 "protobufjs": "^7.5.4",
-                "retry-request": "^8.0.2",
-                "rimraf": "^5.0.1"
+                "retry-request": "^9.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/google-gax/node_modules/gaxios": {
@@ -1793,51 +1800,47 @@
                 "node": ">=18"
             }
         },
+        "node_modules/google-gax/node_modules/gcp-metadata": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+            "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "gaxios": "^7.1.3",
+                "google-logging-utils": "^2.0.0",
+                "json-bigint": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
         "node_modules/google-gax/node_modules/google-auth-library": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-            "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+            "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
-                "gaxios": "^7.0.0",
-                "gcp-metadata": "^8.0.0",
-                "google-logging-utils": "^1.0.0",
-                "gtoken": "^8.0.0",
+                "gaxios": "^7.1.4",
+                "gcp-metadata": "^9.0.0",
+                "google-logging-utils": "^2.0.0",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
-        "node_modules/google-gax/node_modules/gtoken": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-            "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-            "license": "MIT",
+        "node_modules/google-gax/node_modules/google-logging-utils": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+            "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+            "license": "Apache-2.0",
             "optional": true,
-            "dependencies": {
-                "gaxios": "^7.0.0",
-                "jws": "^4.0.0"
-            },
             "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/google-gax/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
+                "node": ">=22"
             }
         },
         "node_modules/google-gax/node_modules/node-fetch": {
@@ -1857,36 +1860,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/node-fetch"
-            }
-        },
-        "node_modules/google-gax/node_modules/retry-request": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
-            "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "extend": "^3.0.2",
-                "teeny-request": "^10.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/google-gax/node_modules/teeny-request": {
-            "version": "10.1.4",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
-            "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "node-fetch": "^3.3.2",
-                "stream-events": "^1.0.5"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/google-logging-utils": {
@@ -1911,17 +1884,51 @@
             }
         },
         "node_modules/gtoken": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-            "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+            "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "gaxios": "^6.0.0",
+                "gaxios": "^7.0.0",
                 "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18"
+            }
+        },
+        "node_modules/gtoken/node_modules/gaxios": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+            "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/gtoken/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/has-symbols": {
@@ -1929,22 +1936,6 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2008,31 +1999,17 @@
             "license": "MIT"
         },
         "node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/http-proxy-agent/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -2526,12 +2503,12 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
-            "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
+            "version": "10.0.9",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-10.0.9.tgz",
+            "integrity": "sha512-BF0qcyplCwp+jMk6HCjFykBz/YhhZSsxrARhOldLwFWH+8kGjQsd2WIMIZhqEuyXRoGFi0ONbDeWDMDoL8MhLw==",
             "license": "MIT-0",
             "engines": {
-                "node": ">=6.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/object-assign": {
@@ -2700,16 +2677,16 @@
             }
         },
         "node_modules/proto3-json-serializer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
-            "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-4.0.2.tgz",
+            "integrity": "sha512-VUQlb/J2WjOG8BKhdLwJUz+MKxSMtBGYh+TaNmRtiYVhlIzXjzeAGIx7gtc3lXlA2iURzfF2+cXaQvC2ofwzpg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "protobufjs": "^7.4.0"
+                "protobufjs": "^7.5.4"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/protobufjs": {
@@ -2818,9 +2795,9 @@
             }
         },
         "node_modules/resend": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/resend/-/resend-6.26.0.tgz",
-            "integrity": "sha512-vkrULozV5nGF8o7tyun/t0+qFgtPpn+cyRhVqeorhOsPUNDiSc/9p/pn8AprdHqJpYaTvftpnQgWurW++FkCdw==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/resend/-/resend-6.28.0.tgz",
+            "integrity": "sha512-xhRMQDZRjvJQ+sWJA3wFaoeVe5CpTxJJAfHnnULX8vifjj4QQLCLRn/AfnMZ4YmVhpFkuiX4LKxZCcj54l67Yw==",
             "license": "MIT",
             "dependencies": {
                 "postal-mime": "2.7.5",
@@ -2859,18 +2836,17 @@
             }
         },
         "node_modules/retry-request": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
-            "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-9.0.1.tgz",
+            "integrity": "sha512-4kGHEBl0ME6gR+8QB1sPMyg58jUxLUcCZNeqLDrfqzk0eWQN8XJFmeu7fmZCjlZCRW0S2u64Ik1HkO/0sWgCYQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@types/request": "^2.48.8",
                 "extend": "^3.0.2",
-                "teeny-request": "^9.0.0"
+                "teeny-request": "^11.0.0"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=22"
             }
         },
         "node_modules/rimraf": {
@@ -3153,21 +3129,18 @@
             }
         },
         "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/string-width-cjs": {
@@ -3186,24 +3159,7 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/string-width-cjs/node_modules/strip-ansi": {
+        "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3214,22 +3170,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-regex": "^6.2.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/strip-ansi-cjs": {
@@ -3242,16 +3182,6 @@
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3280,47 +3210,38 @@
             "optional": true
         },
         "node_modules/teeny-request": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
-            "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+            "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.9",
-                "stream-events": "^1.0.5",
-                "uuid": "^9.0.0"
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "node-fetch": "^3.3.2",
+                "stream-events": "^1.0.5"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=22"
             }
         },
-        "node_modules/teeny-request/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+        "node_modules/teeny-request/node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "debug": "4"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             },
             "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/teeny-request/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
-            "engines": {
-                "node": ">= 6"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/toidentifier": {
@@ -3509,18 +3430,18 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -3543,67 +3464,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/wrappy": {
@@ -3665,51 +3525,6 @@
             "optional": true,
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/yjs": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,18 +17,17 @@
     },
     "main": "lib/index.js",
     "dependencies": {
-        "@anthropic-ai/sdk": "^0",
+        "@anthropic-ai/sdk": "^0.125",
         "@supercharge/promise-pool": "^3",
         "firebase-admin": "^14",
         "firebase-functions": "^7",
-        "nodemailer": "^9",
+        "nodemailer": "^10",
         "prettier": "^3",
         "resend": "^6.26.0",
         "shared-types": "file:./src/shared",
         "yjs": "^13"
     },
     "devDependencies": {
-        "@types/nodemailer": "^8",
         "typescript": "^6"
     },
     "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "wordplay",
-    "version": "0.35.0",
+    "version": "0.37.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wordplay",
-            "version": "0.35.0",
+            "version": "0.37.0",
             "bundleDependencies": [
                 "shared-types"
             ],
             "hasInstallScript": true,
             "dependencies": {
-                "@anthropic-ai/sdk": "^0",
+                "@anthropic-ai/sdk": "^0.125",
                 "@dimforge/rapier2d-compat": "^0.20.0",
                 "@mediapipe/tasks-vision": "^1",
                 "@types/fontkit": "^2",
@@ -89,9 +89,9 @@
             }
         },
         "node_modules/@anthropic-ai/sdk": {
-            "version": "0.123.0",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
-            "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
+            "version": "0.125.0",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.125.0.tgz",
+            "integrity": "sha512-Hq5wYlXupzJ9M1Fzqjqa3hObcuigEXVZJqSYDgeZGM3wF4qrNERM5Z1OOAeoT9rlod8awJ3uYyJjbQXp1ckIGg==",
             "license": "MIT",
             "dependencies": {
                 "json-schema-to-ts": "^3.1.1",
@@ -1305,9 +1305,9 @@
             "license": "MIT"
         },
         "node_modules/@firebase/ai": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.15.0.tgz",
-            "integrity": "sha512-Aj7TbFdAIWZdkX8JfdDStERpR35g6WNs+7XhNPtFLFOizUotj6k4N/D8HJkR45165HhnMJBe4hjOeeaxnnn56Q==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.16.0.tgz",
+            "integrity": "sha512-WRVxl58B61Orwf7st7949ZIW2L4huV80Gpaum1z8v2eH+m2xaxWtC8mOjQyVAOirr6O/yf89cBjlPvoyBpBfTg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/app-check-interop-types": "0.3.5",
@@ -1325,9 +1325,9 @@
             }
         },
         "node_modules/@firebase/analytics": {
-            "version": "0.10.24",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.24.tgz",
-            "integrity": "sha512-OfIAcIIwoqXjBzS+DnUQpOZ7i3ePaNFg83KPpDWjBZUKJmqMwzzAtLJqmKZOkQnW8im6vFR6f2I3M/9hxVd+QA==",
+            "version": "0.10.25",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.25.tgz",
+            "integrity": "sha512-oDagV3PHeNXBdxemksZCdj+GmUT19eCnTOcLdQePIIovFXlm3zWy3Gjeaokt9Nqx24kc4ljK8lU0XGcGmmKZ1A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
@@ -1341,12 +1341,12 @@
             }
         },
         "node_modules/@firebase/analytics-compat": {
-            "version": "0.2.30",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.30.tgz",
-            "integrity": "sha512-uVZEKlLaW4AHAhv8zoN9cTmveX6v86AVqcJ4LCaRCMTChTH8/NsjbisTq1lpBfWCLWS1spqwSHB4vol/YSCdMA==",
+            "version": "0.2.31",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.31.tgz",
+            "integrity": "sha512-msTlG9REujk5rjtOHNLngiuPmvaWGQte8ugL4/F6ZCMb+92Ue7SgjSEpNxINkM8ZtTrbGS83j5SZkt0r+M1Tjw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/analytics": "0.10.24",
+                "@firebase/analytics": "0.10.25",
                 "@firebase/analytics-types": "0.8.5",
                 "@firebase/component": "0.7.5",
                 "@firebase/util": "1.15.3",
@@ -1364,9 +1364,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/app": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.1.tgz",
-            "integrity": "sha512-tjUEorFyKrurH7PbLWv9zDHRuU4mLefgD/yY38D584ziorIRlQz/PVjx4c/SCGyCuUlmyzt72mK+Lh+COAywNQ==",
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.2.tgz",
+            "integrity": "sha512-fyCLPahl3r0Zb7Wzm+JLWcOOH3SaDgAyJzJ8EWIDiv51aNiv+2Pjbpa6myEuP7iXxjmJqrcbVm0GUF7h229T1Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
@@ -1431,12 +1431,12 @@
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/app-compat": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.17.tgz",
-            "integrity": "sha512-5GdJWobqs6jbNYOnaQiSa4Ng8gnFerhqr7nY+v5jlnT7o9QbEeIZRLPQpnLe0TxYSWfRV2lAMbyR0kbXeIos9Q==",
+            "version": "0.5.18",
+            "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.18.tgz",
+            "integrity": "sha512-77H57WuGEsgrv59HdtuhHG+eQdP8di6myz7O93yW6yTZlR/tLSmsCxCq5vHp6AWWDwSV0EVtKUvizXQiQZVBWA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/app": "0.16.1",
+                "@firebase/app": "0.16.2",
                 "@firebase/component": "0.7.5",
                 "@firebase/logger": "0.5.2",
                 "@firebase/util": "1.15.3",
@@ -1456,9 +1456,9 @@
             }
         },
         "node_modules/@firebase/auth": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.5.tgz",
-            "integrity": "sha512-1AXoBJqBVD8WL8FZYo3S2GmJF9YUoom6Y6ngMxOSkzzhW5sT83pLchb6TGFgxes91dfXx8s/VYc5VrLDNqpLog==",
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.6.tgz",
+            "integrity": "sha512-MKRLvF72HJ/irNn2fJR0Gv5FOZNtqv1IBeJHRwK8l8pZ/wi9vuUw8ecyCMvQDDNxfS6uW0MWACL5KC4Y8Pp+fA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
@@ -1480,12 +1480,12 @@
             }
         },
         "node_modules/@firebase/auth-compat": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.10.tgz",
-            "integrity": "sha512-Bvklg2nL7BrBFCAqdsleW8fse9Jh0fARqJPlJmA40uermfWx1bJiO7dnKyZN3J39d2TFVd4VJXtg3i6Wg92/YQ==",
+            "version": "0.6.11",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.11.tgz",
+            "integrity": "sha512-L+xp3DTJQrBV08Vt0UhcL/ofUOSjXom7JOJfbT6oas4o7gCrQnTYFKs8wfiuKLmHoo8BxMr5LdgjAs7o6aAsqQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/auth": "1.13.5",
+                "@firebase/auth": "1.13.6",
                 "@firebase/auth-types": "0.13.2",
                 "@firebase/component": "0.7.5",
                 "@firebase/util": "1.15.3",
@@ -1602,9 +1602,9 @@
             }
         },
         "node_modules/@firebase/firestore": {
-            "version": "4.17.1",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.1.tgz",
-            "integrity": "sha512-8lqPNf2w10CtYG+tayVjZO1pSyQpnhztQRudeD109VtXDzNbASTaYdO43sj5PMsDcWq0aOYY3RmJOUlXu9++jw==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.2.tgz",
+            "integrity": "sha512-SiyQEK1dYPOjItFVA+kZGdvOoRAtMebDBvUaSxJPNZMkKcRwYYK2kzWo5UXTZZj523uMxJnkr+KKVySEMme3kQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
@@ -1624,13 +1624,13 @@
             }
         },
         "node_modules/@firebase/firestore-compat": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.13.tgz",
-            "integrity": "sha512-l9dCewxMzzLOIhcwTjERCKxrWOn1kZ9JvwOQq9zZNq4I/Nbvb/B9njT230V61uvQ9qZ3/qpUG758D8DDTEFXnw==",
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.14.tgz",
+            "integrity": "sha512-HJ2HBNgNPrRsWIJ4E+Kc0u0h1U7HlF7If8AtYjie9HZXlMUmwYSJaXBj9VFm6gkSj5dlKZNcOQ0Ou25CVVG6rA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
-                "@firebase/firestore": "4.17.1",
+                "@firebase/firestore": "4.17.2",
                 "@firebase/firestore-types": "3.0.5",
                 "@firebase/util": "1.15.3",
                 "tslib": "^2.1.0"
@@ -1753,9 +1753,9 @@
             }
         },
         "node_modules/@firebase/messaging": {
-            "version": "0.13.2",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.2.tgz",
-            "integrity": "sha512-KcZoqUu2ih4sLH91dW9tmyHjCR0IQyNzSLZunX5uq7cLeImXb4uO2I0wq5FACduO2I+FoTeWa2BtUv7Jpowqdw==",
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.3.tgz",
+            "integrity": "sha512-nRXPAp+z0kA3KziJtRY9kktHECvRwaaONzHvislFgllhCwJMscW7icWNQA5IjyP8Uc2+GS/4px8Uz6rx6ftTag==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
@@ -1770,13 +1770,13 @@
             }
         },
         "node_modules/@firebase/messaging-compat": {
-            "version": "0.2.29",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.29.tgz",
-            "integrity": "sha512-8Twe4CeYvAx8AzjBxyyQFKzinaMGGt13hPQBqaARQ2QZjagrEaqSVBe+Zy6F4L/vT8DV168yRgRu7W/RK7p+4w==",
+            "version": "0.2.30",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.30.tgz",
+            "integrity": "sha512-m1DPT2ET5x0qYqXLoHwKMAyf1mgZZOhuoE6H6/H4OPsp8zSxMIDEFPaW7MaffPJsCA5J7kHzo+BHVNXK4ZoV+w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@firebase/component": "0.7.5",
-                "@firebase/messaging": "0.13.2",
+                "@firebase/messaging": "0.13.3",
                 "@firebase/util": "1.15.3",
                 "tslib": "^2.1.0"
             },
@@ -2068,24 +2068,39 @@
             }
         },
         "node_modules/@google-cloud/firestore": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.7.1.tgz",
-            "integrity": "sha512-Hp/WI8sH569ANitsko6RNvCUkzTCYudHoINOkQjiJq2FBG6kKnofBAW7PtS823cu6RMxHqK2RxRcspdjrRpUFA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-9.1.0.tgz",
+            "integrity": "sha512-MYh566cRZY/6/UyRIvpYynRwBBK+UFykw4EojSMt/9P74jr7FSWmupplvxPtiNA3NutyEhcEngZqdAoHgENgxA==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
+                "@google-cloud/firestore-api": "^0.2.0",
                 "@opentelemetry/api": "^1.9.0",
                 "fast-deep-equal": "^3.1.3",
                 "functional-red-black-tree": "^1.0.1",
-                "google-gax": "^5.0.1",
+                "google-gax": "^6.0.1",
                 "protobufjs": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@google-cloud/firestore-api": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/firestore-api/-/firestore-api-0.2.0.tgz",
+            "integrity": "sha512-wfHJPZmLqzpy6FN6U+7HkkP/AKhGsbHSpEy/qL2TyI3/pKRAvpamQxZ2qvps5hMRgAjfuHCim+oeJj9RveCaqg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "google-gax": "^5.0.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/@grpc/grpc-js": {
+        "node_modules/@google-cloud/firestore-api/node_modules/@grpc/grpc-js": {
             "version": "1.14.4",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
             "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
@@ -2100,7 +2115,7 @@
                 "node": ">=12.10.0"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/@grpc/proto-loader": {
+        "node_modules/@google-cloud/firestore-api/node_modules/@grpc/proto-loader": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
             "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
@@ -2120,7 +2135,7 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/data-uri-to-buffer": {
+        "node_modules/@google-cloud/firestore-api/node_modules/data-uri-to-buffer": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
             "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
@@ -2131,7 +2146,7 @@
                 "node": ">= 12"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/gaxios": {
+        "node_modules/@google-cloud/firestore-api/node_modules/gaxios": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
             "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
@@ -2147,7 +2162,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/gcp-metadata": {
+        "node_modules/@google-cloud/firestore-api/node_modules/gcp-metadata": {
             "version": "8.1.4",
             "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
             "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
@@ -2163,7 +2178,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/gcp-metadata/node_modules/gaxios": {
+        "node_modules/@google-cloud/firestore-api/node_modules/gcp-metadata/node_modules/gaxios": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
             "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
@@ -2180,7 +2195,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/google-auth-library": {
+        "node_modules/@google-cloud/firestore-api/node_modules/google-auth-library": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
             "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
@@ -2200,7 +2215,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/google-gax": {
+        "node_modules/@google-cloud/firestore-api/node_modules/google-gax": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.8.tgz",
             "integrity": "sha512-M4vpZcXQIC1gqIVGQ7eaU3jXQA6zecStyTXu514TYfThlgSurYJOxHZo9fzU6hAgwPWvuEynAVHWyaIk80VeEA==",
@@ -2224,18 +2239,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/google-logging-utils": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@google-cloud/firestore/node_modules/node-fetch": {
+        "node_modules/@google-cloud/firestore-api/node_modules/node-fetch": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
             "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
@@ -2255,7 +2259,7 @@
                 "url": "https://opencollective.com/node-fetch"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/proto3-json-serializer": {
+        "node_modules/@google-cloud/firestore-api/node_modules/proto3-json-serializer": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
             "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
@@ -2269,7 +2273,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/retry-request": {
+        "node_modules/@google-cloud/firestore-api/node_modules/retry-request": {
             "version": "8.0.4",
             "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.4.tgz",
             "integrity": "sha512-pI6/7eabUYkZxamkOq0g0uMxKLLGnjzhefY+vL8bVXag5rto4OU2YBTPytWLuHH7aEKD6fn7kJycQfid0Mwnkw==",
@@ -2284,7 +2288,7 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/firestore/node_modules/teeny-request": {
+        "node_modules/@google-cloud/firestore-api/node_modules/teeny-request": {
             "version": "10.1.4",
             "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.4.tgz",
             "integrity": "sha512-R1Cg4Vu0UULeDfHL/kjABLaTW++9yD/B6n2g48y5dJ04hsEaxcfmAqbNDzNsbqAYJyIpZafjklLG9YxRu9uzOg==",
@@ -2302,18 +2306,17 @@
             }
         },
         "node_modules/@google-cloud/paginator": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
-            "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-7.0.1.tgz",
+            "integrity": "sha512-k32cWlHAF8yTgg8rciLI8mPMI6UzuJdKp53YRxISRwMFxUl2FYplvs+Mr2UHxKn0W7rXsqZnUZy73AOJFDP8iA==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "arrify": "^2.0.0",
                 "extend": "^3.0.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=22"
             }
         },
         "node_modules/@google-cloud/precise-date": {
@@ -2541,16 +2544,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/pubsub/node_modules/google-logging-utils": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@google-cloud/pubsub/node_modules/node-fetch": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -2757,16 +2750,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@google-cloud/sql/node_modules/google-logging-utils": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@google-cloud/sql/node_modules/node-fetch": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -2830,16 +2813,16 @@
             }
         },
         "node_modules/@google-cloud/storage": {
-            "version": "7.22.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.22.0.tgz",
-            "integrity": "sha512-W98gTQOAntEeEQ7/pZxSQXxfUO5CiQcXJRsxBpUa6UU25n8YN/VtogPBi0H+MAmUrn/6bY/sBhFansoWEsr2/g==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-8.1.0.tgz",
+            "integrity": "sha512-iFDlOGBzmzTelslzcf0yTpoqloyfTUi448PxJXvjtbvGqtc2ftT8HUSl5+sKQPRz70y64ha5FqojDhABP103EA==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@google-cloud/paginator": "^5.0.0",
-                "@google-cloud/projectify": "^4.0.0",
-                "@google-cloud/promisify": "<4.1.0",
+                "@google-cloud/paginator": "^7.0.1",
+                "@google-cloud/projectify": "^6.0.1",
+                "@google-cloud/promisify": "^6.0.1",
                 "abort-controller": "^3.0.0",
                 "async-retry": "^1.3.3",
                 "duplexify": "^4.1.3",
@@ -2849,66 +2832,11 @@
                 "html-entities": "^2.5.2",
                 "mime": "^3.0.0",
                 "p-limit": "^3.0.1",
-                "retry-request": "^7.0.0",
-                "teeny-request": "^9.0.0"
+                "retry-request": "^9.0.1",
+                "teeny-request": "^11.0.1"
             },
             "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/@google-cloud/projectify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
-            "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/@google-cloud/promisify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
-            "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">=22"
             }
         },
         "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
@@ -2972,99 +2900,10 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@google-cloud/storage/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@google-cloud/storage/node_modules/retry-request": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
-            "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/request": "^2.48.8",
-                "extend": "^3.0.2",
-                "teeny-request": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/teeny-request": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
-            "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "dependencies": {
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.9",
-                "stream-events": "^1.0.5",
-                "uuid": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@google-cloud/storage/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/@google-cloud/translate": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-10.0.1.tgz",
-            "integrity": "sha512-LbfsP+Bkrcb+i8Qs/v2LvqLMZchtW4Z6aOx6oiNtko3yrJqY5inalZfvcIc321Czlw2mlmkMRu8ovqYA1IXlGg==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/@google-cloud/translate/-/translate-10.1.0.tgz",
+            "integrity": "sha512-x2aU/8zgEPb5yV7fNskKM9mMCf4Tndvr8RdnCydSeR0jJtm2XHT9fChZAto1lZInl4F59UklaAybIerksr3NRg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5344,13 +5183,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.62.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
-            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+            "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.62.1"
+                "playwright": "1.63.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -6136,17 +5975,6 @@
                 "tslib": "^2.8.0"
             }
         },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-            "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -6214,14 +6042,6 @@
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
-        },
-        "node_modules/@types/caseless": {
-            "version": "0.12.5",
-            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
-            "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -6328,39 +6148,6 @@
                 "undici-types": "~8.3.0"
             }
         },
-        "node_modules/@types/request": {
-            "version": "2.48.13",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
-            "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@types/caseless": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*",
-                "form-data": "^2.5.5"
-            }
-        },
-        "node_modules/@types/request/node_modules/form-data": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
-            "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.4",
-                "mime-types": "^2.1.35",
-                "safe-buffer": "^5.2.1"
-            },
-            "engines": {
-                "node": ">= 0.12"
-            }
-        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -6368,14 +6155,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/@types/tough-cookie": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -9190,9 +8969,9 @@
             "license": "MIT"
         },
         "node_modules/dexie": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.5.tgz",
-            "integrity": "sha512-wWCHdihT3dmlUSuNhn5mMZDWSpG0suxjAni7YjjiZdzabZcKmy3uNZGZ7AeYYXBoLbpSXX35fikPLkPC44Osiw==",
+            "version": "4.4.6",
+            "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.6.tgz",
+            "integrity": "sha512-hJP/BO6mjB+tX6hToIO1kmxYLNmun90wYbfcoAoLpKEyDYal/k33dg0TAfoUe2TDsbbLoVIzljJ3BN2UbR5EOg==",
             "license": "Apache-2.0"
         },
         "node_modules/dfa": {
@@ -10143,32 +9922,32 @@
             }
         },
         "node_modules/firebase": {
-            "version": "12.18.0",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.18.0.tgz",
-            "integrity": "sha512-XaL6tlE5Xd20ZDhckqOMIw+JJTET+wTdeZPxQ7ihc42oxRb7kWUyn/j1LO5V9dH1xq8Rv5R71Pv1fBCdIkt9Rw==",
+            "version": "12.19.0",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.19.0.tgz",
+            "integrity": "sha512-kwXCLcI0ly2lkwygkbuRx6SsX3DSO96355YrWh9SWZ5ncsxK/y5cirn3sY6nZVSiBVE++2nL6Hchzu1EB8uohQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/ai": "2.15.0",
-                "@firebase/analytics": "0.10.24",
-                "@firebase/analytics-compat": "0.2.30",
-                "@firebase/app": "0.16.1",
+                "@firebase/ai": "2.16.0",
+                "@firebase/analytics": "0.10.25",
+                "@firebase/analytics-compat": "0.2.31",
+                "@firebase/app": "0.16.2",
                 "@firebase/app-check": "0.13.1",
                 "@firebase/app-check-compat": "0.4.7",
-                "@firebase/app-compat": "0.5.17",
+                "@firebase/app-compat": "0.5.18",
                 "@firebase/app-types": "0.9.6",
-                "@firebase/auth": "1.13.5",
-                "@firebase/auth-compat": "0.6.10",
+                "@firebase/auth": "1.13.6",
+                "@firebase/auth-compat": "0.6.11",
                 "@firebase/data-connect": "0.7.4",
                 "@firebase/database": "1.1.5",
                 "@firebase/database-compat": "2.1.7",
-                "@firebase/firestore": "4.17.1",
-                "@firebase/firestore-compat": "0.4.13",
+                "@firebase/firestore": "4.17.2",
+                "@firebase/firestore-compat": "0.4.14",
                 "@firebase/functions": "0.14.0",
                 "@firebase/functions-compat": "0.5.0",
                 "@firebase/installations": "0.6.24",
                 "@firebase/installations-compat": "0.2.24",
-                "@firebase/messaging": "0.13.2",
-                "@firebase/messaging-compat": "0.2.29",
+                "@firebase/messaging": "0.13.3",
+                "@firebase/messaging-compat": "0.2.30",
                 "@firebase/performance": "0.7.14",
                 "@firebase/performance-compat": "0.2.27",
                 "@firebase/remote-config": "0.9.2",
@@ -10179,9 +9958,9 @@
             }
         },
         "node_modules/firebase-admin": {
-            "version": "14.3.0",
-            "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.3.0.tgz",
-            "integrity": "sha512-FUxr5HI9C0RNJW3B+CKyJOnIt5uXn/XHheyCECVTLQGSJ/MaE1Zcwf+dCaaG+xx0+VX1A4sZ1t+hc35bu73dVw==",
+            "version": "14.4.0",
+            "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.4.0.tgz",
+            "integrity": "sha512-yEx+GCsHvjH2svh4j1ATW57o8tlfjRQ0klTxvn7XCKUPXWiUQaRTHSzPSqhXtsLYSe4IwTqR7qqrh2sA45A0HA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -10197,8 +9976,8 @@
                 "node": ">=22"
             },
             "optionalDependencies": {
-                "@google-cloud/firestore": "^8.7.1",
-                "@google-cloud/storage": "^7.22.0"
+                "@google-cloud/firestore": "^9.1.0",
+                "@google-cloud/storage": "^8.1.0"
             }
         },
         "node_modules/firebase-admin/node_modules/data-uri-to-buffer": {
@@ -10259,16 +10038,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/firebase-admin/node_modules/google-logging-utils": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/firebase-admin/node_modules/node-fetch": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -10289,9 +10058,9 @@
             }
         },
         "node_modules/firebase-tools": {
-            "version": "15.29.0",
-            "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.29.0.tgz",
-            "integrity": "sha512-9v59oeU7seYNjMUykhQqodXl2J08QVVxVsxgJ0SycnX41xSA7nM4BboAdAK85z0tLSm6PsHjoNqop3cKAe4uaA==",
+            "version": "15.30.0",
+            "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-15.30.0.tgz",
+            "integrity": "sha512-TlbNksehD+78BAsEvFHbFSSggO5Q1XtNY5cobAj1R0lm7gBU2YM4+hq7p+SSctJ4KytKcm3fUlodrn/j315Yzw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11077,6 +10846,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/google-logging-utils": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+            "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/googleapis-common": {
@@ -14374,15 +14153,15 @@
             "peer": true
         },
         "node_modules/lint-staged": {
-            "version": "17.4.1",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
-            "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
+            "version": "17.5.1",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.5.1.tgz",
+            "integrity": "sha512-7EDuco1xnBMeVpvAbeMq1U5KXwJGLmY8q6l+Ye78r36C4mPc+Vg1Z2SK8gHyRTyvPro90A0q5/FAZ+Au23d6QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^4.0.7",
                 "string-argv": "^0.3.2",
-                "tinyexec": "^1.3.0"
+                "tinyexec": "^1.3.1"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -16100,28 +15879,25 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.62.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+            "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.62.1"
+                "playwright-core": "1.63.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
                 "node": ">=20"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.62.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+            "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -16129,21 +15905,6 @@
             },
             "engines": {
                 "node": ">=20"
-            }
-        },
-        "node_modules/playwright/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/portfinder": {
@@ -18139,13 +17900,13 @@
             }
         },
         "node_modules/temporal-polyfill": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.4.tgz",
-            "integrity": "sha512-MLEU0qOD2uXlz24oINNtdLZQl8RgmMxSnRtKEGZGGetTJjlRwQJjk+VsJ4EREaUoiaTb8NJOcUiKtoAiWn9EBg==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.5.tgz",
+            "integrity": "sha512-+H/mmY74i6wXCMcjIhGuSnODcyZnc4eois2myhOyX0UqRAKNXQY5m9iB1en5jQ/n4SXtjLXo1ElBI5bmn8tZwQ==",
             "license": "MIT",
             "dependencies": {
                 "temporal-spec": "1.0.1",
-                "temporal-utils": "1.0.2"
+                "temporal-utils": "1.0.3"
             }
         },
         "node_modules/temporal-spec": {
@@ -18155,9 +17916,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/temporal-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.2.tgz",
-            "integrity": "sha512-1B8Dl4KzrOvsNUlpoWGno2VLQlxroLjDgc5NBjVC9ax9ymdo+ezfyvhyjEMx+IVfhINr6CIG2gcnlP95iRrybQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.3.tgz",
+            "integrity": "sha512-9jbTSX3HvkOWvDpNpFzwX/d1mkCrgQgwLmVTOEiuocZGKHsrQJtttGZFmybJ2zYP5zCSZuU5ZyeS8+eOEPABiQ==",
             "license": "MIT"
         },
         "node_modules/test-exclude": {
@@ -19011,16 +18772,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
-            "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.3.0.tgz",
+            "integrity": "sha512-lhZBVvEHefgE+HQZC9O7EBJgCU/nVzFNl7vkS4RE0APtWLP02/8QVIkQtzBxPquh7lq5/78NHipTj7ODQ6XuyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.33.0",
-                "picomatch": "^4.0.5",
-                "postcss": "^8.5.26",
-                "rolldown": "~1.2.4",
+                "picomatch": "^4.0.7",
+                "postcss": "^8.5.28",
+                "rolldown": "~1.2.6",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -19037,7 +18798,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+                "@vitejs/devtools": "^0.7.1",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -19811,9 +19572,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
-            "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.6.2.tgz",
+            "integrity": "sha512-lh5RCAGFa1Cm2hjtNwLQhSs/AsqdWnTQaBER9fEwN/88pSh7KOtJavtBx/0VlkN/uFd61SwYmljLMDAsHlvzBQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "vitest": "^5"
     },
     "dependencies": {
-        "@anthropic-ai/sdk": "^0",
+        "@anthropic-ai/sdk": "^0.125",
         "@dimforge/rapier2d-compat": "^0.20.0",
         "@mediapipe/tasks-vision": "^1",
         "@types/fontkit": "^2",

--- a/tests/end2end/localize-glossary-forms.spec.ts
+++ b/tests/end2end/localize-glossary-forms.spec.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type LocaleText from '../../src/locale/LocaleText';
 import { expect, test } from '../../playwright/fixtures';
+import { editPersisted } from '../helpers/localize';
 
 /**
  * A glossary term's other written forms are that locale's own — the plurals,
@@ -182,6 +183,12 @@ test('an edit made on the guide’s glossary reaches the submission bundle', asy
         .getByRole('button', { name: text(enUS.ui.localize.button.submit) })
         .first()
         .click();
+
+    // This is the only localization spec that navigates straight off a submit
+    // click, so it is the only one that has to wait for the edit to be durable
+    // rather than merely shown: the write is not awaited, and a full navigation
+    // started before it commits drops the edit.
+    await editPersisted(page, 'glossary.abstraction.word');
 
     // The workspace is where every edit is reviewed and submitted, wherever it
     // was made, so this one is queued there under its own locale path.

--- a/tests/helpers/localize.ts
+++ b/tests/helpers/localize.ts
@@ -51,6 +51,57 @@ export async function localizeOn(page: Page) {
     await settled(page);
 }
 
+/**
+ * Wait until a saved locale edit has actually reached IndexedDB.
+ *
+ * `saveLocaleEdit` updates the `localeEdits` store synchronously so the UI reacts at once, and
+ * does not await the Dexie write behind it. The workspace hydrates from IndexedDB on load, so a
+ * full navigation started before that write commits drops the edit — and asserting that the edit
+ * shows in place proves nothing, because the store has already updated while the row is still in
+ * flight. Poll for the durable row instead, before leaving the page that made the edit.
+ */
+export async function editPersisted(page: Page, editPath: string) {
+    await expect
+        .poll(
+            () =>
+                page.evaluate(
+                    (wanted) =>
+                        new Promise<boolean>((resolve) => {
+                            const request = indexedDB.open(
+                                'wordplay-localization',
+                            );
+                            request.onerror = () => resolve(false);
+                            request.onsuccess = () => {
+                                const db = request.result;
+                                if (!db.objectStoreNames.contains('edits'))
+                                    return resolve(false);
+                                const rows = db
+                                    .transaction('edits', 'readonly')
+                                    .objectStore('edits')
+                                    .getAll();
+                                rows.onerror = () => resolve(false);
+                                rows.onsuccess = () => {
+                                    const result: unknown = rows.result;
+                                    resolve(
+                                        Array.isArray(result) &&
+                                            result.some(
+                                                (row) =>
+                                                    typeof row === 'object' &&
+                                                    row !== null &&
+                                                    'path' in row &&
+                                                    row.path === wanted,
+                                            ),
+                                    );
+                                };
+                            };
+                        }),
+                    editPath,
+                ),
+            { timeout: 10000 },
+        )
+        .toBe(true);
+}
+
 /** Turn the mode off if it's on, so a following test starts from the plain UI. */
 export async function localizeOff(page: Page) {
     const leave = localizeButton(page, 'on');


### PR DESCRIPTION
Routine dependency maintenance. 16 bumps: 11 at the root, 5 in `functions/`.

Root: `@anthropic-ai/sdk` 0.125, `@google-cloud/translate` 10.1, `@playwright/test` 1.63, `dexie` 4.4.6, `firebase` 12.19, `firebase-admin` 14.4, `firebase-tools` 15.30, `lint-staged` 17.5.1, `temporal-polyfill` 1.0.5, `vite` 8.3, `zod` 4.6.2.
Functions: `@anthropic-ai/sdk` 0.125, `firebase-admin` 14.4, `resend` 6.28, `nodemailer` 10.

Every range already covered its target, so these are lockfile-only except for three deliberate edits:

- **`@anthropic-ai/sdk` `^0` → `^0.125`** (both files). On a 0.x package `^0` means *any* 0.x, which is no constraint at all — a routine install could pull a breaking minor of the SDK the translator and two callables depend on.
- **`nodemailer` 9 → 10.** Its only declared breaking change is Node >= 20, which `functions` already requires.
- **`@types/nodemailer` removed**, because nodemailer 10 ships its own declarations where 9 shipped none.

Both lockfiles are generated with **npm 10.9.8**, matching the npm bundled with the Node in `.nvmrc` — which is what CI installs with.

## Held back

**TypeScript 7.** `svelte-check@4.7.6` (latest) peers on `typescript: ^5.0.0 || ^6.0.0`, and `npm run check:now` is a required gate, so TS 7 would break verification itself. Revisit when that peer range moves.

**The `npm audit` floor is unchanged where it matters.** It drops 14 → 10 at the root and 7 → 2 in functions, but the remainder is transitive through `firebase-admin → @google-cloud/storage → teeny-request → uuid`, and `firebase-admin` 14.4 has a byte-identical dependency set to 14.3.

## The one behavior change, and why a test moved

`@playwright/test` 1.63 ships **Chromium 153** (1.62 shipped 152), and that broke one spec — not by regressing the app, but by winning a race the old browser lost.

`saveLocaleEdit` updates the `localeEdits` store synchronously so the UI reacts at once, and `commitEdit` does **not** await the IndexedDB write behind it. `/localize` hydrates from IndexedDB on load, so a full navigation started before that write commits drops the edit. "an edit made on the guide's glossary reaches the submission bundle" is the only localization spec that navigates straight off a submit click, so it is the only one exposed.

Attribution was done by A/B with rebuilds rather than by reasoning: reverting `vite`, `zod`, or `dexie` alone each stayed red; reverting **only** `@playwright/test` went green with every app library left new.

The fix adds `editPersisted` to `tests/helpers/localize.ts`, beside the existing `settled` helper. Note that asserting the edit *shows in place* does **not** work — the store has already updated while the row is in flight, so the assertion resolves on its first poll and adds no wait.

## Verification

| Gate | Result |
| --- | --- |
| `check:now` | 3564 files, 0 errors, 0 warnings |
| `test:run` | 548 files, 9556 tests |
| `test:rules` | 278 tests |
| `locales` | 0 errors; date/time matches CLDR 48.0.0 |
| e2e (chromium) | 283/284 — see below |
| Bundle vs. pre-bump baseline | 109 chunks, 0% immutable growth, heavy libs still lazy |
| `npm ci --dry-run` | clean under npm 10.9.8 and npm 11, both trees |

`functions` has two production-only paths that nothing exercises before deploy, so both were smoke-tested directly: nodemailer 10 constructs a real SMTP transport, and `resend` exposes `emails.send`. **Worth confirming a feedback email and a sign-in email after deploy** — `resend` is the more exposed of the two, since `signinEmail.ts` reaches it through an `await import` behind the emulator early-return.

## Two pre-existing failures on main, not from this PR

Both were confirmed against main's own dependencies and are unrelated to these bumps:

- **`kit-editing.spec.ts:121` "a kit's page renders its exports"** fails identically on main (31s timeout).
- **`galleryEdited` crashes the functions emulator**: `listEq(before.curators, after.curators)` reads `.length` of undefined, i.e. a gallery document missing those fields.

WebKit's two `chrome-selection` failures under the new WebKit 26.6 are being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)