### PR TITLE
Show a signed-out visitor a public gallery's how-tos (#1375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 ### Fixed
 
 - 🎨 A heading inside a tabbed panel, like the ones in Settings, now sits closer to the part it names instead of drifting up toward the section above it.
+- 📖 A public gallery's how-tos now show up when you're not signed in. (#1375)
 
 ## 0.36.0 - 2026-09-09
 

--- a/src/db/howtos/HowToDatabase.svelte.ts
+++ b/src/db/howtos/HowToDatabase.svelte.ts
@@ -35,6 +35,7 @@ import {
 import { SvelteMap } from 'svelte/reactivity';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
+import resolveHowTos from './resolveHowTos';
 
 ////////////////////////////////
 // SCHEMAS
@@ -855,6 +856,11 @@ export class HowToDatabase {
         return this.getHowTo(newHowTo.id);
     }
 
+    /**
+     * A how-to by id: `undefined` when it isn't there or isn't ours to see, and
+     * `false` when the read itself failed. The difference is the caller's to act
+     * on — only a failed read is worth asking again (#1375).
+     */
     async getHowTo(howToId: string): Promise<HowTo | undefined | false> {
         // do we have the how-to cached? return it.
         const howTo = this.howtos.get(howToId);
@@ -884,13 +890,21 @@ export class HowToDatabase {
         }
     }
 
-    async getHowTos(howToIds: string[]): Promise<HowTo[]> {
-        const results = await Promise.all(
-            howToIds.map((id) => this.getHowTo(id)),
+    /**
+     * The how-tos of a gallery, or `false` when we couldn't read any of them.
+     *
+     * Retries what it couldn't reach, because a signed-out visitor has no
+     * listener to heal a slow read: every query here is built from a uid, so
+     * their only path is this one, and a single timed-out read used to leave a
+     * public space looking empty (#1375). `false` rather than an empty list for
+     * the same reason — "we couldn't go look" is not "there are none", and every
+     * caller already guards on it before replacing what it is showing.
+     */
+    async getHowTos(howToIds: string[]): Promise<HowTo[] | false> {
+        const { howTos, unreachable } = await resolveHowTos(howToIds, (id) =>
+            this.getHowTo(id),
         );
-        return results.filter(
-            (ht): ht is HowTo => ht !== undefined && ht !== false,
-        );
+        return howTos.length === 0 && unreachable ? false : howTos;
     }
 
     ignore() {

--- a/src/db/howtos/resolveHowTos.test.ts
+++ b/src/db/howtos/resolveHowTos.test.ts
@@ -1,0 +1,86 @@
+import type HowTo from './HowToDatabase.svelte';
+import resolveHowTos from './resolveHowTos';
+import { expect, test, vi } from 'vitest';
+
+/** Only identity matters here, so stand-ins beat building real how-tos. */
+const one = { id: 'h1' } as unknown as HowTo;
+const two = { id: 'h2' } as unknown as HowTo;
+
+/** Never actually wait, so the retry costs the test nothing. */
+const wait = () => Promise.resolve();
+
+/** A lookup that answers each id from a queue, so an id can fail and then succeed. */
+function answering(answers: Record<string, (HowTo | undefined | false)[]>) {
+    return vi.fn((id: string) => {
+        const queue = answers[id];
+        const next = queue && queue.length > 1 ? queue.shift() : queue?.[0];
+        return Promise.resolve(next);
+    });
+}
+
+test('everything readable comes back, in the order asked for', async () => {
+    const result = await resolveHowTos(
+        ['h1', 'h2'],
+        answering({ h1: [one], h2: [two] }),
+        wait,
+    );
+    expect(result.howTos).toEqual([one, two]);
+    expect(result.unreachable).toBe(false);
+});
+
+// The #1375 case: a visitor has no listener, so without this the first failed
+// read is the last word and the space is permanently empty.
+test('a read that failed once is asked again, and succeeds', async () => {
+    const lookup = answering({ h1: [false, one] });
+    const result = await resolveHowTos(['h1'], lookup, wait);
+    expect(result.howTos).toEqual([one]);
+    expect(result.unreachable).toBe(false);
+    expect(lookup).toHaveBeenCalledTimes(2);
+});
+
+test('a how-to that is simply not there is never asked again', async () => {
+    const lookup = answering({ h1: [undefined] });
+    const result = await resolveHowTos(['h1'], lookup, wait);
+    expect(result.howTos).toEqual([]);
+    // Absent is an answer, unlike a failed read, so retrying it only costs time.
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(result.unreachable).toBe(false);
+});
+
+test('only what failed is retried, not what already resolved', async () => {
+    const lookup = answering({ h1: [one], h2: [false, two] });
+    const result = await resolveHowTos(['h1', 'h2'], lookup, wait);
+    expect(result.howTos).toEqual([one, two]);
+    expect(lookup).toHaveBeenCalledWith('h1');
+    // Three calls, not four: h1 answered the first time.
+    expect(lookup).toHaveBeenCalledTimes(3);
+});
+
+test('still unreachable after the retry says so, so the caller can keep what it had', async () => {
+    const lookup = answering({ h1: [false] });
+    const result = await resolveHowTos(['h1'], lookup, wait);
+    expect(result.howTos).toEqual([]);
+    expect(result.unreachable).toBe(true);
+    // Bounded: the assertion waiting on these tiles allows 30s and each read
+    // may spend 8s, so a third attempt would not fit.
+    expect(lookup).toHaveBeenCalledTimes(2);
+});
+
+test('a partial answer is reported with what is missing', async () => {
+    const result = await resolveHowTos(
+        ['h1', 'h2'],
+        answering({ h1: [one], h2: [false] }),
+        wait,
+    );
+    // Showing the one we could read beats showing nothing.
+    expect(result.howTos).toEqual([one]);
+    expect(result.unreachable).toBe(true);
+});
+
+test('asking for nothing reaches no one and is not unreachable', async () => {
+    const lookup = answering({});
+    const result = await resolveHowTos([], lookup, wait);
+    expect(result.howTos).toEqual([]);
+    expect(result.unreachable).toBe(false);
+    expect(lookup).not.toHaveBeenCalled();
+});

--- a/src/db/howtos/resolveHowTos.ts
+++ b/src/db/howtos/resolveHowTos.ts
@@ -1,0 +1,77 @@
+import type HowTo from './HowToDatabase.svelte';
+
+/** What one lookup can say: the how-to, `undefined` for "isn't there", `false`
+ *  for "couldn't go look". */
+export type HowToLookup = (id: string) => Promise<HowTo | undefined | false>;
+
+export type HowTosResult = {
+    /** Everything that resolved, in the order asked for. */
+    howTos: HowTo[];
+    /** Whether any id was still unreachable after the retry. */
+    unreachable: boolean;
+};
+
+/** How long to wait before the one retry. Short because the read it follows has
+ *  already spent its own budget failing. */
+const RETRY_DELAY_MS = 300;
+
+/**
+ * Exactly one retry. `Database.read` gives each read an 8s budget, so two
+ * attempts is already up to 16s of someone watching an empty space, and a third
+ * would be worth less than telling them sooner that we came up empty.
+ */
+const ATTEMPTS = 2;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * The how-tos of a gallery, retrying the ones we couldn't reach.
+ *
+ * A signed-out visitor is the reason this exists (#1375). Everyone else gets
+ * their how-tos from a listener, and the page effect reads the database's map
+ * synchronously, so it is *subscribed* to it: a slow first read heals when the
+ * snapshot lands and the effect re-runs. A visitor starts no listener at all —
+ * every query in `HowToDatabase` is built from a uid — so their only path is one
+ * `getHowTo` per id, and `getHowTo` swallows a failed read as `false`. Nothing
+ * re-ran, so one timed-out read left the space permanently empty: the canvas and
+ * the navigation menu both render from this list. Under a loaded emulator on
+ * WebKit, which is ~2-3x slower than Chromium for Firestore round-trips, that is
+ * how a public space with a how-to in it showed a visitor nothing.
+ *
+ * "Couldn't go look" is kept apart from "isn't there" for the reason
+ * `GalleryDatabase.find` keeps them apart, and the caller needs the difference:
+ * an empty list that came from a failed read must not replace a good one.
+ */
+export default async function resolveHowTos(
+    ids: string[],
+    lookup: HowToLookup,
+    wait: (ms: number) => Promise<unknown> = sleep,
+): Promise<HowTosResult> {
+    const found = new Map<string, HowTo>();
+    let pending = ids;
+
+    for (let attempt = 0; attempt < ATTEMPTS && pending.length > 0; attempt++) {
+        if (attempt > 0) await wait(RETRY_DELAY_MS);
+
+        // Called with the id alone: `map` would otherwise hand a lookup an
+        // index and an array it never asked for.
+        const results = await Promise.all(pending.map((id) => lookup(id)));
+        const retry: string[] = [];
+        results.forEach((result, index) => {
+            const id = pending[index];
+            if (id === undefined) return;
+            // `undefined` is an answer — it isn't there, or isn't ours to see —
+            // so it is never retried. Only `false` is a question we failed to ask.
+            if (result === false) retry.push(id);
+            else if (result !== undefined) found.set(id, result);
+        });
+        pending = retry;
+    }
+
+    return {
+        howTos: ids
+            .map((id) => found.get(id))
+            .filter((howTo): howTo is HowTo => howTo !== undefined),
+        unreachable: pending.length > 0,
+    };
+}

--- a/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
+++ b/src/routes/[[locale]]/gallery/[galleryid]/howto/+page.svelte
@@ -94,12 +94,20 @@
     // true if queried how-to exists and user has access, false if query failed, null if query in progress
     let urlLoaded = $state<null | boolean>(null);
 
+    // Which how-to lookup is current, for the reason `resolution` above exists:
+    // these reads overlap when the gallery resolves more than once, and without
+    // this a slow failing one lands last and empties a list that had arrived.
+    let howToResolution = 0;
+
     // get all of the how-tos for the gallery if the user has gallery access
     // otherwise, see if there was a specific how-to id in the url and if so just get that one
     $effect(() => {
         if (gallery) {
+            const generation = ++howToResolution;
             HowTos.getHowTos(gallery.getHowTos()).then((data) => {
-                if (data) howTos = data;
+                // A lookup that finished after a later one started is stale;
+                // `false` means we couldn't look, which is not an empty space.
+                if (generation === howToResolution && data) howTos = data;
             });
         } else if (urlID) {
             urlLoaded = null;

--- a/src/util/importGraph.test.ts
+++ b/src/util/importGraph.test.ts
@@ -654,6 +654,14 @@ test('resolving a color needs no basis', () => {
  * of these graphs already carried via `parseLocaleDoc` — so this is under a
  * kilobyte, and only `projects` had no room left in its hundredth.
  *
+ * Retrying a how-to read (#1375) is **+1 file** on every graph: `resolveHowTos.ts`, a
+ * dependency-free helper `HowToDatabase` calls, and `HowToDatabase` is on all five through
+ * `Database`. Three kilobytes, which is real growth on none of these and crosses a rounding
+ * boundary on one — `projects` measured 4.2603MB against a 4.26 ceiling. Folding it into
+ * `HowToDatabase.svelte.ts` instead saves neither the byte nor much else: that module
+ * can't be imported by a unit test on its own ("HowToDatabase is not a constructor"), so
+ * the retry policy would have had no test at the level that can actually reach it.
+ *
  * Cross-project code sharing (#8) is **+11 files** on every graph, all of them conflicts
  * or the one module that raises them. A conflict is constructed synchronously during
  * analysis, so the node that can raise it must import it statically: `Borrow` carries the
@@ -677,11 +685,11 @@ test('resolving a color needs no basis', () => {
 // math functions' documentation are both that, and neither moved a file count. Files
 // creeping is a door opening, and is the number to look at first.
 test.each([
-    ['src/routes/+layout.svelte', 521, 3.89],
-    ['src/components/app/Page.svelte', 544, 4.14],
-    ['src/routes/[[locale]]/+page.svelte', 559, 4.23],
-    ['src/routes/[[locale]]/galleries/+page.svelte', 563, 4.24],
-    ['src/routes/[[locale]]/projects/+page.svelte', 570, 4.26],
+    ['src/routes/+layout.svelte', 522, 3.89],
+    ['src/components/app/Page.svelte', 545, 4.14],
+    ['src/routes/[[locale]]/+page.svelte', 560, 4.23],
+    ['src/routes/[[locale]]/galleries/+page.svelte', 564, 4.24],
+    ['src/routes/[[locale]]/projects/+page.svelte', 571, 4.27],
 ])('%s stays within its import budget', (entry, maxFiles, maxMB) => {
     const reach = reachFrom(entry, Root);
     expect(


### PR DESCRIPTION
# Context

`seeded-load.spec.ts`'s "a signed-out visitor reads a public space and cannot take part" fails on webkit on `main`. The issue asks whether this is the product or the test. **It is the product.**

A visitor's path to a how-to has **no listener and no retry**, so one slow read is the last word. Everyone else gets how-tos from a listener, and the page effect reads the database's `SvelteMap` synchronously — so it is *subscribed* to it, and a slow first read heals when a snapshot lands and the effect re-runs. **That reactive dependency is the retry.** A visitor starts no listener at all, because every query in `HowToDatabase` is built from a uid, and `getHowTo` swallows a failed read as `false`. Nothing re-ran, so a timed-out read left a public space permanently empty — the canvas and the navigation menu both render from that one list.

Two things rule out the obvious alternatives: rules admit the read (`firestore.rules` and `howToAccessScenarios.ts` assert `anon: ['read']`), and the navigation combobox passes a plain `label` with no `item` snippet, so the WebKit rich-option-snippet caveat doesn't apply — an empty combobox really does mean `howTos === []`.

## The fix

`getHowTos` retries what it couldn't reach, once, and answers `false` when it still can't. "We couldn't go look" is not "there are none" — the distinction `GalleryDatabase.find` already draws between `missing` and `unreachable`, reused rather than reinvented. Every caller was already written as `if (data)`, a guard that could never fail before and now means what it reads like; two of them even annotated a `false` they could never receive. The how-to space additionally guards on a generation, because these reads overlap when a gallery resolves more than once and a slow failing one could otherwise land last and empty a list that had arrived.

**Why this is WebKit's failure:** `playwright.config.ts` says it in the repo's own words — WebKit is ~2-3× slower than Chromium for Firestore round-trips. This route also still carries the language runtime (#1280) and builds a `Project` + `ConceptIndex` on mount, so the main thread is busy exactly while the 8s read budget runs.

Not taken: a gallery-scoped listener not gated on `$user`. It is the structural answer and it is bigger, and it has a trap worth recording — `handleSnapshot`'s cache GC prunes against `listenerDocIds` once it reaches `expectedHowToListeners`, which is **0** for a visitor, so an uncounted listener that registers a key trips the GC immediately. It would also want an anon `list` rules test; `howToRules.test.ts` only ever exercises `doc.get()`.

## Related issues

- Closes #1375
- Related Issue #907, #1351, #1280

## Verification

- `npx playwright test seeded-load --project=webkit` against a seeded emulator — 6/6 pass, including the failing test.
- `npx playwright test howto gallery --project=chromium` — 11/11, covering the three other `getHowTos` callers this changes.
- `npm run check:now` clean; `npm run test:run` 548 files, 9561 passed; `npm run test:sweep` 2527 passed.

**I could not reproduce the flake locally** — the spec passes alone on `main`, which matches the report of failures only during full-suite runs, where four workers contend on the single-process emulator. So the retry policy is unit tested (7 cases, including that an absent how-to is never retried while an unreachable one is) rather than pinned to the flake. Note that webkit runs **nightly only**, so this PR's own CI will not exercise it.

The helper is a leaf of its own because folding it into `HowToDatabase` saves nothing and that module can't be imported by a unit test on its own ("HowToDatabase is not a constructor"), which would leave the policy untestable at the level that reaches it. That costs +1 file on five import budgets, recorded there with the measurement (`projects` measured 4.2603MB against a 4.26 ceiling — a rounding boundary, not real growth).

**Accessibility:** no UI change; the same tiles render, they now arrive when the first read is slow. No new markup, colors, or focus targets, so screen-reader and keyboard passes are unchanged from `main` and I have not run them.

## Checklist

- [ ] Worth a reviewer's eye: whether the structural listener is wanted instead of, or in addition to, this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
