### PR TITLE
Keep a bind's name whole when localizing (#1368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These notes are publicly posted in [production](https://wordplay.dev/updates), s
 
 - 🎨 A heading inside a tabbed panel, like the ones in Settings, now sits closer to the part it names instead of drifting up toward the section above it.
 - 🚩 We fixed asking for a character in a gallery to be reviewed, which always failed before. (#1372)
+- 🌐 Translating a program no longer renames a name in one place but not the others, which used to break the program. (#1368)
 
 ## 0.36.0 - 2026-09-09
 

--- a/src/db/projects/translateProjectContent.ts
+++ b/src/db/projects/translateProjectContent.ts
@@ -782,6 +782,27 @@ export default async function translateProjectContent(
         // references can be retargeted while the source name still resolves —
         // essential in replace mode, where the source name is then removed.
         const targetNameByNames = new Map<Names, string>();
+        /**
+         * Definitions the reference pass refused to respell, so the declaration
+         * pass must leave them alone too (#1368).
+         *
+         * The two passes could disagree because only one of them can miss: the
+         * declaration rename re-finds its node and looks the translation up on
+         * the original `Names`, so it always fires, while a reference can be
+         * refused. The result was a bind declared in the target language and
+         * read in the source one — `UnknownName` on every reference, in a
+         * program that ran before it was localized. A name that stays in the
+         * source language is a translation that did less; a half-renamed bind is
+         * a program that no longer runs, which is the trade this file already
+         * makes elsewhere.
+         *
+         * Read by the reference, `NameType` and declaration passes, which all
+         * run after it is filled. The input-name pass runs before, so an input
+         * of a refused definition can still be respelled; nothing has been seen
+         * to reach that, and catching it would mean deciding every refusal
+         * before any pass rewrites the tree.
+         */
+        const unrespelled = new Set<Names>();
         for (const bindToTranslate of bindsToTranslate) {
             const { names, original } = bindToTranslate;
             // If we already have a translation, use it.
@@ -1235,102 +1256,131 @@ export default async function translateProjectContent(
                 // before the name change is applied); standard-library references
                 // fall back to the definition's name in the target locale (present
                 // via the withPrimaryLocale above).
-                newProject = newProject.withRevisedNodes(
-                    newProject
-                        .getSources()
-                        .reduce(
-                            (
-                                references: {
-                                    reference: Reference;
-                                    source: Source;
-                                }[],
-                                source,
-                            ) => [
-                                ...references,
-                                ...source
-                                    .nodes()
-                                    .filter(
-                                        (node): node is Reference =>
-                                            node instanceof Reference,
-                                    )
-                                    .map((reference) => ({
-                                        reference,
-                                        source,
-                                    })),
-                            ],
-                            [],
-                        )
-                        .map(({ reference, source }) => {
-                            const definition = reference.resolve(
-                                newProject.getContext(source),
-                            );
-
-                            // Find the references to this bind so we can replace them with the new name
-                            if (definition === undefined)
-                                return [reference, reference];
-
-                            if (
-                                spellsPreservedName(
-                                    definition,
-                                    reference.getName(),
-                                    newProject.getSourceOf(definition) !==
-                                        undefined,
+                const referenceEdits = newProject
+                    .getSources()
+                    .reduce(
+                        (
+                            references: {
+                                reference: Reference;
+                                source: Source;
+                            }[],
+                            source,
+                        ) => [
+                            ...references,
+                            ...source
+                                .nodes()
+                                .filter(
+                                    (node): node is Reference =>
+                                        node instanceof Reference,
                                 )
-                            )
-                                return [reference, reference];
+                                .map((reference) => ({
+                                    reference,
+                                    source,
+                                })),
+                        ],
+                        [],
+                    )
+                    .map(({ reference, source }) => {
+                        const definition = reference.resolve(
+                            newProject.getContext(source),
+                        );
 
-                            // Get the name in the target language. An operator
-                            // position — binary or unary — wants the symbolic
-                            // name: a unary rewritten to a word glues onto its
-                            // operand with no space (`~cellHolds` became
-                            // `nocellHolds`, one name token that resolves
-                            // nothing), which refused every file that used `~`.
-                            const parent = newProject
-                                .getRoot(reference)
-                                ?.getParent(reference);
-                            const operator =
-                                (parent instanceof BinaryEvaluate ||
-                                    parent instanceof UnaryEvaluate) &&
-                                parent.fun === reference
-                                    ? true
-                                    : undefined;
-                            const translation = targetName(
+                        // Find the references to this bind so we can replace them with the new name
+                        if (definition === undefined)
+                            return { reference, keep: true };
+
+                        if (
+                            spellsPreservedName(
                                 definition,
-                                operator,
-                            );
-
-                            if (
-                                translation === undefined ||
-                                reference.getName() === translation
+                                reference.getName(),
+                                newProject.getSourceOf(definition) !==
+                                    undefined,
                             )
-                                return [reference, reference];
+                        )
+                            return { reference, keep: true };
 
-                            // Never respell a reference into something that
-                            // means something else here. The locale's word for
-                            // a basis definition can be the very word an
-                            // enclosing bind already uses — ja-JP calls `Time`
-                            // 時間, and `time/en,時間/zh: Time(…)` carries that
-                            // name itself — so the rewritten reference resolves
-                            // to the bind and the bind references itself. The
-                            // reverse direction is guarded by seeding
-                            // `existingNames` with the basis names; this is the
-                            // direction that wasn't.
-                            // Asked from the reference's own position, since
-                            // what a name means depends on where it sits, and
-                            // only a *different* definition in scope is a
-                            // reason to refuse: a member reference
-                            // (`list.join(…)`) resolves through its receiver's
-                            // type rather than lexically, so finding nothing
-                            // here means nothing shadows it.
-                            const shadow = reference.getDefinitionOfNameInScope(
-                                translation,
-                                newProject.getContext(source),
-                            );
-                            if (shadow !== undefined && shadow !== definition)
-                                return [reference, reference];
+                        // Get the name in the target language. An operator
+                        // position — binary or unary — wants the symbolic
+                        // name: a unary rewritten to a word glues onto its
+                        // operand with no space (`~cellHolds` became
+                        // `nocellHolds`, one name token that resolves
+                        // nothing), which refused every file that used `~`.
+                        const parent = newProject
+                            .getRoot(reference)
+                            ?.getParent(reference);
+                        const operator =
+                            (parent instanceof BinaryEvaluate ||
+                                parent instanceof UnaryEvaluate) &&
+                            parent.fun === reference
+                                ? true
+                                : undefined;
+                        const translation = targetName(definition, operator);
 
-                            return [reference, Reference.make(translation)];
-                        }),
+                        if (
+                            translation === undefined ||
+                            reference.getName() === translation
+                        )
+                            return { reference, keep: true };
+
+                        // Never respell a reference into something that
+                        // means something else here. The locale's word for
+                        // a basis definition can be the very word an
+                        // enclosing bind already uses — ja-JP calls `Time`
+                        // 時間, and `time/en,時間/zh: Time(…)` carries that
+                        // name itself — so the rewritten reference resolves
+                        // to the bind and the bind references itself. The
+                        // reverse direction is guarded by seeding
+                        // `existingNames` with the basis names; this is the
+                        // direction that wasn't.
+                        // Asked from the reference's own position, since
+                        // what a name means depends on where it sits, and
+                        // only a *different* definition in scope is a
+                        // reason to refuse: a member reference
+                        // (`list.join(…)`) resolves through its receiver's
+                        // type rather than lexically, so finding nothing
+                        // here means nothing shadows it.
+                        const shadow = reference.getDefinitionOfNameInScope(
+                            translation,
+                            newProject.getContext(source),
+                        );
+                        if (shadow !== undefined && shadow !== definition)
+                            return {
+                                reference,
+                                keep: true,
+                                shadowed: definition.names,
+                            };
+
+                        return {
+                            reference,
+                            keep: false,
+                            translation,
+                            definition,
+                        };
+                    });
+
+                // A definition is respelled everywhere or nowhere. The guard
+                // above asks from each reference's own position, so one
+                // reference can be shadowed while its siblings are not — and
+                // respelling only the siblings would point them at the very
+                // definition the guard exists to avoid. So one refusal takes the
+                // definition out of this pass, and out of the declaration pass
+                // with it.
+                for (const edit of referenceEdits)
+                    if (edit.shadowed !== undefined)
+                        unrespelled.add(edit.shadowed);
+
+                newProject = newProject.withRevisedNodes(
+                    referenceEdits.map((edit) =>
+                        edit.keep ||
+                        edit.translation === undefined ||
+                        (edit.definition !== undefined &&
+                            unrespelled.has(edit.definition.names))
+                            ? [edit.reference, edit.reference]
+                            : [
+                                  edit.reference,
+                                  Reference.make(edit.translation),
+                              ],
+                    ),
                 );
 
                 // Type annotations name their definition too — `zombie•Zombie` is
@@ -1376,7 +1426,11 @@ export default async function translateProjectContent(
                             const translation = targetName(definition, false);
                             if (
                                 translation === undefined ||
-                                name.getName() === translation
+                                name.getName() === translation ||
+                                // Respelled everywhere or nowhere: an annotation
+                                // of a definition the pass above declined to
+                                // rename would name something no longer there.
+                                unrespelled.has(definition.names)
                             )
                                 return [name, name];
                             return [name, NameType.make(translation)];
@@ -1391,7 +1445,8 @@ export default async function translateProjectContent(
                 bindsToTranslate.map(({ names }) => {
                     const target = current(names);
                     const translation = targetNameByNames.get(names);
-                    if (translation === undefined) return [target, target];
+                    if (translation === undefined || unrespelled.has(names))
+                        return [target, target];
                     return [
                         target,
                         replace

--- a/src/db/projects/translateStructures.test.ts
+++ b/src/db/projects/translateStructures.test.ts
@@ -526,3 +526,43 @@ test('rewriting a project written in several languages collapses all of it', asy
     expect(out).not.toContain('/fr');
     expect(conflicts(revised)).toBe(0);
 });
+
+// A bind whose declaration is renamed and whose references are not is a program
+// that no longer runs — `UnknownName` on every reference, plus `UnusedBind` on
+// the declaration — where before it was a program that ran (#1368). The two
+// passes could disagree because only one of them can miss: the declaration
+// rename re-finds its node and looks the translation up on the original `Names`,
+// so it always fires, while a reference can be refused. The shadow guard is the
+// refusal that is reachable from here.
+test('a reference that cannot be respelled keeps its declaration too', async () => {
+    if (en === undefined || es === undefined) throw new Error('bad locale');
+
+    // `cat` translates to a word another bind in scope already answers to, so
+    // respelling the reference would point it at `perro` rather than at `cat`.
+    const source = new Source('start', 'perro: 1\ncat: 2\ncat + perro');
+    const project = Project.make(null, 'test', source, [], DefaultLocale);
+    expect(conflicts(project)).toBe(0);
+
+    const result = await translateProjectContent(
+        project,
+        en,
+        es,
+        async (texts) =>
+            texts.map((t) =>
+                t === 'cat' ? 'perro' : t === 'perro' ? 'xperro' : t,
+            ),
+        undefined,
+        true,
+    );
+
+    expect(result).not.toBeNull();
+    const out = result?.getSources()[0].code.toString() ?? '';
+
+    // The bind that could be renamed was; the one that couldn't keeps both
+    // halves of its name, which is a translation that did less rather than a
+    // program that doesn't run.
+    expect(out).toContain('xperro: 1');
+    expect(out).toContain('cat: 2');
+    expect(out).toContain('cat + xperro');
+    expect(conflicts(result as Project)).toBe(0);
+});


### PR DESCRIPTION
# Context

Localizing a program could rename a bind's **declaration** and leave its **references** spelled the way the creator wrote them, turning a program that ran into one reporting `UnknownName` on every reference plus `UnusedBind` on the declaration.

**The issue's own hypothesis is not what this was, and that is worth saying first.** It guesses that the six project rebuilds hand back fresh `Names` and the identity-keyed `targetNameByNames` misses. Reading the rebuild machinery refutes that: `Node.replaceChild` returns a child *unchanged* when it neither is nor contains the replacement, `Bind.clone` routes `names` through it, `withPrimaryLocale` touches no `Source`, and the one full retokenize (`withKeywordedSources`) runs **last**, after every map read. The ne-NP program from the issue localizes **correctly** in a unit test, references and all — I tried both the reduced case and the real how-to program.

## What it actually is

**The declaration rename can never miss and the reference pass can, and nothing reconciled them.** The declaration pass re-finds its node through `current()` and looks the translation up on the *original* `Names`, so it always fires. The reference pass has four ways to refuse — no definition, `spellsPreservedName`, no translation, and the shadow guard — and every one of them returned `[reference, reference]` and **recorded nothing**.

The reachable one is the shadow guard, and it reproduces: a program with 0 conflicts becomes one with 2.

```
perro: 1          →  xperro: 1
cat: 2               perro: 2      ← `cat` renamed here…
cat + perro          cat + xperro  ← …but not here
```

When the target-language word for `cat` already means something else where the reference sits, respelling it would silently retarget the reference, so the guard correctly declines — and the declaration was renamed anyway.

So a refusal now takes the definition out of the declaration pass too, and out of the `NameType` pass, which had no guard of its own and would have left an annotation naming something no longer there. The decision is made **per definition rather than per reference**, because the guard asks from each reference's own position: one reference can be shadowed while its siblings are not, and respelling only the siblings would point them at the very definition the guard exists to avoid.

A name that stays in the source language is a translation that did less; a half-renamed bind is a program that no longer runs. That is the trade this file already makes elsewhere.

## What this does not fix

**The ne-NP case in the issue is still unexplained.** Its damage is a contiguous suffix in document order, which is the signature of a `withRevisedNodes` batch that stops landing partway rather than of per-definition misses — and `replaceChild` drops a replacement silently when the original has left the tree, with `Node.invalidReplacementToString` gated on `inBrowser`, so under the CLI even a type-invalid replacement is swallowed. I could not reach that from a test. What is fixed is the asymmetry that turns **any** refusal, whatever its cause, into a broken program rather than a less translated one — so that case would now degrade safely too.

## Related issues

- Closes #1368
- Related Issue #1367, #1310, #1276

## Verification

- New regression test in `translateStructures.test.ts`. **It fails on `main`** (`expected 'xperro: 1\nperro: 2\ncat + xperro' to contain 'cat: 2'`) and passes here — checked by reverting just the source file.
- `npm run check:now` clean; `npm run test:run` 548 files, 9561 passed; `npm run test:sweep` 2527 passed, which is the corpus gate for localized examples.

Note the diff is larger than the change: the reference pass had to be un-nested from its `withRevisedNodes(...)` argument so the refusals can be collected before the edits are applied, which re-indents the whole block.

One known gap, recorded in the code: the input-name pass runs *before* this set is filled, so an input of a refused definition can still be respelled. Nothing has been seen to reach it, and catching it would mean deciding every refusal before any pass rewrites the tree.

**Accessibility:** no UI change — this is the localization pass that rewrites a project's names. No new markup, colors, or focus targets, so screen-reader and keyboard passes are unchanged from `main` and I have not run them.

## Checklist

- [ ] Worth a reviewer's eye: whether to chase the ne-NP orphaning now, which would mean instrumenting `withRevisedNodes` to log per replacement pair whether it landed, and un-gating `invalidReplacementToString` from `inBrowser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
