### PR TITLE
Fix two kits follow-ups: a crashing gallery trigger and a racing kit fixture

### DIFF
--- a/functions/src/galleryEdited.test.ts
+++ b/functions/src/galleryEdited.test.ts
@@ -5,6 +5,7 @@ import {
     flattenHowToViewers,
     galleryContentChanged,
     howToViewersChanged,
+    sameIdList,
     sharesCurator,
     type HowToSource,
 } from './galleryEdited.js';
@@ -123,6 +124,37 @@ describe('galleryContentChanged', () => {
  * rewrite every open report on every gallery write — including this function's
  * own writes, which come back through the same trigger.
  */
+/**
+ * The membership comparison the trigger gates on. It ran as an unexported
+ * `listEq` typed `string[]` and indexed straight into `.length`, so a gallery
+ * document without `curators` or `creators` threw — killing the invocation, and
+ * throwing again on every later edit, because the trigger's own write comes back
+ * through it. `page-preview.spec.ts` writes exactly such a fixture.
+ */
+describe('sameIdList', () => {
+    it('compares lists as sets, ignoring order', () => {
+        expect(sameIdList(['a', 'b'], ['b', 'a'])).toBe(true);
+        expect(sameIdList(['a'], ['a', 'b'])).toBe(false);
+        expect(sameIdList([], [])).toBe(true);
+    });
+
+    it('treats a missing list as empty rather than throwing', () => {
+        expect(sameIdList(undefined, [])).toBe(true);
+        expect(sameIdList([], undefined)).toBe(true);
+        expect(sameIdList(undefined, undefined)).toBe(true);
+        expect(sameIdList(undefined, ['a'])).toBe(false);
+        expect(sameIdList(['a'], undefined)).toBe(false);
+    });
+
+    it('treats a value that is not a list as empty', () => {
+        // A trigger reads whatever is stored, and nothing validates it on the
+        // way in — so a malformed field must not be able to kill the function.
+        expect(sameIdList('a', [])).toBe(true);
+        expect(sameIdList(null, undefined)).toBe(true);
+        expect(sameIdList({ 0: 'a' }, ['a'])).toBe(false);
+    });
+});
+
 describe('curatorsChanged', () => {
     it('is true when a curator is added', () => {
         expect(

--- a/functions/src/galleryEdited.ts
+++ b/functions/src/galleryEdited.ts
@@ -103,6 +103,25 @@ export function howToViewersChanged(
 }
 
 /**
+ * Compare two id lists as sets, tolerating a value that is missing or is not a
+ * list at all.
+ *
+ * A trigger sees every document in the collection, not only the ones the app
+ * writes through `Gallery` — an older schema version, or a fixture that sets
+ * only the fields it cares about, can be missing one of these entirely. That
+ * matters more than it looks: an unhandled throw here kills the whole
+ * invocation, so the indexing and moderation writes below never run, and the
+ * function's own write re-enters this same trigger, so one malformed document
+ * throws on every subsequent edit to it.
+ */
+export function sameIdList(a: unknown, b: unknown): boolean {
+    const left = Array.isArray(a) ? [...a].sort() : [];
+    const right = Array.isArray(b) ? [...b].sort() : [];
+    if (left.length !== right.length) return false;
+    return left.every((id, index) => id === right[index]);
+}
+
+/**
  * Whether a curator changed anything a decision was about. Deliberately blind
  * to the fields this function itself writes: its own write comes back through
  * the same trigger, and counting that as a change would re-review forever.
@@ -143,6 +162,11 @@ export default async function galleryEdited(
 ): Promise<unknown> {
     const before = event.data?.before.data();
     const after = event.data?.after.data();
+    // The wildcard is what the document actually is; the stored `id` field is a
+    // denormalization of it that a document written outside `Gallery` can be
+    // missing, and passing undefined to `where()` throws rather than matching
+    // nothing.
+    const galleryId = event.params.id;
     const db = getFirestore();
     const galleryStore = db.collection('galleries');
 
@@ -161,17 +185,6 @@ export default async function galleryEdited(
         return Promise.all(promises);
     };
 
-    const listEq = (a: string[], b: string[]): boolean => {
-        if (a.length !== b.length) return false;
-        const aSorted = [...a].sort();
-        const bSorted = [...b].sort();
-
-        for (let i = 0; i < aSorted.length; i++) {
-            if (aSorted[i] !== bSorted[i]) return false;
-        }
-        return true;
-    };
-
     // if the list of creators or curators for the gallery has changed,
     // then we need to look at all other galleries to see if they have this changed gallery
     // in its list of expanded galleries
@@ -182,18 +195,18 @@ export default async function galleryEdited(
         // if deletion, then remove this gallery from all other galleries' lists of expanded galleries and viewers
 
         const galleriesToUpdate = await galleryStore
-            .where('howToExpandedGalleries', 'array-contains', before.id)
+            .where('howToExpandedGalleries', 'array-contains', galleryId)
             .get();
         galleriesToUpdate.forEach((expandedGallery) => {
             const otherGallery = expandedGallery.data();
             const howToExpandedGalleries: string[] =
                 otherGallery.howToExpandedGalleries.filter(
-                    (id: string) => id !== before.id,
+                    (id: string) => id !== galleryId,
                 );
             const howToViewers: Record<string, string[]> = {
                 ...otherGallery.howToViewers,
             };
-            delete howToViewers[before.id];
+            delete howToViewers[galleryId];
 
             updates.push({
                 ref: galleryStore.doc(expandedGallery.id),
@@ -207,8 +220,8 @@ export default async function galleryEdited(
     } else if (
         after &&
         before &&
-        listEq(before.curators, after.curators) &&
-        listEq(before.creators, after.creators)
+        sameIdList(before.curators, after.curators) &&
+        sameIdList(before.creators, after.creators)
     ) {
         // Neither list changed, so there's nothing to propagate. Falls through
         // to the moderation and index work below rather than returning: this
@@ -218,7 +231,7 @@ export default async function galleryEdited(
         // otherwise, update the howToViewers and howToViewersFlat fields of all galleries
 
         const galleriesToUpdate = await galleryStore
-            .where('howToExpandedGalleries', 'array-contains', after.id)
+            .where('howToExpandedGalleries', 'array-contains', galleryId)
             .get();
 
         galleriesToUpdate.forEach((expandedGallery) => {
@@ -236,10 +249,13 @@ export default async function galleryEdited(
             if (
                 sharesCurator(after.curators ?? [], otherGallery.curators ?? [])
             )
-                howToViewers[after.id] = [
-                    ...new Set([...after.curators, ...after.creators]),
+                howToViewers[galleryId] = [
+                    ...new Set([
+                        ...(after.curators ?? []),
+                        ...(after.creators ?? []),
+                    ]),
                 ].sort();
-            else delete howToViewers[after.id];
+            else delete howToViewers[galleryId];
 
             updates.push({
                 ref: galleryStore.doc(expandedGallery.id),
@@ -373,7 +389,7 @@ export default async function galleryEdited(
         }
 
         if (Object.keys(self).length > 0)
-            updates.push({ ref: galleryStore.doc(after.id), data: self });
+            updates.push({ ref: galleryStore.doc(galleryId), data: self });
     }
 
     // Who may review this gallery's open reports (#938). `moderators` is
@@ -390,7 +406,7 @@ export default async function galleryEdited(
         const curators: string[] = after.curators ?? [];
         const open = await db
             .collection('reports')
-            .where('gallery', '==', after.id)
+            .where('gallery', '==', galleryId)
             .where('resolved', '==', false)
             .get();
         for (const report of open.docs)

--- a/functions/src/kitEdited.test.ts
+++ b/functions/src/kitEdited.test.ts
@@ -144,6 +144,23 @@ describe('what costs a kit its listing', () => {
         expect(unlists(listed, listed)).toBe(false);
     });
 
+    it('cannot arrive already listed, however the document was written', () => {
+        // `claimChanged` is true whenever `before` is undefined, so every create is a
+        // fresh submission. That is what stops a kit listing itself — including one
+        // written straight to Firestore through the Admin SDK, which bypasses the rules
+        // but not this trigger. A test fixture that writes `listed: true` on a create is
+        // not pre-approving a kit, it is racing the trigger that resets it.
+        expect(unlists(undefined, listed)).toBe(true);
+        expect(
+            nextModeration(
+                'approved',
+                true,
+                claimChanged(undefined, listed) ||
+                    versionAdded(undefined, listed),
+            ),
+        ).toBe('pending');
+    });
+
     it('a kit that was never listed has no listing to lose', () => {
         const unlisted = { ...listed, listed: false };
         expect(unlists(unlisted, { ...unlisted, name: 'amy/other' })).toBe(

--- a/tests/end2end/kit-editing.spec.ts
+++ b/tests/end2end/kit-editing.spec.ts
@@ -3,6 +3,32 @@ import { createTestProject } from '../helpers/createProject';
 import { getTestFirestore } from '../helpers/firestore';
 
 /**
+ * Wait until the stored kit satisfies `check`, so a test never races `kitEdited`.
+ *
+ * That trigger owns `words`, `moderation` and the listing decision, and it runs on Admin
+ * SDK writes too — a fixture cannot write its way past it.
+ */
+async function waitForKit(
+    id: string,
+    check: (data: FirebaseFirestore.DocumentData) => boolean,
+    what: string,
+) {
+    await expect
+        .poll(
+            async () => {
+                const stored = await getTestFirestore()
+                    .collection('kits')
+                    .doc(id)
+                    .get();
+                const data = stored.data();
+                return data !== undefined && check(data);
+            },
+            { timeout: 20000, message: `the kit never ${what}` },
+        )
+        .toBe(true);
+}
+
+/**
  * A kit reference has to be *drawn*, not merely parsed.
  *
  * `BorrowView` names each field it renders, so a field it doesn't name is invisible —
@@ -136,7 +162,11 @@ test("a kit's page renders its exports", async ({ page }) => {
             latest: 1,
             versionCount: 1,
             public: true,
-            moderation: 'approved',
+            // A publish is a request, not a decision. `kitEdited` recomputes these on
+            // every create — `claimChanged` is true whenever `before` is undefined — so a
+            // fixture that claims approval here is overwritten and then races the trigger
+            // for whichever the registry's query sees first.
+            moderation: 'pending',
             moderatedAt: null,
             flags: {
                 dehumanization: null,
@@ -144,12 +174,11 @@ test("a kit's page renders its exports", async ({ page }) => {
                 disclosure: null,
                 misinformation: null,
             },
-            words: ['palette', 'warm', 'colours', 'dusk'],
+            words: [],
             exports: ['sunset'],
             kinds: ['Number'],
-            // What the registry filters on, so the tile below has something to list.
-            listed: true,
-            listedVersion: 1,
+            listed: false,
+            listedVersion: null,
             updated: Date.now(),
             originProject: null,
         });
@@ -170,6 +199,28 @@ test("a kit's page renders its exports", async ({ page }) => {
             exports: ['dusk'],
             created: Date.now(),
         });
+
+    // `kitEdited` rebuilds `words`, which is how we know it has seen the create and had
+    // its say about the listing.
+    await waitForKit(
+        id,
+        (kit) => Array.isArray(kit.words) && kit.words.length > 0,
+        'was indexed',
+    );
+
+    // Now approve it, as the moderate callable does. Name, description, exports, kinds and
+    // latest are all unchanged, so `claimChanged` and `versionAdded` are both false and the
+    // trigger leaves the decision alone rather than sending it back to pending.
+    await db.collection('kits').doc(id).update({
+        moderation: 'approved',
+        listed: true,
+        listedVersion: 1,
+    });
+    await waitForKit(
+        id,
+        (kit) => kit.listed === true && kit.moderation === 'approved',
+        'stayed listed',
+    );
 
     await page.goto(`/guide?kit=${encodeURIComponent(name)}`);
 


### PR DESCRIPTION
Two defects found while verifying #1381, both traced to `b30b04a01` and both confirmed against main's own dependencies before attributing them.

## 1. `galleryEdited` crashed the functions emulator

The trigger sees every document in `galleries/`, not only the ones the app writes through `Gallery`, and it threw on two fields it assumed were present:

- **`listEq(before.curators, after.curators)`** read `.length` of undefined. The rest of the file already defends with `?? []` in fifteen places — these two calls were the only ones that didn't. Replaced with an exported **`sameIdList`**, which treats a missing *or non-array* value as empty, so the mistake can't be repeated at a new call site and so it can be tested.
- **`.where('howToExpandedGalleries', 'array-contains', before.id)`** passed undefined, which Firestore rejects outright (`Cannot use "undefined" as a Firestore value`). I only found this one by verifying the fix to the first. The document's id is the wildcard, `event.params.id`; the stored `id` field is a denormalization a document written outside `Gallery` can be missing. All eight uses now read the wildcard.

Both throws killed the whole invocation, so the indexing and moderation writes below never ran — and because the function's own write re-enters the same trigger, one malformed document threw again on **every later edit to it**. Every e2e run was logging `Your function was killed` and a socket hang up.

The document that triggers it is `page-preview.spec.ts`'s gallery fixture, which sets only the three fields that test cares about. That's a fair thing for a fixture to do, which is rather the point: a trigger has to survive it.

**Verified:** across the full chromium suite, `Your function was killed` **0**, `Cannot read properties of undefined` **0**, `not a valid query constraint` **0**. All three were non-zero on every run before.

## 2. `kit-editing.spec.ts` "a kit's page renders its exports"

Not a product bug — an invalid fixture. The test wrote its kit straight to Firestore claiming `moderation: 'approved'` and `listed: true`. It cannot: `kitEdited` owns the listing decision, and `claimChanged` is true whenever `before` is undefined, so **every create is a fresh submission**. The trigger reset the document to `pending`/`listed: false`. Admin SDK writes bypass the rules but *not* the trigger, which is exactly why that guarantee lives there.

So the test was racing: it passed only when the registry's query reached the server before the trigger's write landed, and it had stopped winning — a 30s timeout waiting for a tile that was never going to appear. (It passed once early in my verification of #1381 and never again, which is what made it look like state-dependent flake.)

It now publishes the way a creator does, waits for the trigger to index the kit, and only then approves it the way the moderate callable does. On that second write `name`, `description`, `exports`, `kinds` and `latest` are all unchanged, so `claimChanged` and `versionAdded` are both false and the decision stands. Runs in ~2s instead of timing out; 3/3 green.

## How I found them

The diagnosis is worth recording because two plausible theories were wrong. For the kit, the aria snapshot showed the registry listing only the three built-ins, and the filter counts confirmed the cloud kit was absent. Narrowing the client query clause by clause showed `public` alone returned the document but `public + listed` returned zero **with no error** — and `fromCache: false`, so it was a real server read. Reading the document again *after* the trigger ran showed `listed: false, moderation: 'pending'`, which named the cause exactly.

## Tests

- `sameIdList`: set comparison, a missing list, and a value that isn't a list at all.
- `kitEdited`: pins the guarantee that misled the fixture — a kit cannot arrive already listed, however the document was written.

## Verification

| Gate | Result |
| --- | --- |
| `check:now` | 3564 files, 0 errors, 0 warnings |
| `functions` `tsc` | clean |
| `functions` unit tests | 59 passed |
| e2e (chromium, full) | 282/284 — the two are unrelated flakes, see below |
| `kit-editing.spec.ts` | 3/3 green, three consecutive runs |

The two remaining e2e failures are pre-existing flakes, not from this PR: `accessibility.spec.ts` "join flow" passes in isolation, and "landing carousel" is a fade-timing race on a carousel hint caught mid-transition (`#e2e2e2` on white) — it passed 4/4 on re-run with these changes present.

Separately and **not addressed here**: `npm run test:run` is intermittently red on main — order-dependent and nondeterministic, a different set each time (`examples.test.ts > Fireworks/en has no conflicts`, assorted `retargetExampleNames` cases), all passing in isolation. Reproduced with these changes stashed. It's normally masked by a warm `.vite/vitest` cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)