### PR TITLE
Let a character be reported (#1372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 ### Fixed
 
 - 🎨 A heading inside a tabbed panel, like the ones in Settings, now sits closer to the part it names instead of drifting up toward the section above it.
+- 🚩 We fixed asking for a character in a gallery to be reviewed, which always failed before. (#1372)
 
 ## 0.36.0 - 2026-09-09
 

--- a/functions/src/report.ts
+++ b/functions/src/report.ts
@@ -5,6 +5,10 @@ import type {
     ReportOutput,
     ReportSubjectKind,
 } from 'shared-types';
+// The value comes from the relative path rather than from `shared-types`, whose
+// `main` names a file the source package doesn't have — the same split
+// `notices.ts` makes for `MAX_NOTICES`.
+import { ReportSubjectKinds } from './shared/index.js';
 import { forgetMessageTranslations } from './chatTranslations.js';
 import getResponsibility from './responsibility.js';
 import reportId from './reportId.js';
@@ -198,13 +202,7 @@ export default async function report(
 }
 
 function isKind(kind: unknown): kind is ReportSubjectKind {
-    return (
-        kind === 'project' ||
-        kind === 'gallery' ||
-        kind === 'howto' ||
-        kind === 'chat' ||
-        kind === 'kit'
-    );
+    return ReportSubjectKinds.some((k) => k === kind);
 }
 
 /**

--- a/functions/src/shared/index.ts
+++ b/functions/src/shared/index.ts
@@ -198,9 +198,23 @@ export type ModerateGalleryOutput = {
 };
 
 // RESPONSIBILITY (#938)
-/** The kinds of thing a report can be about. */
-export type ReportSubjectKind =
-    'project' | 'gallery' | 'chat' | 'howto' | 'character' | 'kit';
+/**
+ * The kinds of thing a report can be about.
+ *
+ * A list rather than a bare union because the callable has to test an unknown
+ * at runtime, and a hand-written guard is a second copy to remember: `character`
+ * was added here and never added there, so every character report was refused
+ * for months (#1372).
+ */
+export const ReportSubjectKinds = [
+    'project',
+    'gallery',
+    'chat',
+    'howto',
+    'character',
+    'kit',
+] as const;
+export type ReportSubjectKind = (typeof ReportSubjectKinds)[number];
 
 /**
  * A moderatable thing's visibility, in the only terms responsibility depends


### PR DESCRIPTION
# Context

Reporting a character always failed with `invalid-argument`. `ReportSubjectKind` has included `'character'` since #822, and everything downstream was already built for it — `describeSubject` reads a character through the project branch deliberately, and `applyRemedy` has a full character branch — but `isKind`, the callable's runtime guard, never listed it, so the request was rejected before any of that ran. The gallery page really does send it (`gallery/[galleryid]/+page.svelte` renders `<ReportButton kind="character">`).

`git log -L 200,210:functions/src/report.ts` gives the cause exactly: `isKind` was written in #938 with four kinds, gained `kit` with #8, and never gained `character`. **It is a list that has to be remembered in two places, and wasn't.**

So rather than adding a fifth `||`, this derives the union from a list and tests against that list, which makes the two impossible to disagree — the same call `noticeSync.test.ts`'s exhaustive `Record<ReportSubjectKind, true>` already makes, and why no new test is warranted.

One subtlety: the value is imported from `./shared/index.js` rather than from `shared-types`, whose `main` names a file the source package doesn't have. That is the split `notices.ts` already makes for `MAX_NOTICES`; importing the value from `shared-types` would typecheck and fail to resolve at runtime.

## Related issues

- Closes #1372

## Verification

- `npm run check:now` — clean.
- `npm run test:run` — 548 files, 9561 passed.
- `cd functions && npx tsc --noEmit` — clean. Worth doing explicitly: neither `check:now` nor `npm test` builds `functions/`.
- Behaviour of the guard checked directly against every `ReportSubjectKind` plus non-members (`undefined`, `null`, a number, an unknown string).

**Accessibility:** no UI change — the button already existed and already rendered; only the callable's answer changes. No new markup, colors, or focus targets, so screen-reader and keyboard passes are unchanged from `main` and I have not run them.

## Checklist

- [ ] Worth a reviewer's eye: this is server-side only. `tests/end2end/report.spec.ts` has a project-report test a character case could be added to, but at ~5s for a bug the type system now prevents, that seemed the wrong level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
